### PR TITLE
Remove separate import/reference queries, keep combined only

### DIFF
--- a/src/language/c.rs
+++ b/src/language/c.rs
@@ -37,13 +37,8 @@ const C_IMPORT_QUERY_STR: &str = r#"
 (preproc_include
   path: (string_literal) @import.path)
 (preproc_include
-  path: (system_lib_string) @import.path)
+    path: (system_lib_string) @import.path)
 "#;
-
-static C_IMPORT_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
-    tree_sitter::Query::new(&tree_sitter_c::LANGUAGE.into(), C_IMPORT_QUERY_STR)
-        .expect("Failed to parse C import query")
-});
 
 const C_REFERENCE_QUERY_STR: &str = r#"
 (call_expression
@@ -53,21 +48,8 @@ const C_REFERENCE_QUERY_STR: &str = r#"
     field: (field_identifier) @reference.name))
 "#;
 
-static C_REFERENCE_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
-    tree_sitter::Query::new(&tree_sitter_c::LANGUAGE.into(), C_REFERENCE_QUERY_STR)
-        .expect("Failed to parse C reference query")
-});
-
 fn c_query() -> &'static tree_sitter::Query {
     &C_QUERY
-}
-
-fn c_import_query() -> &'static tree_sitter::Query {
-    &C_IMPORT_QUERY
-}
-
-fn c_reference_query() -> &'static tree_sitter::Query {
-    &C_REFERENCE_QUERY
 }
 
 static C_IMPORT_REF_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
@@ -86,8 +68,6 @@ pub const C_SPEC: LanguageSpec = LanguageSpec {
     extensions: &["c"],
     grammar_fn: || tree_sitter_c::LANGUAGE.into(),
     query_fn: c_query,
-    import_query_fn: c_import_query,
-    reference_query_fn: c_reference_query,
     import_ref_query_fn: c_import_ref_query,
     class_like_parents: &[],
     ancestor_visibility_rules: &[],

--- a/src/language/common.rs
+++ b/src/language/common.rs
@@ -1,7 +1,6 @@
 //! Shared extraction engine for all language packs.
 //!
-//! Provides `extract_with_spec` (symbols), `extract_imports_with_spec`,
-//! `extract_references_with_spec`, and the combined
+//! Provides `extract_with_spec` (symbols) and the combined
 //! `extract_imports_and_references_with_spec` that runs a single
 //! tree-sitter query traversal for both imports and references.
 
@@ -185,137 +184,8 @@ pub(crate) fn extract_with_spec<'a>(
     result
 }
 
-pub(crate) fn extract_imports_with_spec<'a>(
-    tree: &'a tree_sitter::Tree,
-    source: &'a [u8],
-    spec: &LanguageSpec,
-    _file_path: &std::path::Path,
-) -> Vec<crate::model::UnresolvedImport> {
-    let query = (spec.import_query_fn)();
-    let path_idx = query
-        .capture_index_for_name("import.path")
-        .expect("import.path capture must exist");
-    let alias_idx = query.capture_index_for_name("import.alias");
-    let symbol_idx = query.capture_index_for_name("import.symbol");
-    let star_idx = query.capture_index_for_name("import.star");
-
-    let mut query_cursor = tree_sitter::QueryCursor::new();
-    let mut matches = query_cursor.matches(query, tree.root_node(), source);
-
-    // Collect raw captures first - defer String allocation out of hot loop.
-    struct RawImport {
-        range: SourceRange,
-        namespace: Option<(usize, usize)>,
-        alias: Option<(usize, usize)>,
-        symbol: Option<(usize, usize)>,
-        star: bool,
-    }
-    let mut raw: Vec<RawImport> = Vec::new();
-
-    while let Some(m) = matches.next() {
-        let mut namespace: Option<(usize, usize)> = None;
-        let mut alias: Option<(usize, usize)> = None;
-        let mut symbol: Option<(usize, usize)> = None;
-        let mut star = false;
-        let mut node: Option<tree_sitter::Node<'a>> = None;
-
-        for capture in m.captures {
-            let idx = capture.index;
-            if idx == path_idx {
-                let rng = source_range_from_node(&capture.node);
-                namespace = Some((rng.byte_start, rng.byte_end));
-                node = Some(capture.node);
-            } else if let Some(alias_idx) = alias_idx
-                && idx == alias_idx
-            {
-                let rng = source_range_from_node(&capture.node);
-                alias = Some((rng.byte_start, rng.byte_end));
-            } else if let Some(symbol_idx) = symbol_idx
-                && idx == symbol_idx
-            {
-                let rng = source_range_from_node(&capture.node);
-                symbol = Some((rng.byte_start, rng.byte_end));
-                if node.is_none() {
-                    node = Some(capture.node);
-                }
-            } else if let Some(star_idx) = star_idx
-                && idx == star_idx
-            {
-                star = true;
-            }
-        }
-
-        if let Some(ns) = namespace {
-            let range = source_range_from_node(&node.unwrap_or_else(|| tree.root_node()));
-            raw.push(RawImport {
-                range,
-                namespace: Some(ns),
-                alias,
-                symbol,
-                star,
-            });
-        }
-    }
-
-    // Allocate Strings outside the hot loop, in a single pass.
-    let slice = |(s, e): (usize, usize)| -> String {
-        let s = &source[s..e];
-        std::str::from_utf8(s).unwrap_or("").to_string()
-    };
-    let mut imports: Vec<crate::model::UnresolvedImport> = Vec::with_capacity(raw.len());
-    for r in raw {
-        imports.push(crate::model::UnresolvedImport {
-            namespace: slice(r.namespace.expect("namespace is required")),
-            alias: r.alias.map(slice),
-            symbol: r.symbol.map(slice),
-            star: r.star,
-            range: r.range,
-        });
-    }
-
-    imports.sort_by_key(|i| i.range.byte_start);
-    imports
-}
-
 // TODO(MVP): Handle multi-line import statements where the statement spans
 //multiple lines (PEP 328, JS template literals).
