### PR TITLE
Chore/group and trace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,6 +424,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -555,6 +578,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ignore"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -662,6 +701,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -692,6 +737,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -704,6 +758,7 @@ dependencies = [
  "anyhow",
  "clap",
  "criterion",
+ "ignore",
  "insta",
  "petgraph",
  "rayon",
@@ -712,6 +767,8 @@ dependencies = [
  "serde_yaml",
  "strum",
  "thiserror",
+ "tracing",
+ "tracing-subscriber",
  "tree-sitter",
  "tree-sitter-c",
  "tree-sitter-cpp",
@@ -720,7 +777,6 @@ dependencies = [
  "tree-sitter-python",
  "tree-sitter-rust",
  "tree-sitter-typescript",
- "walkdir",
  "webbrowser",
 ]
 
@@ -729,6 +785,15 @@ name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "num-traits"
@@ -1043,6 +1108,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1177,6 +1251,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1194,6 +1277,67 @@ checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1327,6 +1471,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,74 +2,62 @@
 name = "meta-ast"
 version = "0.1.0"
 edition = "2024"
-license = "Apache-2.0"
 readme = "README.md"
+license = "Apache-2.0"
 
-[features]
-default = []
-embed-cytoscape = []
+[[bench]]
+harness = false
+name = "pipeline"
+
+[[bench]]
+harness = false
+name = "graph"
 
 [dependencies]
 # Serialization
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
-webbrowser = "1.2"
 strum = { version = "0.28", features = ["derive"] }
+webbrowser = "1.2"
 
 # Error handling
 anyhow = "1.0"
 thiserror = "2.0"
 
+# Diagnostics
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
 # Tree-Sitter Dependencies
 tree-sitter = "0.26.3"
 tree-sitter-c = "0.24.1"
 tree-sitter-cpp = "0.23.4"
-tree-sitter-python = "0.25.0"
-tree-sitter-javascript = "0.25.0"
-tree-sitter-typescript = "0.23.2"
-tree-sitter-rust = "0.24.0"
 tree-sitter-go = "0.25.0"
+tree-sitter-javascript = "0.25.0"
+tree-sitter-python = "0.25.0"
+tree-sitter-rust = "0.24.0"
+tree-sitter-typescript = "0.23.2"
 
 # Graph
 petgraph = "0.8.3"
 
 # Cli
-clap = { version = "4.6", features = ["derive", "env", "color"] }
+clap = { version = "4.6", features = ["color", "derive", "env"] }
 
 # Parallelism
 rayon = "1.10"
 
 # Filesystem
-walkdir = "2.5.0"
+ignore = "0.4"
 
 [dev-dependencies]
-insta = { version = "1.47", features = ["json"] }
 criterion = { version = "0.8", features = ["html_reports"] }
+insta = { version = "1.47", features = ["json"] }
 
-[[bench]]
-name = "pipeline"
-harness = false
-
-[[bench]]
-name = "graph"
-harness = false
-
-[profile.release]
-opt-level = "z"
-lto = true
-codegen-units = 1
-panic = "abort"
-strip = true
-
-[profile.test]
-opt-level = 1
-debug = true
-debug-assertions = true
-overflow-checks = true
-lto = false
-incremental = true
-codegen-units = 256
+[features]
+default = []
+embed-cytoscape = []
 
 [profile.bench]
 opt-level = 3
@@ -79,3 +67,19 @@ overflow-checks = false
 lto = true
 incremental = false
 codegen-units = 1
+
+[profile.release]
+opt-level = "z"
+strip = true
+lto = true
+panic = "abort"
+codegen-units = 1
+
+[profile.test]
+opt-level = 1
+debug = true
+debug-assertions = true
+overflow-checks = true
+lto = false
+incremental = true
+codegen-units = 256

--- a/docs/STRUCTURE.md
+++ b/docs/STRUCTURE.md
@@ -390,6 +390,18 @@ Diagnostics are accumulated in a `Vec<Diagnostic>` separate from the symbol mode
 3. If > 50% of a file's nodes are errors, the file is marked as unparseable but does not abort the pipeline.
 4. Fatal errors are reserved for invalid configuration or unrecoverable I/O failures.
 
+### 6.4 Query Compilation Failure Strategy
+
+Tree-sitter queries are hardcoded constants in each language pack. If a query fails to compile, it indicates a programmer bug in the shipped query text, not a runtime input error.
+
+**Strategy**: `compile_query` uses `panic!()` rather than `std::process::abort()` or `Result` propagation.
+
+**Why not `abort()`**: `panic!()` runs destructors, is propagated by rayon, and integrates with Rust's panic infrastructure. `abort()` skips all cleanup.
+
+**Why not `Result`**: Queries are compiled inside `LazyLock<T>::new()` closures which require `FnOnce() -> T` (infallible return). Threading `Result` through `LazyLock` -> `LanguageSpec.query_fn` -> `extract_with_spec` -> `extract_single_file` would touch 6+ functions across 4 modules for a failure mode that is a hardcoded-query bug.
+
+**Mitigation**: `language::validate_queries()` eagerly initializes all 16 `LazyLock` statics at startup, ensuring any query bug panics immediately rather than after processing files.
+
 ---
 
 ## 7. Rust Language Features Used

--- a/src/graph/resolver.rs
+++ b/src/graph/resolver.rs
@@ -15,8 +15,42 @@ use crate::language::LangId;
 use crate::model::{FileExtraction, FileId, SymbolId, Visibility};
 
 type ScopeMap = HashMap<String, Vec<(SymbolId, f32)>>;
-type SymbolIndexEntry = (SymbolId, String, LangId, Option<Visibility>);
-type SymbolIndex = HashMap<FileId, Vec<SymbolIndexEntry>>;
+pub(crate) type SymbolIndexEntry = (SymbolId, String, LangId, Option<Visibility>);
+pub(crate) type SymbolIndex = HashMap<FileId, Vec<SymbolIndexEntry>>;
+
+/// Bundles the data needed for scope resolution across files.
+pub struct ResolutionContext {
+    pub symbol_index: SymbolIndex,
+    pub import_adjacency: HashMap<FileId, Vec<FileId>>,
+    pub file_languages: HashMap<FileId, LangId>,
+    pub file_paths: HashMap<FileId, PathBuf>,
+}
+
+impl ResolutionContext {
+    /// Build a ResolutionContext from extraction results and graph data.
+    pub fn from_extractions(
+        extractions: &[FileExtraction],
+        path_to_file_id: &HashMap<PathBuf, FileId>,
+        import_adjacency: HashMap<FileId, Vec<FileId>>,
+    ) -> Self {
+        let symbol_index = build_symbol_index(extractions, path_to_file_id);
+        let file_languages: HashMap<_, _> = extractions
+            .iter()
+            .filter_map(|f| Some((path_to_file_id.get(&f.path)?.to_owned(), f.lang)))
+            .collect();
+        let file_paths: HashMap<_, _> = path_to_file_id
+            .iter()
+            .map(|(path, &fid)| (fid, path.clone()))
+            .collect();
+
+        Self {
+            symbol_index,
+            import_adjacency,
+            file_languages,
+            file_paths,
+        }
+    }
+}
 
 /// Pre-computed visible scope for each file.
 ///
@@ -34,24 +68,11 @@ impl FlattenedScopeCache {
     /// - 1.0: own file or direct import, same language
     /// - 0.8: transitive import, same language
     /// - 0.6: cross-language imports
-    pub fn build(
-        symbol_index: &SymbolIndex,
-        import_adjacency: &HashMap<FileId, Vec<FileId>>,
-        file_languages: &HashMap<FileId, LangId>,
-        file_paths: &HashMap<FileId, PathBuf>,
-        diagnostics: &mut Vec<Diagnostic>,
-    ) -> Self {
+    pub fn build(ctx: &ResolutionContext, diagnostics: &mut Vec<Diagnostic>) -> Self {
         let mut scopes: HashMap<FileId, ScopeMap> = HashMap::new();
 
-        for &file_id in symbol_index.keys() {
-            let scope = Self::compute_scope(
-                file_id,
-                symbol_index,
-                import_adjacency,
-                file_languages,
-                file_paths,
-                diagnostics,
-            );
+        for &file_id in ctx.symbol_index.keys() {
+            let scope = Self::compute_scope(file_id, ctx, diagnostics);
             scopes.insert(file_id, scope);
         }
 
@@ -60,13 +81,10 @@ impl FlattenedScopeCache {
 
     fn compute_scope(
         file_id: FileId,
-        symbol_index: &SymbolIndex,
-        import_adjacency: &HashMap<FileId, Vec<FileId>>,
-        file_languages: &HashMap<FileId, LangId>,
-        file_paths: &HashMap<FileId, PathBuf>,
+        ctx: &ResolutionContext,
         diagnostics: &mut Vec<Diagnostic>,
     ) -> ScopeMap {
-        let source_lang = file_languages.get(&file_id).copied();
+        let source_lang = ctx.file_languages.get(&file_id).copied();
         let mut scope: ScopeMap = HashMap::new();
         let mut visited: HashSet<FileId> = HashSet::new();
         let mut queue: VecDeque<(FileId, usize)> = VecDeque::new();
@@ -78,7 +96,7 @@ impl FlattenedScopeCache {
                 continue;
             }
 
-            if let Some(symbols) = symbol_index.get(&current) {
+            if let Some(symbols) = ctx.symbol_index.get(&current) {
                 for (sym_id, name, sym_lang, visibility) in symbols {
                     // TODO(MVP): Language-aware default visibility - Python/JS default
                     //             public, Rust/C++ default private. Currently over-approximates
@@ -110,16 +128,18 @@ impl FlattenedScopeCache {
                 }
             }
 
-            if let Some(neighbors) = import_adjacency.get(&current) {
+            if let Some(neighbors) = ctx.import_adjacency.get(&current) {
                 for &neighbor in neighbors {
                     if !visited.contains(&neighbor) {
                         queue.push_back((neighbor, distance + 1));
                     } else if neighbor == file_id {
-                        let path = file_paths
+                        let path = ctx
+                            .file_paths
                             .get(&current)
                             .cloned()
                             .unwrap_or_else(|| PathBuf::from("<unknown>"));
-                        let root_path = file_paths
+                        let root_path = ctx
+                            .file_paths
                             .get(&file_id)
                             .map(|p| p.display().to_string())
                             .unwrap_or_else(|| "<unknown>".to_string());
@@ -397,18 +417,14 @@ mod tests {
             vec![(SymbolId(10), "main".into(), LangId::Python, None)],
         );
 
-        let import_adjacency: HashMap<FileId, Vec<FileId>> = HashMap::new();
-        let mut file_languages = HashMap::new();
-        file_languages.insert(FileId(0), LangId::Python);
-        let file_paths: HashMap<FileId, PathBuf> = HashMap::new();
+        let ctx = ResolutionContext {
+            symbol_index,
+            import_adjacency: HashMap::new(),
+            file_languages: HashMap::from([(FileId(0), LangId::Python)]),
+            file_paths: HashMap::new(),
+        };
 
-        let cache = FlattenedScopeCache::build(
-            &symbol_index,
-            &import_adjacency,
-            &file_languages,
-            &file_paths,
-            &mut Vec::new(),
-        );
+        let cache = FlattenedScopeCache::build(&ctx, &mut Vec::new());
         let result = cache.resolve(FileId(0), "main");
         assert!(result.is_some());
         let matches = result.unwrap();
@@ -431,21 +447,17 @@ mod tests {
             )],
         );
 
-        let mut import_adjacency = HashMap::new();
-        import_adjacency.insert(FileId(0), vec![FileId(1)]);
+        let ctx = ResolutionContext {
+            symbol_index,
+            import_adjacency: HashMap::from([(FileId(0), vec![FileId(1)])]),
+            file_languages: HashMap::from([
+                (FileId(0), LangId::Python),
+                (FileId(1), LangId::Python),
+            ]),
+            file_paths: HashMap::new(),
+        };
 
-        let mut file_languages = HashMap::new();
-        file_languages.insert(FileId(0), LangId::Python);
-        file_languages.insert(FileId(1), LangId::Python);
-        let file_paths: HashMap<FileId, PathBuf> = HashMap::new();
-
-        let cache = FlattenedScopeCache::build(
-            &symbol_index,
-            &import_adjacency,
-            &file_languages,
-            &file_paths,
-            &mut Vec::new(),
-        );
+        let cache = FlattenedScopeCache::build(&ctx, &mut Vec::new());
         let result = cache.resolve(FileId(0), "helper");
         assert!(result.is_some());
         let matches = result.unwrap();
@@ -462,18 +474,14 @@ mod tests {
             vec![(SymbolId(10), "foo".into(), LangId::Python, None)],
         );
 
-        let import_adjacency = HashMap::new();
-        let mut file_languages = HashMap::new();
-        file_languages.insert(FileId(0), LangId::Python);
-        let file_paths: HashMap<FileId, PathBuf> = HashMap::new();
+        let ctx = ResolutionContext {
+            symbol_index,
+            import_adjacency: HashMap::new(),
+            file_languages: HashMap::from([(FileId(0), LangId::Python)]),
+            file_paths: HashMap::new(),
+        };
 
-        let cache = FlattenedScopeCache::build(
-            &symbol_index,
-            &import_adjacency,
-            &file_languages,
-            &file_paths,
-            &mut Vec::new(),
-        );
+        let cache = FlattenedScopeCache::build(&ctx, &mut Vec::new());
         assert!(cache.resolve(FileId(0), "bar").is_none());
     }
 
@@ -500,22 +508,20 @@ mod tests {
         );
 
         // Cycle: 0 -> 1 -> 0
-        let mut import_adjacency = HashMap::new();
-        import_adjacency.insert(FileId(0), vec![FileId(1)]);
-        import_adjacency.insert(FileId(1), vec![FileId(0)]);
+        let ctx = ResolutionContext {
+            symbol_index,
+            import_adjacency: HashMap::from([
+                (FileId(0), vec![FileId(1)]),
+                (FileId(1), vec![FileId(0)]),
+            ]),
+            file_languages: HashMap::from([
+                (FileId(0), LangId::Python),
+                (FileId(1), LangId::Python),
+            ]),
+            file_paths: HashMap::new(),
+        };
 
-        let mut file_languages = HashMap::new();
-        file_languages.insert(FileId(0), LangId::Python);
-        file_languages.insert(FileId(1), LangId::Python);
-        let file_paths: HashMap<FileId, PathBuf> = HashMap::new();
-
-        let cache = FlattenedScopeCache::build(
-            &symbol_index,
-            &import_adjacency,
-            &file_languages,
-            &file_paths,
-            &mut Vec::new(),
-        );
+        let cache = FlattenedScopeCache::build(&ctx, &mut Vec::new());
         // Should not infinite loop
         assert!(cache.resolve(FileId(0), "b").is_some());
         assert!(cache.resolve(FileId(1), "a").is_some());
@@ -535,21 +541,14 @@ mod tests {
             )],
         );
 
-        let mut import_adjacency = HashMap::new();
-        import_adjacency.insert(FileId(0), vec![FileId(1)]);
+        let ctx = ResolutionContext {
+            symbol_index,
+            import_adjacency: HashMap::from([(FileId(0), vec![FileId(1)])]),
+            file_languages: HashMap::from([(FileId(0), LangId::Python), (FileId(1), LangId::Rust)]),
+            file_paths: HashMap::new(),
+        };
 
-        let mut file_languages = HashMap::new();
-        file_languages.insert(FileId(0), LangId::Python);
-        file_languages.insert(FileId(1), LangId::Rust);
-        let file_paths: HashMap<FileId, PathBuf> = HashMap::new();
-
-        let cache = FlattenedScopeCache::build(
-            &symbol_index,
-            &import_adjacency,
-            &file_languages,
-            &file_paths,
-            &mut Vec::new(),
-        );
+        let cache = FlattenedScopeCache::build(&ctx, &mut Vec::new());
         let result = cache.resolve(FileId(0), "util");
         assert!(result.is_some());
         assert_eq!(result.unwrap()[0].1, 0.6);

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -38,8 +38,8 @@ pub fn discover_files(
         return Ok(results);
     }
 
-    for entry in walkdir::WalkDir::new(root)
-        .into_iter()
+    for entry in ignore::WalkBuilder::new(root)
+        .build()
         .filter_map(|e| e.ok())
     {
         let path = entry.into_path();
@@ -195,6 +195,20 @@ mod tests {
         let files = discover_files(&path, None).unwrap();
         assert_eq!(files.len(), 1);
         assert_eq!(files[0].1, LangId::Python);
+    }
+
+    #[test]
+    fn discover_files_respects_gitignore() {
+        let root = PathBuf::from("tests/fixtures/mixed");
+        let files = discover_files(&root, None).unwrap();
+        let paths: Vec<_> = files
+            .iter()
+            .map(|(p, _)| p.file_name().unwrap().to_str().unwrap())
+            .collect();
+        assert!(
+            !paths.contains(&"test.generated.py"),
+            "gitignored file should be excluded"
+        );
     }
 
     #[test]

--- a/src/language/c.rs
+++ b/src/language/c.rs
@@ -64,7 +64,7 @@ fn c_import_ref_query() -> &'static tree_sitter::Query {
     &C_IMPORT_REF_QUERY
 }
 
-pub const C_SPEC: LanguageSpec = LanguageSpec {
+pub(crate) const C_SPEC: LanguageSpec = LanguageSpec {
     extensions: &["c"],
     grammar_fn: || tree_sitter_c::LANGUAGE.into(),
     query_fn: c_query,

--- a/src/language/common.rs
+++ b/src/language/common.rs
@@ -16,11 +16,7 @@ pub(crate) fn compile_query(
     match tree_sitter::Query::new(lang, src) {
         Ok(q) => q,
         Err(e) => {
-            eprintln!(
-                "FATAL: query compilation failed for {}: {}. Aborting.",
-                label, e
-            );
-            std::process::abort()
+            panic!("query compilation failed for {label}: {e}");
         }
     }
 }
@@ -318,7 +314,9 @@ pub(crate) fn extract_imports_and_references_with_spec<'a>(
 
     let slice = |(s, e): (usize, usize)| -> String {
         let s = &source[s..e];
-        std::str::from_utf8(s).unwrap_or("").to_string()
+        std::str::from_utf8(s)
+            .unwrap_or("<invalid-utf8>")
+            .to_string()
     };
     let mut imports: Vec<crate::model::UnresolvedImport> = Vec::with_capacity(raw_imports.len());
     for r in raw_imports {
@@ -338,7 +336,7 @@ pub(crate) fn extract_imports_and_references_with_spec<'a>(
         Vec::with_capacity(ref_ranges.len());
     for range in ref_ranges {
         let name = std::str::from_utf8(&source[range.byte_start..range.byte_end])
-            .unwrap_or("")
+            .unwrap_or("<invalid-utf8>")
             .to_string();
         references.push(crate::model::UnresolvedReference { name, range });
     }

--- a/src/language/cpp.rs
+++ b/src/language/cpp.rs
@@ -62,7 +62,7 @@ fn cpp_import_ref_query() -> &'static tree_sitter::Query {
     &CPP_IMPORT_REF_QUERY
 }
 
-pub const CPP_SPEC: LanguageSpec = LanguageSpec {
+pub(crate) const CPP_SPEC: LanguageSpec = LanguageSpec {
     extensions: &["cc", "cpp", "cxx"],
     grammar_fn: || tree_sitter_cpp::LANGUAGE.into(),
     query_fn: cpp_query,

--- a/src/language/go.rs
+++ b/src/language/go.rs
@@ -86,7 +86,7 @@ fn go_import_ref_query() -> &'static tree_sitter::Query {
     &GO_IMPORT_REF_QUERY
 }
 
-pub const GO_SPEC: LanguageSpec = LanguageSpec {
+pub(crate) const GO_SPEC: LanguageSpec = LanguageSpec {
     extensions: &["go"],
     grammar_fn: || tree_sitter_go::LANGUAGE.into(),
     query_fn: go_query,

--- a/src/language/javascript.rs
+++ b/src/language/javascript.rs
@@ -90,7 +90,7 @@ fn js_import_ref_query() -> &'static tree_sitter::Query {
     &JS_IMPORT_REF_QUERY
 }
 
-pub const JS_SPEC: LanguageSpec = LanguageSpec {
+pub(crate) const JS_SPEC: LanguageSpec = LanguageSpec {
     extensions: &["js", "mjs", "cjs"],
     grammar_fn: || tree_sitter_javascript::LANGUAGE.into(),
     query_fn: js_query,

--- a/src/language/mod.rs
+++ b/src/language/mod.rs
@@ -5,15 +5,15 @@
 //! constructors (symbols, imports, references), and language-specific
 //! extraction heuristics.
 
-pub mod c;
+pub(crate) mod c;
 pub(crate) mod common;
-pub mod cpp;
-pub mod go;
-pub mod javascript;
-pub mod python;
-pub mod rust;
-pub mod tsx;
-pub mod typescript;
+pub(crate) mod cpp;
+pub(crate) mod go;
+pub(crate) mod javascript;
+pub(crate) mod python;
+pub(crate) mod rust;
+pub(crate) mod tsx;
+pub(crate) mod typescript;
 
 use serde::Serialize;
 use tree_sitter::Query;
@@ -94,6 +94,15 @@ pub fn spec_for(id: LangId) -> &'static LanguageSpec {
 
 pub fn grammar_for(id: LangId) -> tree_sitter::Language {
     (spec_for(id).grammar_fn)()
+}
+
+/// Eagerly initialize all language query statics.
+/// Call at startup to fail fast on query compilation bugs.
+pub fn validate_queries() {
+    for id in LangId::all() {
+        let _ = (spec_for(id).query_fn)();
+        let _ = (spec_for(id).import_ref_query_fn)();
+    }
 }
 
 pub fn extract_symbols_for<'a>(

--- a/src/language/python.rs
+++ b/src/language/python.rs
@@ -81,7 +81,7 @@ fn python_import_ref_query() -> &'static tree_sitter::Query {
     &PYTHON_IMPORT_REF_QUERY
 }
 
-pub const PYTHON_SPEC: LanguageSpec = LanguageSpec {
+pub(crate) const PYTHON_SPEC: LanguageSpec = LanguageSpec {
     extensions: &["py", "pyi"],
     grammar_fn: || tree_sitter_python::LANGUAGE.into(),
     query_fn: python_query,

--- a/src/language/rust.rs
+++ b/src/language/rust.rs
@@ -91,7 +91,7 @@ fn rust_import_ref_query() -> &'static tree_sitter::Query {
     &RUST_IMPORT_REF_QUERY
 }
 
-pub const RUST_SPEC: LanguageSpec = LanguageSpec {
+pub(crate) const RUST_SPEC: LanguageSpec = LanguageSpec {
     extensions: &["rs"],
     grammar_fn: || tree_sitter_rust::LANGUAGE.into(),
     query_fn: rust_query,

--- a/src/language/tsx.rs
+++ b/src/language/tsx.rs
@@ -29,7 +29,7 @@ fn tsx_query() -> &'static tree_sitter::Query {
     &TSX_QUERY
 }
 
-pub const TSX_SPEC: LanguageSpec = LanguageSpec {
+pub(crate) const TSX_SPEC: LanguageSpec = LanguageSpec {
     extensions: &["tsx"],
     grammar_fn: || tree_sitter_typescript::LANGUAGE_TSX.into(),
     query_fn: tsx_query,

--- a/src/language/typescript.rs
+++ b/src/language/typescript.rs
@@ -2,7 +2,7 @@ use crate::language::LanguageSpec;
 use crate::model::Visibility;
 use std::sync::LazyLock;
 
-pub const TS_FAMILY_QUERY: &str = r#"
+pub(crate) const TS_FAMILY_QUERY: &str = r#"
 (function_declaration
   "async"? @async
   name: (identifier) @name
@@ -75,7 +75,7 @@ static TS_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
     )
 });
 
-pub const TS_FAMILY_IMPORT_QUERY: &str = r#"
+pub(crate) const TS_FAMILY_IMPORT_QUERY: &str = r#"
 (import_statement
   source: (string) @import.path)
 (import_statement
@@ -93,7 +93,7 @@ pub const TS_FAMILY_IMPORT_QUERY: &str = r#"
       (identifier) @import.symbol)))
 "#;
 
-pub const TS_FAMILY_REFERENCE_QUERY: &str = r#"
+pub(crate) const TS_FAMILY_REFERENCE_QUERY: &str = r#"
 (call_expression
   function: (identifier) @reference.name)
 (call_expression
@@ -117,7 +117,7 @@ fn ts_query() -> &'static tree_sitter::Query {
     &TS_QUERY
 }
 
-pub const TS_SPEC: LanguageSpec = LanguageSpec {
+pub(crate) const TS_SPEC: LanguageSpec = LanguageSpec {
     extensions: &["ts", "cts", "mts"],
     grammar_fn: || tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
     query_fn: ts_query,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod language;
 pub mod model;
 pub mod output;
 pub mod parser;
+pub mod pipeline;
 
 pub use error::{Diagnostic, Error, Severity};
 pub use input::detect_language;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,14 @@
-use std::collections::HashMap;
-
 use clap::Parser;
-use meta_ast::graph::resolver;
-use meta_ast::graph::{GraphBuilder, SccAnalysis};
 use meta_ast::interface::args::Cli;
 use meta_ast::model::SnapshotId;
 
 fn main() -> anyhow::Result<()> {
+    meta_ast::language::validate_queries();
+
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
     let cli = Cli::parse();
 
     match cli {
@@ -23,11 +25,10 @@ fn main() -> anyhow::Result<()> {
 
             for file in &result.files {
                 for diag in &file.diagnostics {
-                    eprintln!(
-                        "[{:?}] {}: {}",
-                        diag.severity,
-                        diag.path.display(),
-                        diag.message
+                    tracing::warn!(
+                        path = %diag.path.display(),
+                        severity = ?diag.severity,
+                        "{}", diag.message
                     );
                 }
             }
@@ -43,105 +44,21 @@ fn main() -> anyhow::Result<()> {
         }
 
         Cli::Graph(args) => {
-            let files = meta_ast::input::discover_files(&args.path, None)?;
             let snapshot_id = SnapshotId(1);
-            let mut builder = GraphBuilder::new(snapshot_id);
+            let (analysis, diags) = meta_ast::pipeline::analyze_graph(&args.path, snapshot_id)?;
 
-            for (path, lang) in &files {
-                builder.add_file(path.clone(), *lang);
-            }
-
-            let result = meta_ast::extractor::extract(&files);
-
-            for file in &result.files {
-                for diag in &file.diagnostics {
-                    eprintln!(
-                        "[{:?}] {}: {}",
-                        diag.severity,
-                        diag.path.display(),
-                        diag.message
-                    );
-                }
-            }
-
-            // Pass 2: add symbols and import edges
-            for file in &result.files {
-                for symbol in &file.symbols {
-                    builder.add_symbol(symbol)?;
-                }
-            }
-
-            // Resolve import edges: convert UnresolvedImport → builder.add_import
-            let mut path_to_file_id: HashMap<std::path::PathBuf, meta_ast::model::FileId> =
-                HashMap::new();
-            for file in &result.files {
-                if let Some(fid) = builder.file_id_for_path(&file.path) {
-                    path_to_file_id.insert(file.path.clone(), fid);
-                }
-            }
-
-            for file in &result.files {
-                let Some(&source_fid) = path_to_file_id.get(&file.path) else {
-                    continue;
-                };
-                for import in &file.imports {
-                    if let Some(dir) = file.path.parent()
-                        && let Some(target) =
-                            resolver::normalize_import_path(dir, &import.namespace, file.lang)
-                    {
-                        builder.add_import(source_fid, target);
-                    }
-                }
-            }
-
-            // Pass 3: build scope cache and resolve references
-            let symbol_index = resolver::build_symbol_index(&result.files, &path_to_file_id);
-            let import_adjacency = builder.import_adjacency();
-            let file_languages: HashMap<_, _> = result
-                .files
-                .iter()
-                .filter_map(|f| Some((path_to_file_id.get(&f.path)?.to_owned(), f.lang)))
-                .collect();
-            let file_paths: HashMap<_, _> = path_to_file_id
-                .iter()
-                .map(|(path, &fid)| (fid, path.clone()))
-                .collect();
-            let mut diagnostics: Vec<meta_ast::error::Diagnostic> = Vec::new();
-            let scope_cache = resolver::FlattenedScopeCache::build(
-                &symbol_index,
-                &import_adjacency,
-                &file_languages,
-                &file_paths,
-                &mut diagnostics,
-            );
-            let ref_edges = resolver::resolve_all_references(
-                &result.files,
-                &path_to_file_id,
-                &scope_cache,
-                &mut diagnostics,
-            );
-
-            for diag in &diagnostics {
-                eprintln!(
-                    "[{:?}] {}: {}",
-                    diag.severity,
-                    diag.path.display(),
-                    diag.message
+            for diag in &diags {
+                tracing::warn!(
+                    path = %diag.path.display(),
+                    severity = ?diag.severity,
+                    "{}", diag.message
                 );
             }
 
-            // Pass 4: add reference edges
-            for (from, to) in ref_edges {
-                builder.add_reference(from, to);
-            }
-
-            let graph = builder.build();
-            let scc_analysis = SccAnalysis::analyze(&graph.graph);
-
             if args.html {
                 let html = meta_ast::output::dashboard::to_graph_html(
-                    &graph,
-                    &scc_analysis,
+                    &analysis.graph,
+                    &analysis.scc,
                     snapshot_id.0 as u64,
                     args.self_contained,
                 )?;
@@ -156,12 +73,12 @@ fn main() -> anyhow::Result<()> {
                 let path_str = path.to_string_lossy().to_string();
                 std::fs::write(&path, &html)?;
                 if let Err(e) = webbrowser::open(&path_str) {
-                    eprintln!("Warning: could not open browser: {e}");
+                    tracing::warn!(error = %e, "could not open browser");
                 }
             } else {
                 let content = meta_ast::output::graph::serialize_graph(
-                    &graph,
-                    &scc_analysis,
+                    &analysis.graph,
+                    &analysis.scc,
                     snapshot_id.0 as u64,
                     &args.format,
                 )?;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -15,7 +15,8 @@ thread_local! {
     static PARSERS: RefCell<[Option<Parser>; LangId::COUNT]> = const { RefCell::new([const { None }; LangId::COUNT]) };
 }
 
-pub struct ParsedFile {
+#[allow(dead_code)]
+pub(crate) struct ParsedFile {
     pub tree: tree_sitter::Tree,
     pub source: Vec<u8>,
 }
@@ -38,7 +39,7 @@ fn get_or_init_parser(
         .ok_or_else(|| Error::Config("parser slot was not initialized".into()))
 }
 
-pub fn parse_tree(lang: LangId, source: &[u8]) -> Result<tree_sitter::Tree, Error> {
+pub(crate) fn parse_tree(lang: LangId, source: &[u8]) -> Result<tree_sitter::Tree, Error> {
     PARSERS.with(|cache| {
         let parsers = &mut *cache.borrow_mut();
         let parser = get_or_init_parser(parsers, lang)?;
@@ -49,7 +50,8 @@ pub fn parse_tree(lang: LangId, source: &[u8]) -> Result<tree_sitter::Tree, Erro
     })
 }
 
-pub fn parse(lang: LangId, source: &[u8]) -> Result<ParsedFile, Error> {
+#[allow(dead_code)]
+pub(crate) fn parse(lang: LangId, source: &[u8]) -> Result<ParsedFile, Error> {
     let tree = parse_tree(lang, source)?;
     Ok(ParsedFile {
         tree,
@@ -57,7 +59,7 @@ pub fn parse(lang: LangId, source: &[u8]) -> Result<ParsedFile, Error> {
     })
 }
 
-pub fn error_ratio(tree: &tree_sitter::Tree, source: &[u8]) -> f64 {
+pub(crate) fn error_ratio(tree: &tree_sitter::Tree, source: &[u8]) -> f64 {
     if source.is_empty() {
         return 0.0;
     }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1,0 +1,104 @@
+use std::collections::HashMap;
+use std::path::Path;
+
+use crate::error::Diagnostic;
+use crate::graph::{CodeGraph, GraphBuilder, SccAnalysis};
+use crate::input;
+use crate::model::{FileId, SnapshotId};
+
+/// Result of the full graph analysis pipeline.
+pub struct GraphAnalysis {
+    pub graph: CodeGraph,
+    pub scc: SccAnalysis,
+    pub snapshot_id: SnapshotId,
+}
+
+/// Run the full graph analysis pipeline on a path.
+///
+/// Discovers files, extracts symbols/imports/references in parallel,
+/// builds the dependency graph, resolves cross-file references,
+/// and computes SCC analysis.
+pub fn analyze_graph(
+    root: &Path,
+    snapshot_id: SnapshotId,
+) -> anyhow::Result<(GraphAnalysis, Vec<Diagnostic>)> {
+    let files = input::discover_files(root, None)?;
+
+    let extraction = crate::extractor::extract(&files);
+
+    let mut diagnostics: Vec<Diagnostic> = extraction
+        .files
+        .iter()
+        .flat_map(|f| f.diagnostics.iter().cloned())
+        .collect();
+
+    let mut builder = GraphBuilder::new(snapshot_id);
+    for (path, lang) in &files {
+        builder.add_file(path.clone(), *lang);
+    }
+
+    for file in &extraction.files {
+        for symbol in &file.symbols {
+            if let Err(e) = builder.add_symbol(symbol) {
+                diagnostics.push(Diagnostic {
+                    path: file.path.clone(),
+                    severity: crate::error::Severity::Warning,
+                    message: format!("failed to add symbol to graph: {e}"),
+                    source_range: None,
+                });
+            }
+        }
+    }
+
+    let mut path_to_file_id: HashMap<std::path::PathBuf, FileId> = HashMap::new();
+    for file in &extraction.files {
+        if let Some(fid) = builder.file_id_for_path(&file.path) {
+            path_to_file_id.insert(file.path.clone(), fid);
+        }
+    }
+
+    for file in &extraction.files {
+        let Some(&source_fid) = path_to_file_id.get(&file.path) else {
+            continue;
+        };
+        for import in &file.imports {
+            if let Some(dir) = file.path.parent()
+                && let Some(target) =
+                    crate::graph::resolver::normalize_import_path(dir, &import.namespace, file.lang)
+            {
+                builder.add_import(source_fid, target);
+            }
+        }
+    }
+
+    let import_adjacency = builder.import_adjacency();
+    let ctx = crate::graph::resolver::ResolutionContext::from_extractions(
+        &extraction.files,
+        &path_to_file_id,
+        import_adjacency,
+    );
+    let scope_cache = crate::graph::resolver::FlattenedScopeCache::build(&ctx, &mut diagnostics);
+
+    let ref_edges = crate::graph::resolver::resolve_all_references(
+        &extraction.files,
+        &path_to_file_id,
+        &scope_cache,
+        &mut diagnostics,
+    );
+
+    for (from, to) in ref_edges {
+        builder.add_reference(from, to);
+    }
+
+    let graph = builder.build();
+    let scc = SccAnalysis::analyze(&graph.graph);
+
+    Ok((
+        GraphAnalysis {
+            graph,
+            scc,
+            snapshot_id,
+        },
+        diagnostics,
+    ))
+}

--- a/tests/fixtures/mixed/.gitignore
+++ b/tests/fixtures/mixed/.gitignore
@@ -1,0 +1,1 @@
+*.generated.py

--- a/tests/integration/pipeline_test.rs
+++ b/tests/integration/pipeline_test.rs
@@ -203,13 +203,13 @@ fn cross_file_reference_resolution() {
         .filter_map(|f| Some((path_map.get(&f.path)?.to_owned(), f.lang)))
         .collect();
     let file_paths: HashMap<_, _> = path_map.iter().map(|(k, v)| (*v, k.clone())).collect();
-    let scope_cache = meta_ast::graph::resolver::FlattenedScopeCache::build(
-        &symbol_index,
-        &import_adjacency,
-        &file_languages,
-        &file_paths,
-        &mut Vec::new(),
-    );
+    let ctx = meta_ast::graph::resolver::ResolutionContext {
+        symbol_index,
+        import_adjacency,
+        file_languages,
+        file_paths,
+    };
+    let scope_cache = meta_ast::graph::resolver::FlattenedScopeCache::build(&ctx, &mut Vec::new());
 
     let ref_edges = meta_ast::graph::resolver::resolve_all_references(
         &result.files,
@@ -324,13 +324,13 @@ fn cross_file_reference_rust_crate() {
         .filter_map(|f| Some((path_map.get(&f.path)?.to_owned(), f.lang)))
         .collect();
     let file_paths: HashMap<_, _> = path_map.iter().map(|(k, v)| (*v, k.clone())).collect();
-    let scope_cache = meta_ast::graph::resolver::FlattenedScopeCache::build(
-        &symbol_index,
-        &import_adjacency,
-        &file_languages,
-        &file_paths,
-        &mut Vec::new(),
-    );
+    let ctx = meta_ast::graph::resolver::ResolutionContext {
+        symbol_index,
+        import_adjacency,
+        file_languages,
+        file_paths,
+    };
+    let scope_cache = meta_ast::graph::resolver::FlattenedScopeCache::build(&ctx, &mut Vec::new());
     let ref_edges = meta_ast::graph::resolver::resolve_all_references(
         &result.files,
         &path_map,
@@ -414,13 +414,13 @@ fn cross_file_reference_typescript() {
         .filter_map(|f| Some((path_map.get(&f.path)?.to_owned(), f.lang)))
         .collect();
     let file_paths: HashMap<_, _> = path_map.iter().map(|(k, v)| (*v, k.clone())).collect();
-    let scope_cache = meta_ast::graph::resolver::FlattenedScopeCache::build(
-        &symbol_index,
-        &import_adjacency,
-        &file_languages,
-        &file_paths,
-        &mut Vec::new(),
-    );
+    let ctx = meta_ast::graph::resolver::ResolutionContext {
+        symbol_index,
+        import_adjacency,
+        file_languages,
+        file_paths,
+    };
+    let scope_cache = meta_ast::graph::resolver::FlattenedScopeCache::build(&ctx, &mut Vec::new());
     let ref_edges = meta_ast::graph::resolver::resolve_all_references(
         &result.files,
         &path_map,
@@ -539,13 +539,13 @@ fn edge_circular_does_not_infinite_loop() {
     let mut diagnostics: Vec<meta_ast::error::Diagnostic> = Vec::new();
 
     // Should complete without panic (cycle handled by visited set)
-    let scope_cache = meta_ast::graph::resolver::FlattenedScopeCache::build(
-        &symbol_index,
-        &import_adjacency,
-        &file_languages,
-        &file_paths,
-        &mut diagnostics,
-    );
+    let ctx = meta_ast::graph::resolver::ResolutionContext {
+        symbol_index,
+        import_adjacency,
+        file_languages,
+        file_paths,
+    };
+    let scope_cache = meta_ast::graph::resolver::FlattenedScopeCache::build(&ctx, &mut diagnostics);
     assert!(!scope_cache.is_empty(), "scope cache should not be empty");
     assert_eq!(scope_cache.len(), 2, "should have 2 file scopes");
 
@@ -621,13 +621,13 @@ fn edge_transitive_resolution() {
         .filter_map(|f| Some((path_map.get(&f.path)?.to_owned(), f.lang)))
         .collect();
     let file_paths: HashMap<_, _> = path_map.iter().map(|(k, v)| (*v, k.clone())).collect();
-    let scope_cache = meta_ast::graph::resolver::FlattenedScopeCache::build(
-        &symbol_index,
-        &import_adjacency,
-        &file_languages,
-        &file_paths,
-        &mut Vec::new(),
-    );
+    let ctx = meta_ast::graph::resolver::ResolutionContext {
+        symbol_index,
+        import_adjacency,
+        file_languages,
+        file_paths,
+    };
+    let scope_cache = meta_ast::graph::resolver::FlattenedScopeCache::build(&ctx, &mut Vec::new());
     let ref_edges = meta_ast::graph::resolver::resolve_all_references(
         &result.files,
         &path_map,
@@ -725,13 +725,13 @@ fn edge_unresolved_ref_creates_no_edges() {
         .collect();
     let file_paths: HashMap<_, _> = path_map.iter().map(|(k, v)| (*v, k.clone())).collect();
     let mut diagnostics: Vec<meta_ast::error::Diagnostic> = Vec::new();
-    let scope_cache = meta_ast::graph::resolver::FlattenedScopeCache::build(
-        &symbol_index,
-        &import_adjacency,
-        &file_languages,
-        &file_paths,
-        &mut diagnostics,
-    );
+    let ctx = meta_ast::graph::resolver::ResolutionContext {
+        symbol_index,
+        import_adjacency,
+        file_languages,
+        file_paths,
+    };
+    let scope_cache = meta_ast::graph::resolver::FlattenedScopeCache::build(&ctx, &mut Vec::new());
     let ref_edges = meta_ast::graph::resolver::resolve_all_references(
         &result.files,
         &path_map,
@@ -797,13 +797,13 @@ fn edge_selfref_does_not_create_self_loop() {
         .filter_map(|f| Some((path_map.get(&f.path)?.to_owned(), f.lang)))
         .collect();
     let file_paths: HashMap<_, _> = path_map.iter().map(|(k, v)| (*v, k.clone())).collect();
-    let scope_cache = meta_ast::graph::resolver::FlattenedScopeCache::build(
-        &symbol_index,
-        &import_adjacency,
-        &file_languages,
-        &file_paths,
-        &mut Vec::new(),
-    );
+    let ctx = meta_ast::graph::resolver::ResolutionContext {
+        symbol_index,
+        import_adjacency,
+        file_languages,
+        file_paths,
+    };
+    let scope_cache = meta_ast::graph::resolver::FlattenedScopeCache::build(&ctx, &mut Vec::new());
     let ref_edges = meta_ast::graph::resolver::resolve_all_references(
         &result.files,
         &path_map,


### PR DESCRIPTION
This pull request introduces several significant improvements and refactorings to the codebase, focusing on diagnostics, file discovery, scope resolution, and dependency management. The main highlights include a new strategy for handling Tree-sitter query compilation errors, improved file discovery that respects `.gitignore`, a refactored API for scope resolution, and various dependency and visibility adjustments for better maintainability and performance.

**Diagnostics and Error Handling:**

- Documented and implemented a new strategy for Tree-sitter query compilation failures: now, a failed query compilation triggers a `panic!()` instead of `abort()` or propagating a `Result`, ensuring immediate feedback for programmer errors and better integration with Rust's panic infrastructure. Also, eager validation at startup ensures bugs are caught early. [[1]](diffhunk://#diff-70955eb31aecd71c3b2d02a4adefcb42bb5f0a98cc7a2dfc63af0eea8ce133b1R393-R404) [[2]](diffhunk://#diff-6537bb9450bb06c97631e83e5114d59e93bb13dbf21887fb713e64b7efae8b6aL19-R19)

**File Discovery Improvements:**

- Switched file discovery from `walkdir` to `ignore::WalkBuilder`, so discovered files now respect `.gitignore` and similar ignore files. Added a test to ensure gitignored files are excluded. [[1]](diffhunk://#diff-306fabc3ade1a58278e40c0c99da8c0d45c5f2b7e7e43c3ead13d64099194aa2L41-R42) [[2]](diffhunk://#diff-306fabc3ade1a58278e40c0c99da8c0d45c5f2b7e7e43c3ead13d64099194aa2R200-R213)
- Updated dependencies in `Cargo.toml` to include `ignore` and removed `walkdir`.

**Scope Resolution Refactor:**

- Introduced a new `ResolutionContext` struct to bundle all data needed for scope resolution, simplifying the API and reducing parameter lists. Updated `FlattenedScopeCache` and its usage to accept this context object. Refactored tests accordingly. [[1]](diffhunk://#diff-6ddea779d2c615afc12fd931732558a471ac0137f7b4d209b1e94570a6646ed4L18-R53) [[2]](diffhunk://#diff-6ddea779d2c615afc12fd931732558a471ac0137f7b4d209b1e94570a6646ed4L37-R75) [[3]](diffhunk://#diff-6ddea779d2c615afc12fd931732558a471ac0137f7b4d209b1e94570a6646ed4L63-R87) [[4]](diffhunk://#diff-6ddea779d2c615afc12fd931732558a471ac0137f7b4d209b1e94570a6646ed4L81-R99) [[5]](diffhunk://#diff-6ddea779d2c615afc12fd931732558a471ac0137f7b4d209b1e94570a6646ed4L113-R142) [[6]](diffhunk://#diff-6ddea779d2c615afc12fd931732558a471ac0137f7b4d209b1e94570a6646ed4L400-R427) [[7]](diffhunk://#diff-6ddea779d2c615afc12fd931732558a471ac0137f7b4d209b1e94570a6646ed4L434-R460) [[8]](diffhunk://#diff-6ddea779d2c615afc12fd931732558a471ac0137f7b4d209b1e94570a6646ed4L465-R484) [[9]](diffhunk://#diff-6ddea779d2c615afc12fd931732558a471ac0137f7b4d209b1e94570a6646ed4L503-R524) [[10]](diffhunk://#diff-6ddea779d2c615afc12fd931732558a471ac0137f7b4d209b1e94570a6646ed4L538-R551)

**Dependency and Visibility Adjustments:**

- Changed the visibility of language modules and their `LanguageSpec` constants from `pub` to `pub(crate)` for better encapsulation. [[1]](diffhunk://#diff-57e4b5420f699f92d9cbd8f1b7c701f2e918a6bcdadef53feaf29a040ba80240L8-R16) [[2]](diffhunk://#diff-9b8d092fd8bd1d2817988afb9c31043e8c501b3361714ebba988af740cbb9569L67-R67) [[3]](diffhunk://#diff-c6a5152c9ab2e6f5423e1ce13c4e69e8b9bbcae8b3c91de489028ceec08afadcL65-R65) [[4]](diffhunk://#diff-5a93ec4a89f6838655ba3ccaa203a67c4c84c878157d35d92131d00d31e6105bL89-R89) [[5]](diffhunk://#diff-f96f069fd1af5ec9ca2979221afe2ca37f844ea25720bce3389b2fa03fb75ba0L93-R93)
- Updated and reorganized dependencies and features in `Cargo.toml` for diagnostics (`tracing`), benchmarking, and improved build profiles. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L5-R76) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L73-L81)

**Other Improvements:**

- Improved handling of invalid UTF-8 in symbol and reference extraction, now using `<invalid-utf8>` as a fallback instead of an empty string. [[1]](diffhunk://#diff-6537bb9450bb06c97631e83e5114d59e93bb13dbf21887fb713e64b7efae8b6aL321-R319) [[2]](diffhunk://#diff-6537bb9450bb06c97631e83e5114d59e93bb13dbf21887fb713e64b7efae8b6aL341-R339)

These changes collectively improve the robustness, maintainability, and correctness of the codebase, especially around error handling and file processing.