-
-pub(crate) fn extract_references_with_spec<'a>(
-    tree: &'a tree_sitter::Tree,
-    source: &'a [u8],
-    spec: &LanguageSpec,
-) -> Vec<crate::model::UnresolvedReference> {
-    let query = (spec.reference_query_fn)();
-    let ref_idx = query
-        .capture_index_for_name("reference.name")
-        .expect("reference.name capture must exist");
-
-    let mut query_cursor = tree_sitter::QueryCursor::new();
-    let mut matches = query_cursor.matches(query, tree.root_node(), source);
-
-    // Collect byte ranges first - no String allocation in the hot loop.
-    let mut ranges: Vec<SourceRange> = Vec::new();
-
-    while let Some(m) = matches.next() {
-        for capture in m.captures {
-            if capture.index == ref_idx {
-                ranges.push(source_range_from_node(&capture.node));
-            }
-        }
-    }
-
-    // Allocate Strings once, in a linear pass after the cursor is done.
-    let mut references: Vec<crate::model::UnresolvedReference> = Vec::with_capacity(ranges.len());
-    for range in ranges {
-        let name = std::str::from_utf8(&source[range.byte_start..range.byte_end])
-            .unwrap_or("")
-            .to_string();
-        references.push(crate::model::UnresolvedReference { name, range });
-    }
-
-    references.sort_by_key(|r| r.range.byte_start);
-    references
-}
 
 fn resolve_import_path_from_symbol_node<'a>(
     node: tree_sitter::Node<'a>,

--- a/src/language/cpp.rs
+++ b/src/language/cpp.rs
@@ -42,11 +42,6 @@ const CPP_IMPORT_QUERY_STR: &str = r#"
   path: (system_lib_string) @import.path)
 "#;
 
-static CPP_IMPORT_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
-    tree_sitter::Query::new(&tree_sitter_cpp::LANGUAGE.into(), CPP_IMPORT_QUERY_STR)
-        .expect("Failed to parse C++ import query")
-});
-
 const CPP_REFERENCE_QUERY_STR: &str = r#"
 (call_expression
   function: (identifier) @reference.name)
@@ -54,18 +49,6 @@ const CPP_REFERENCE_QUERY_STR: &str = r#"
   function: (field_expression
     field: (field_identifier) @reference.name))
 "#;
-
-static CPP_REFERENCE_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
-    tree_sitter::Query::new(&tree_sitter_cpp::LANGUAGE.into(), CPP_REFERENCE_QUERY_STR)
-        .expect("Failed to parse C++ reference query")
-});
-
-fn cpp_import_query() -> &'static tree_sitter::Query {
-    &CPP_IMPORT_QUERY
-}
-fn cpp_reference_query() -> &'static tree_sitter::Query {
-    &CPP_REFERENCE_QUERY
-}
 
 static CPP_IMPORT_REF_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
     tree_sitter::Query::new(
@@ -83,8 +66,6 @@ pub const CPP_SPEC: LanguageSpec = LanguageSpec {
     extensions: &["cc", "cpp", "cxx"],
     grammar_fn: || tree_sitter_cpp::LANGUAGE.into(),
     query_fn: cpp_query,
-    import_query_fn: cpp_import_query,
-    reference_query_fn: cpp_reference_query,
     import_ref_query_fn: cpp_import_ref_query,
     class_like_parents: &["class_specifier"],
     ancestor_visibility_rules: &[],

--- a/src/language/go.rs
+++ b/src/language/go.rs
@@ -59,13 +59,8 @@ static GO_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
 const GO_IMPORT_QUERY_STR: &str = r#"
 (import_spec
   name: (_)? @import.alias
-  path: (interpreted_string_literal) @import.path)
+  path:     (interpreted_string_literal) @import.path)
 "#;
-
-static GO_IMPORT_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
-    tree_sitter::Query::new(&tree_sitter_go::LANGUAGE.into(), GO_IMPORT_QUERY_STR)
-        .expect("Failed to parse Go import query")
-});
 
 const GO_REFERENCE_QUERY_STR: &str = r#"
 (call_expression
@@ -75,21 +70,8 @@ const GO_REFERENCE_QUERY_STR: &str = r#"
     field: (field_identifier) @reference.name))
 "#;
 
-static GO_REFERENCE_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
-    tree_sitter::Query::new(&tree_sitter_go::LANGUAGE.into(), GO_REFERENCE_QUERY_STR)
-        .expect("Failed to parse Go reference query")
-});
-
 fn go_query() -> &'static tree_sitter::Query {
     &GO_QUERY
-}
-
-fn go_import_query() -> &'static tree_sitter::Query {
-    &GO_IMPORT_QUERY
-}
-
-fn go_reference_query() -> &'static tree_sitter::Query {
-    &GO_REFERENCE_QUERY
 }
 
 static GO_IMPORT_REF_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
@@ -108,8 +90,6 @@ pub const GO_SPEC: LanguageSpec = LanguageSpec {
     extensions: &["go"],
     grammar_fn: || tree_sitter_go::LANGUAGE.into(),
     query_fn: go_query,
-    import_query_fn: go_import_query,
-    reference_query_fn: go_reference_query,
     import_ref_query_fn: go_import_ref_query,
     class_like_parents: &[],
     ancestor_visibility_rules: &[],

--- a/src/language/javascript.rs
+++ b/src/language/javascript.rs
@@ -70,14 +70,6 @@ const JS_IMPORT_QUERY_STR: &str = r#"
       (identifier) @import.symbol)))
 "#;
 
-static JS_IMPORT_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
-    tree_sitter::Query::new(
-        &tree_sitter_javascript::LANGUAGE.into(),
-        JS_IMPORT_QUERY_STR,
-    )
-    .expect("Failed to parse JavaScript import query")
-});
-
 const JS_REFERENCE_QUERY_STR: &str = r#"
 (call_expression
   function: (identifier) @reference.name)
@@ -85,21 +77,6 @@ const JS_REFERENCE_QUERY_STR: &str = r#"
   function: (member_expression
     property: (property_identifier) @reference.name))
 "#;
-
-static JS_REFERENCE_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
-    tree_sitter::Query::new(
-        &tree_sitter_javascript::LANGUAGE.into(),
-        JS_REFERENCE_QUERY_STR,
-    )
-    .expect("Failed to parse JavaScript reference query")
-});
-
-fn js_import_query() -> &'static tree_sitter::Query {
-    &JS_IMPORT_QUERY
-}
-fn js_reference_query() -> &'static tree_sitter::Query {
-    &JS_REFERENCE_QUERY
-}
 
 static JS_IMPORT_REF_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
     tree_sitter::Query::new(
@@ -117,8 +94,6 @@ pub const JS_SPEC: LanguageSpec = LanguageSpec {
     extensions: &["js", "mjs", "cjs"],
     grammar_fn: || tree_sitter_javascript::LANGUAGE.into(),
     query_fn: js_query,
-    import_query_fn: js_import_query,
-    reference_query_fn: js_reference_query,
     import_ref_query_fn: js_import_ref_query,
     class_like_parents: &["class_declaration", "class"],
     ancestor_visibility_rules: &[("export_statement", Visibility::Public)],

--- a/src/language/mod.rs
+++ b/src/language/mod.rs
@@ -74,8 +74,6 @@ pub struct LanguageSpec {
     pub query_fn: fn() -> &'static Query,
     // TODO(MVP): Add import_path_resolver: fn(&str, &Path) -> Option<PathBuf>
     //             to LanguageSpec for per-language path normalization logic.
-    pub import_query_fn: fn() -> &'static Query,
-    pub reference_query_fn: fn() -> &'static Query,
     pub import_ref_query_fn: fn() -> &'static Query,
     pub class_like_parents: &'static [&'static str],
     pub ancestor_visibility_rules: &'static [(&'static str, Visibility)],
@@ -104,23 +102,6 @@ pub fn extract_symbols_for<'a>(
     source: &'a [u8],
 ) -> Vec<RawSymbol<'a>> {
     common::extract_with_spec(tree, source, spec_for(id))
-}
-
-pub fn extract_imports_for<'a>(
-    id: LangId,
-    tree: &'a tree_sitter::Tree,
-    source: &'a [u8],
-    file_path: &std::path::Path,
-) -> Vec<crate::model::UnresolvedImport> {
-    common::extract_imports_with_spec(tree, source, spec_for(id), file_path)
-}
-
-pub fn extract_references_for<'a>(
-    id: LangId,
-    tree: &'a tree_sitter::Tree,
-    source: &'a [u8],
-) -> Vec<crate::model::UnresolvedReference> {
-    common::extract_references_with_spec(tree, source, spec_for(id))
 }
 
 pub fn extract_imports_and_references_for<'a>(

--- a/src/language/python.rs
+++ b/src/language/python.rs
@@ -58,14 +58,6 @@ const PYTHON_IMPORT_QUERY_STR: &str = r#"
   (wildcard_import) @import.star)
 "#;
 
-static PYTHON_IMPORT_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
-    tree_sitter::Query::new(
-        &tree_sitter_python::LANGUAGE.into(),
-        PYTHON_IMPORT_QUERY_STR,
-    )
-    .expect("Failed to parse Python import query")
-});
-
 const PYTHON_REFERENCE_QUERY_STR: &str = r#"
 (call
   function: (identifier) @reference.name)
@@ -73,21 +65,6 @@ const PYTHON_REFERENCE_QUERY_STR: &str = r#"
   function: (attribute
     attribute: (identifier) @reference.name))
 "#;
-
-static PYTHON_REFERENCE_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
-    tree_sitter::Query::new(
-        &tree_sitter_python::LANGUAGE.into(),
-        PYTHON_REFERENCE_QUERY_STR,
-    )
-    .expect("Failed to parse Python reference query")
-});
-
-fn python_import_query() -> &'static tree_sitter::Query {
-    &PYTHON_IMPORT_QUERY
-}
-fn python_reference_query() -> &'static tree_sitter::Query {
-    &PYTHON_REFERENCE_QUERY
-}
 
 static PYTHON_IMPORT_REF_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
     tree_sitter::Query::new(
@@ -108,8 +85,6 @@ pub const PYTHON_SPEC: LanguageSpec = LanguageSpec {
     extensions: &["py", "pyi"],
     grammar_fn: || tree_sitter_python::LANGUAGE.into(),
     query_fn: python_query,
-    import_query_fn: python_import_query,
-    reference_query_fn: python_reference_query,
     import_ref_query_fn: python_import_ref_query,
     class_like_parents: &["class_definition"],
     ancestor_visibility_rules: &[],

--- a/src/language/rust.rs
+++ b/src/language/rust.rs
@@ -66,11 +66,6 @@ const RUST_IMPORT_QUERY_STR: &str = r#"
   alias: (identifier) @import.alias)
 "#;
 
-static RUST_IMPORT_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
-    tree_sitter::Query::new(&tree_sitter_rust::LANGUAGE.into(), RUST_IMPORT_QUERY_STR)
-        .expect("Failed to parse Rust import query")
-});
-
 const RUST_REFERENCE_QUERY_STR: &str = r#"
 (call_expression
   function: (identifier) @reference.name)
@@ -83,18 +78,6 @@ const RUST_REFERENCE_QUERY_STR: &str = r#"
 (macro_invocation
   macro: (identifier) @reference.name)
 "#;
-
-static RUST_REFERENCE_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
-    tree_sitter::Query::new(&tree_sitter_rust::LANGUAGE.into(), RUST_REFERENCE_QUERY_STR)
-        .expect("Failed to parse Rust reference query")
-});
-
-fn rust_import_query() -> &'static tree_sitter::Query {
-    &RUST_IMPORT_QUERY
-}
-fn rust_reference_query() -> &'static tree_sitter::Query {
-    &RUST_REFERENCE_QUERY
-}
 
 static RUST_IMPORT_REF_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
     tree_sitter::Query::new(
@@ -112,8 +95,6 @@ pub const RUST_SPEC: LanguageSpec = LanguageSpec {
     extensions: &["rs"],
     grammar_fn: || tree_sitter_rust::LANGUAGE.into(),
     query_fn: rust_query,
-    import_query_fn: rust_import_query,
-    reference_query_fn: rust_reference_query,
     import_ref_query_fn: rust_import_ref_query,
     class_like_parents: &["impl_item"],
     ancestor_visibility_rules: &[],

--- a/src/language/tsx.rs
+++ b/src/language/tsx.rs
@@ -13,22 +13,6 @@ static TSX_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
     .expect("Failed to parse TSX query")
 });
 
-static TSX_IMPORT_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
-    tree_sitter::Query::new(
-        &tree_sitter_typescript::LANGUAGE_TSX.into(),
-        TS_FAMILY_IMPORT_QUERY,
-    )
-    .expect("Failed to parse TSX import query")
-});
-
-static TSX_REFERENCE_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
-    tree_sitter::Query::new(
-        &tree_sitter_typescript::LANGUAGE_TSX.into(),
-        TS_FAMILY_REFERENCE_QUERY,
-    )
-    .expect("Failed to parse TSX reference query")
-});
-
 static TSX_IMPORT_REF_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
     tree_sitter::Query::new(
         &tree_sitter_typescript::LANGUAGE_TSX.into(),
@@ -44,19 +28,11 @@ fn tsx_import_ref_query() -> &'static tree_sitter::Query {
 fn tsx_query() -> &'static tree_sitter::Query {
     &TSX_QUERY
 }
-fn tsx_import_query() -> &'static tree_sitter::Query {
-    &TSX_IMPORT_QUERY
-}
-fn tsx_reference_query() -> &'static tree_sitter::Query {
-    &TSX_REFERENCE_QUERY
-}
 
 pub const TSX_SPEC: LanguageSpec = LanguageSpec {
     extensions: &["tsx"],
     grammar_fn: || tree_sitter_typescript::LANGUAGE_TSX.into(),
     query_fn: tsx_query,
-    import_query_fn: tsx_import_query,
-    reference_query_fn: tsx_reference_query,
     import_ref_query_fn: tsx_import_ref_query,
     class_like_parents: &["class_declaration", "class"],
     ancestor_visibility_rules: &[("export_statement", Visibility::Public)],

--- a/src/language/typescript.rs
+++ b/src/language/typescript.rs
@@ -101,22 +101,6 @@ pub const TS_FAMILY_REFERENCE_QUERY: &str = r#"
     property: (property_identifier) @reference.name))
 "#;
 
-static TS_IMPORT_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
-    tree_sitter::Query::new(
-        &tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
-        TS_FAMILY_IMPORT_QUERY,
-    )
-    .expect("Failed to parse TypeScript import query")
-});
-
-static TS_REFERENCE_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
-    tree_sitter::Query::new(
-        &tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
-        TS_FAMILY_REFERENCE_QUERY,
-    )
-    .expect("Failed to parse TypeScript reference query")
-});
-
 static TS_IMPORT_REF_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
     tree_sitter::Query::new(
         &tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
@@ -133,20 +117,10 @@ fn ts_query() -> &'static tree_sitter::Query {
     &TS_QUERY
 }
 
-fn ts_import_query() -> &'static tree_sitter::Query {
-    &TS_IMPORT_QUERY
-}
-
-fn ts_reference_query() -> &'static tree_sitter::Query {
-    &TS_REFERENCE_QUERY
-}
-
 pub const TS_SPEC: LanguageSpec = LanguageSpec {
     extensions: &["ts", "cts", "mts"],
     grammar_fn: || tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
     query_fn: ts_query,
-    import_query_fn: ts_import_query,
-    reference_query_fn: ts_reference_query,
     import_ref_query_fn: ts_import_ref_query,
     class_like_parents: &["class_declaration", "class"],
     ancestor_visibility_rules: &[("export_statement", Visibility::Public)],


### PR DESCRIPTION
## Summary

Every language pack defined 3 tree-sitter queries (import, reference, combined) where the combined was literally `"import_query\nreference_query"` at compile time. The separate queries were dead code -- all callers already used `extract_imports_and_references_for` which runs a single tree-sitter cursor traversal.

### Changes
- Removed `import_query_fn` and `reference_query_fn` from `LanguageSpec` struct
- Removed `extract_imports_for` and `extract_references_for` public API
- Removed `extract_imports_with_spec` and `extract_references_with_spec` from common
- Removed the separate `*_IMPORT_QUERY` / `*_REFERENCE_QUERY` statics and accessor functions from all 8 language packs
- Kept the query string constants (they are concatenated at compile time for the combined query)

All 198 tests pass.