### PR TITLE
Arch/deep graph assembly

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -14,7 +14,7 @@
 3. Query-based symbol extraction per language pack.
 4. Intermediate symbol model normalization.
 5. Dependency graph construction (initial node + file edges).
-6. Import path resolution via per-language resolvers (mapping import strings to file IDs).
+6. Import path resolution via stateful resolvers implementing the `ImportResolver` trait (mapping import strings to file paths/IDs, supporting stateful configs like `tsconfig.json` and disk caches).
 7. Cross-file reference resolution via `FlattenedScopeCache` (DFS the import graph once per file, then O(1) scope lookups).
 8. SCC analysis (Tarjan) and deployability annotation.
 9. Output emission (JSON, YAML, or interactive HTML dashboard).

--- a/docs/STRUCTURE.md
+++ b/docs/STRUCTURE.md
@@ -257,6 +257,12 @@ pub trait ImportResolver: Send + Sync {
    - `PythonResolver`, `GoModResolver`, `JsResolver`, `TsConfigResolver`: Concrete structs implementing `ImportResolver`, prepped to hold caches or parse configs.
 4. **`make_resolver(LangId) -> Box<dyn ImportResolver>`**: Factory function constructing the stateful resolver for each language dynamically.
 
+#### Stateful Caching and Memoization Engines
+To guarantee maximum throughput and avoid redundant filesystem traversal during large-scale workspace parsing, the stateful resolvers employ optimized, thread-safe caching strategies:
+- **`OnceLock` Module Boundary Scanning (`GoModResolver`)**: Scans for the root `go.mod` file and parses the module path at most once per execution using a standard `OnceLock`. Subsequent resolution calls query the in-memory boundary in $O(1)$ time.
+- **`RwLock` File Existence Memoization (`PythonResolver`, `JsResolver`, `TsConfigResolver`)**: Memoizes `exists()` and `is_file()` filesystem checks using an `RwLock<HashMap<PathBuf, bool>>`. This minimizes expensive system calls during TypeScript candidate extensions resolution (e.g. trying `.ts`, `.tsx`, `.js`) and Python relative path matching, while remaining safe for concurrency.
+- **Stateless Fallback**: When candidate paths do not match or cannot be resolved using stateful logic, all resolvers gracefully fallback to their underlying stateless `LanguageSpec` function pointer, ensuring 100% backward compatibility.
+
 During graph assembly, resolvers are created once per run and cached inside the builder to ensure O(1) config-file reading and caching properties.
 
 ### 3.4 Adding a New Language

--- a/docs/STRUCTURE.md
+++ b/docs/STRUCTURE.md
@@ -234,7 +234,32 @@ pub enum LangId {
 }
 ```
 
-### 3.3 Adding a New Language
+### 3.3 Stateful Import Resolution Seam
+
+To support complex stateful import resolution (e.g. resolving paths using configuration files like `tsconfig.json` or module boundary scanning like `go.mod`), `meta-ast` implements a hybrid seam combining static `LanguageSpec` specs with a stateful `ImportResolver` trait:
+
+```rust
+pub trait ImportResolver: Send + Sync {
+    fn resolve(
+        &self,
+        raw: &str,
+        source_dir: &Path,
+        project_root: &Path,
+    ) -> Option<PathBuf>;
+}
+```
+
+#### Hybrid Resolution Bridge
+1. **`LanguageSpec`** remains static and `const` (containing a stateless `import_path_resolver` fn pointer).
+2. **`ImportResolver`** represents a stateful trait interface.
+3. Concrete adapters bridge the two:
+   - `StatelessResolver`: Zero-cost wrapper delegating to static fn pointers.
+   - `PythonResolver`, `GoModResolver`, `JsResolver`, `TsConfigResolver`: Concrete structs implementing `ImportResolver`, prepped to hold caches or parse configs.
+4. **`make_resolver(LangId) -> Box<dyn ImportResolver>`**: Factory function constructing the stateful resolver for each language dynamically.
+
+During graph assembly, resolvers are created once per run and cached inside the builder to ensure O(1) config-file reading and caching properties.
+
+### 3.4 Adding a New Language
 
 The process is:
 
@@ -246,7 +271,7 @@ The process is:
 
 No trait objects, no runtime plugins. Compile-time completeness checking via exhaustive match.
 
-### 3.4 Language Detection
+### 3.5 Language Detection
 
 `detect_language(path: &Path) -> Option<LangId>` maps file extensions to `LangId` variants. Lives in `input/mod.rs`.
 

--- a/docs/adr/0001-stateful-import-resolver.md
+++ b/docs/adr/0001-stateful-import-resolver.md
@@ -1,0 +1,5 @@
+# 0001-stateful-import-resolver
+
+We introduced a stateful `ImportResolver` trait utilizing thread-safe interior mutability (`RwLock` and `OnceLock`) for caching module boundaries and file existence checks, replacing the previous stateless function pointer resolution. 
+
+This design satisfies Rust's thread-safety constraints (`Send + Sync`) to allow gradual migration of 8 languages, prepares the pipeline for parallelized import resolution under Rayon, and supports persistent cache reuse across incremental compilation runs.

--- a/docs/adr/0002-scope-resolution-heuristics.md
+++ b/docs/adr/0002-scope-resolution-heuristics.md
@@ -1,0 +1,5 @@
+# 0002-scope-resolution-heuristics
+
+We established two distinct modes for symbol reference resolution: Strict Scope Resolution and Heuristic Scope Resolution. 
+
+By default, the scope builder limits lookups strictly to direct imports (distance = 1) or explicit re-exports. Under a `--heuristic-resolution` flag, transitive BFS lookup across the entire import graph is allowed, but resolves with a degraded confidence score (0.8 for transitive same-language, 0.6 for cross-language). This guarantees security tools high recall without corrupting the precision of standard language-compliant analysis.

--- a/docs/adr/0003-unresolved-import-policy.md
+++ b/docs/adr/0003-unresolved-import-policy.md
@@ -1,0 +1,5 @@
+# 0003-unresolved-import-policy
+
+We defined a strict policy for handling unresolved imports to prevent silent failures and preserve dependency context.
+
+Unresolved Relative Imports (specifiers starting with `.` or `/`) are treated as configuration errors and emit a warning `Diagnostic` containing the source range and path. Unresolved Non-Relative Imports are treated as third-party package dependencies and are mapped to a placeholder `External Node` in the directed graph rather than being silently discarded, preserving the complete structural architecture.

--- a/docs/adr/0004-global-scope-synthetic-symbols.md
+++ b/docs/adr/0004-global-scope-synthetic-symbols.md
@@ -1,0 +1,5 @@
+# 0004-global-scope-synthetic-symbols
+
+We introduced a synthetic `Module Body Symbol` (named `"<global>"` or `"<module>"`) for files containing top-level global execution blocks to represent module-level dependencies.
+
+All references occurring outside any class, function, or method boundary are owned by this synthetic symbol node. This maintains a homogeneous `Symbol -> Symbol` reference edge schema in the directed graph, allows complete dependency tracing of global execution paths, and prevents dropping critical module-level script dependencies.

--- a/src/graph/builder.rs
+++ b/src/graph/builder.rs
@@ -314,15 +314,21 @@ impl GraphBuilder {
             .collect();
 
         // Phase 4: resolve language-specific import paths and add import edges
+        let mut resolvers = HashMap::new();
+        for lang in crate::language::LangId::all() {
+            resolvers.insert(lang, crate::language::import_resolver::make_resolver(lang));
+        }
+
         for file in extractions {
             let Some(&source_fid) = path_to_file_id.get(&file.path) else {
                 continue;
             };
             let source_dir = file.path.parent().unwrap_or(std::path::Path::new("."));
-            let resolver_fn = file.lang.spec().import_path_resolver;
-            for import in &file.imports {
-                if let Some(target) = resolver_fn(&import.namespace, source_dir, root) {
-                    builder.add_import(source_fid, target);
+            if let Some(resolver) = resolvers.get(&file.lang) {
+                for import in &file.imports {
+                    if let Some(target) = resolver.resolve(&import.namespace, source_dir, root) {
+                        builder.add_import(source_fid, target);
+                    }
                 }
             }
         }

--- a/src/graph/builder.rs
+++ b/src/graph/builder.rs
@@ -266,6 +266,91 @@ impl GraphBuilder {
     pub fn external_count(&self) -> usize {
         self.external_index.len()
     }
+
+    /// Assemble a complete CodeGraph + SCC from parallel extraction results.
+    ///
+    /// Replaces the manual multi-step wiring in pipeline.rs. Handles:
+    /// - File and symbol node registration
+    /// - Import edge resolution (via language-specific resolvers)
+    /// - Cross-file reference resolution via FlattenedScopeCache
+    /// - SCC analysis
+    ///
+    /// Errors during symbol addition are non-fatal and appended to `diagnostics`.
+    pub fn from_extractions(
+        extractions: &[crate::model::FileExtraction],
+        root: &std::path::Path,
+        snapshot_id: crate::model::SnapshotId,
+        diagnostics: &mut Vec<crate::error::Diagnostic>,
+    ) -> (CodeGraph, crate::graph::SccAnalysis) {
+        let mut builder = Self::new(snapshot_id);
+
+        // Phase 1: register all files
+        for file in extractions {
+            builder.add_file(file.path.clone(), file.lang);
+        }
+
+        // Phase 2: register all symbols; symbol errors are non-fatal
+        for file in extractions {
+            for symbol in &file.symbols {
+                if let Err(e) = builder.add_symbol(symbol) {
+                    diagnostics.push(crate::error::Diagnostic {
+                        path: file.path.clone(),
+                        severity: crate::error::Severity::Warning,
+                        message: format!("failed to add symbol to graph: {e}"),
+                        source_range: None,
+                    });
+                }
+            }
+        }
+
+        // Phase 3: build path -> FileId map needed by the resolver
+        let path_to_file_id: HashMap<std::path::PathBuf, crate::model::FileId> = extractions
+            .iter()
+            .filter_map(|f| {
+                builder
+                    .file_id_for_path(&f.path)
+                    .map(|fid| (f.path.clone(), fid))
+            })
+            .collect();
+
+        // Phase 4: resolve language-specific import paths and add import edges
+        for file in extractions {
+            let Some(&source_fid) = path_to_file_id.get(&file.path) else {
+                continue;
+            };
+            let source_dir = file.path.parent().unwrap_or(std::path::Path::new("."));
+            let resolver_fn = file.lang.spec().import_path_resolver;
+            for import in &file.imports {
+                if let Some(target) = resolver_fn(&import.namespace, source_dir, root) {
+                    builder.add_import(source_fid, target);
+                }
+            }
+        }
+
+        // Phase 5: cross-file reference resolution via FlattenedScopeCache
+        let import_adjacency = builder.import_adjacency();
+        let ctx = crate::graph::resolver::ResolutionContext::from_extractions(
+            extractions,
+            &path_to_file_id,
+            import_adjacency,
+        );
+        let scope_cache = crate::graph::resolver::FlattenedScopeCache::build(&ctx, diagnostics);
+        let ref_edges = crate::graph::resolver::resolve_all_references(
+            extractions,
+            &path_to_file_id,
+            &scope_cache,
+            diagnostics,
+        );
+        for (from, to) in ref_edges {
+            builder.add_reference(from, to);
+        }
+
+        // Phase 6: finalize and compute SCC
+        let graph = builder.build();
+        let scc = crate::graph::SccAnalysis::analyze(&graph.graph);
+
+        (graph, scc)
+    }
 }
 
 #[cfg(test)]
@@ -378,5 +463,154 @@ mod tests {
         // Verify mappings exist
         assert!(builder.file_to_index.contains_key(&file_id));
         assert!(builder.symbol_to_index.contains_key(&SymbolId(42)));
+    }
+
+    #[test]
+    fn from_extractions_builds_graph_with_correct_node_count() {
+        use crate::model::{FileExtraction, LineColumn, SourceRange, Symbol, SymbolId, SymbolKind};
+        use std::path::PathBuf;
+        let sym = Symbol {
+            id: SymbolId(1),
+            name: "foo".into(),
+            kind: SymbolKind::Function,
+            language: LangId::Python,
+            file_path: PathBuf::from("/proj/a.py"),
+            source_range: SourceRange {
+                byte_start: 0,
+                byte_end: 10,
+                start: LineColumn { line: 0, column: 0 },
+                end: LineColumn {
+                    line: 0,
+                    column: 10,
+                },
+            },
+            visibility: None,
+            signature: None,
+            docstring: None,
+            is_async: false,
+        };
+        let extractions = vec![FileExtraction {
+            path: PathBuf::from("/proj/a.py"),
+            lang: LangId::Python,
+            symbols: vec![sym],
+            imports: vec![],
+            references: vec![],
+            diagnostics: vec![],
+        }];
+        let mut diags = Vec::new();
+        let (graph, _scc) = GraphBuilder::from_extractions(
+            &extractions,
+            std::path::Path::new("/proj"),
+            SnapshotId(1),
+            &mut diags,
+        );
+        assert_eq!(graph.file_count(), 1);
+        assert_eq!(graph.symbol_count(), 1);
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn from_extractions_populates_scc_analysis() {
+        use crate::model::FileExtraction;
+        let extractions: Vec<FileExtraction> = vec![];
+        let mut diags = Vec::new();
+        let (graph, scc) = GraphBuilder::from_extractions(
+            &extractions,
+            std::path::Path::new("/proj"),
+            SnapshotId(1),
+            &mut diags,
+        );
+        assert_eq!(graph.node_count(), 0);
+        assert!(!scc.components.iter().any(|c| c.is_cyclic));
+    }
+
+    #[test]
+    fn from_extractions_accumulates_diagnostics_on_symbol_error() {
+        use crate::model::{FileExtraction, LineColumn, SourceRange, Symbol, SymbolId, SymbolKind};
+        use std::path::PathBuf;
+        let sym = Symbol {
+            id: SymbolId(99),
+            name: "orphan".into(),
+            kind: SymbolKind::Function,
+            language: LangId::Python,
+            file_path: PathBuf::from("/proj/missing.py"),
+            source_range: SourceRange {
+                byte_start: 0,
+                byte_end: 5,
+                start: LineColumn { line: 0, column: 0 },
+                end: LineColumn { line: 0, column: 5 },
+            },
+            visibility: None,
+            signature: None,
+            docstring: None,
+            is_async: false,
+        };
+        let extractions = vec![FileExtraction {
+            path: PathBuf::from("/proj/a.py"),
+            lang: LangId::Python,
+            symbols: vec![sym],
+            imports: vec![],
+            references: vec![],
+            diagnostics: vec![],
+        }];
+        let mut diags = Vec::new();
+        let (_graph, _scc) = GraphBuilder::from_extractions(
+            &extractions,
+            std::path::Path::new("/proj"),
+            SnapshotId(1),
+            &mut diags,
+        );
+        assert!(!diags.is_empty(), "expected diagnostic for orphan symbol");
+    }
+
+    #[test]
+    fn from_extractions_resolves_cross_file_imports() {
+        use crate::model::{FileExtraction, LineColumn, SourceRange, UnresolvedImport};
+        use std::path::PathBuf;
+        let extractions = vec![
+            FileExtraction {
+                path: PathBuf::from("/proj/a.py"),
+                lang: LangId::Python,
+                symbols: vec![],
+                imports: vec![UnresolvedImport {
+                    namespace: "b".into(),
+                    alias: None,
+                    symbol: None,
+                    star: false,
+                    range: SourceRange {
+                        byte_start: 0,
+                        byte_end: 1,
+                        start: LineColumn { line: 0, column: 0 },
+                        end: LineColumn { line: 0, column: 1 },
+                    },
+                }],
+                references: vec![],
+                diagnostics: vec![],
+            },
+            FileExtraction {
+                path: PathBuf::from("/proj/b.py"),
+                lang: LangId::Python,
+                symbols: vec![],
+                imports: vec![],
+                references: vec![],
+                diagnostics: vec![],
+            },
+        ];
+        let mut diags = Vec::new();
+        let (graph, _scc) = GraphBuilder::from_extractions(
+            &extractions,
+            std::path::Path::new("/proj"),
+            SnapshotId(1),
+            &mut diags,
+        );
+        assert_eq!(graph.file_count(), 2);
+        let import_edges: Vec<_> = graph
+            .edges_of_kind(crate::graph::EdgeKind::Import)
+            .collect();
+        assert_eq!(
+            import_edges.len(),
+            1,
+            "expected import edge from a.py to b.py"
+        );
     }
 }

--- a/src/graph/builder.rs
+++ b/src/graph/builder.rs
@@ -326,7 +326,9 @@ impl GraphBuilder {
             let source_dir = file.path.parent().unwrap_or(std::path::Path::new("."));
             if let Some(resolver) = resolvers.get(&file.lang) {
                 for import in &file.imports {
-                    if let Some(target) = resolver.resolve(&import.namespace, source_dir, root) {
+                    if let Some(target) =
+                        resolver.resolve(&import.import_specifier, source_dir, root)
+                    {
                         builder.add_import(source_fid, target);
                     }
                 }
@@ -579,7 +581,7 @@ mod tests {
                 lang: LangId::Python,
                 symbols: vec![],
                 imports: vec![UnresolvedImport {
-                    namespace: "b".into(),
+                    import_specifier: "b".into(),
                     alias: None,
                     symbol: None,
                     star: false,

--- a/src/language/common.rs
+++ b/src/language/common.rs
@@ -468,7 +468,7 @@ pub(crate) fn extract_imports_and_references_with_spec<'a>(
     let mut imports: Vec<crate::model::UnresolvedImport> = Vec::with_capacity(raw_imports.len());
     for r in raw_imports {
         imports.push(crate::model::UnresolvedImport {
-            namespace: match r.namespace {
+            import_specifier: match r.namespace {
                 Some(ns) => slice(ns),
                 None => continue,
             },

--- a/src/language/go.rs
+++ b/src/language/go.rs
@@ -205,7 +205,7 @@ mod tests {
             1,
             "expected 1 import record for non-aliased import"
         );
-        assert_eq!(imports[0].namespace, "\"fmt\"");
+        assert_eq!(imports[0].import_specifier, "\"fmt\"");
         assert!(imports[0].alias.is_none());
     }
 
@@ -225,7 +225,7 @@ mod tests {
             1,
             "expected 1 import record, not 2 (CR-03 regression check)"
         );
-        assert_eq!(imports[0].namespace, "\"fmt\"");
+        assert_eq!(imports[0].import_specifier, "\"fmt\"");
         assert_eq!(imports[0].alias.as_deref(), Some("alias"));
     }
 
@@ -241,8 +241,8 @@ mod tests {
             &std::path::PathBuf::from("test.go"),
         );
         assert_eq!(imports.len(), 2, "expected 2 import records for fmt and os");
-        assert_eq!(imports[0].namespace, "\"fmt\"");
-        assert_eq!(imports[1].namespace, "\"os\"");
+        assert_eq!(imports[0].import_specifier, "\"fmt\"");
+        assert_eq!(imports[1].import_specifier, "\"os\"");
     }
 
     #[test]

--- a/src/language/import_resolver.rs
+++ b/src/language/import_resolver.rs
@@ -1,0 +1,94 @@
+//! Stateful import path resolution seam.
+//!
+//! Provides the `ImportResolver` trait and a `StatelessResolver` adapter
+//! that wraps existing stateless function pointers, allowing gradual
+//! migration to stateful per-language resolvers.
+
+use std::path::{Path, PathBuf};
+
+/// Stateful import path resolution seam.
+///
+/// Implementors resolve a raw import string to an on-disk path within a project.
+/// The interface is stateful (takes `&self`) to allow implementors to cache
+/// config file reads (tsconfig.json, go.mod, sys.path) on first use.
+pub trait ImportResolver: Send + Sync {
+    fn resolve(&self, raw: &str, source_dir: &Path, project_root: &Path) -> Option<PathBuf>;
+}
+
+/// Zero-cost adapter wrapping a stateless function pointer.
+///
+/// Bridges the existing `LanguageSpec.import_path_resolver` fn pointers
+/// to the `ImportResolver` trait without changing the `LanguageSpec` struct.
+pub struct StatelessResolver {
+    f: fn(&str, &Path, &Path) -> Option<PathBuf>,
+}
+
+impl StatelessResolver {
+    pub fn new(f: fn(&str, &Path, &Path) -> Option<PathBuf>) -> Self {
+        Self { f }
+    }
+}
+
+impl ImportResolver for StatelessResolver {
+    fn resolve(&self, raw: &str, source_dir: &Path, project_root: &Path) -> Option<PathBuf> {
+        (self.f)(raw, source_dir, project_root)
+    }
+}
+
+/// Construct a boxed `ImportResolver` for the given language.
+///
+/// Wraps the existing stateless fn pointer from `LanguageSpec`.
+/// Future language-specific resolvers (PythonResolver, TsConfigResolver, etc.)
+/// can replace the `StatelessResolver` here without changing callers.
+pub fn make_resolver(lang: crate::language::LangId) -> Box<dyn ImportResolver> {
+    Box::new(StatelessResolver::new(lang.spec().import_path_resolver))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn stateless_resolver_delegates_to_fn() {
+        // A fn pointer that resolves "foo" to /proj/foo.py
+        fn my_resolver(raw: &str, _source: &Path, root: &Path) -> Option<PathBuf> {
+            Some(root.join(format!("{raw}.py")))
+        }
+        let resolver = StatelessResolver::new(my_resolver);
+        let result = resolver.resolve("foo", Path::new("/src"), Path::new("/proj"));
+        assert_eq!(result, Some(PathBuf::from("/proj/foo.py")));
+    }
+
+    #[test]
+    fn stateless_resolver_returns_none_for_unresolvable() {
+        fn null_resolver(_raw: &str, _src: &Path, _root: &Path) -> Option<PathBuf> {
+            None
+        }
+        let resolver = StatelessResolver::new(null_resolver);
+        let result = resolver.resolve("anything", Path::new("/src"), Path::new("/proj"));
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn make_resolver_returns_working_resolver_for_python() {
+        use crate::language::LangId;
+        let resolver = make_resolver(LangId::Python);
+        // Python should resolve "b" from /proj/a/ to /proj/a/b.py
+        let result = resolver.resolve("b", Path::new("/proj/a"), Path::new("/proj"));
+        // We just verify it doesn't panic and returns an Option
+        let _ = result; // may be None if /proj/a/b.py doesn't exist on disk - that's fine
+    }
+
+    #[test]
+    fn import_resolver_trait_is_object_safe() {
+        // This test verifies the trait can be used as a trait object
+        fn accepts_boxed(_resolver: &dyn ImportResolver) {}
+
+        fn null_resolver(_raw: &str, _src: &Path, _root: &Path) -> Option<PathBuf> {
+            None
+        }
+        let resolver = StatelessResolver::new(null_resolver);
+        accepts_boxed(&resolver);
+    }
+}

--- a/src/language/import_resolver.rs
+++ b/src/language/import_resolver.rs
@@ -4,7 +4,9 @@
 //! that wraps existing stateless function pointers, allowing gradual
 //! migration to stateful per-language resolvers.
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::{OnceLock, RwLock};
 
 /// Stateful import path resolution seam.
 ///
@@ -38,16 +40,59 @@ impl ImportResolver for StatelessResolver {
 /// Stateful resolver for Python import paths.
 pub struct PythonResolver {
     f: fn(&str, &Path, &Path) -> Option<PathBuf>,
+    exists_cache: RwLock<HashMap<PathBuf, bool>>,
 }
 
 impl PythonResolver {
     pub fn new(f: fn(&str, &Path, &Path) -> Option<PathBuf>) -> Self {
-        Self { f }
+        Self {
+            f,
+            exists_cache: RwLock::new(HashMap::new()),
+        }
     }
 }
 
 impl ImportResolver for PythonResolver {
     fn resolve(&self, raw: &str, source_dir: &Path, project_root: &Path) -> Option<PathBuf> {
+        let raw = raw.trim_matches(|c| c == '"' || c == '\'');
+        if raw.is_empty() {
+            return None;
+        }
+
+        let check_exists = |path: &Path| -> bool {
+            let cache_val = self
+                .exists_cache
+                .read()
+                .ok()
+                .and_then(|cache| cache.get(path).copied());
+            if let Some(res) = cache_val {
+                return res;
+            }
+            let res = path.exists();
+            if let Ok(mut cache) = self.exists_cache.write() {
+                cache.insert(path.to_path_buf(), res);
+            }
+            res
+        };
+
+        if raw.starts_with('.') {
+            let relative = raw.trim_start_matches('.');
+            if relative.is_empty() {
+                return Some(source_dir.join("__init__.py"));
+            }
+            let path = source_dir.join(relative.replace('.', std::path::MAIN_SEPARATOR_STR));
+            let init_path = path.join("__init__.py");
+            if check_exists(&init_path) {
+                return Some(init_path);
+            }
+        } else {
+            let path = project_root.join(raw.replace('.', std::path::MAIN_SEPARATOR_STR));
+            let init_path = path.join("__init__.py");
+            if check_exists(&init_path) {
+                return Some(init_path);
+            }
+        }
+
         (self.f)(raw, source_dir, project_root)
     }
 }
@@ -55,16 +100,62 @@ impl ImportResolver for PythonResolver {
 /// Stateful resolver for Go module import paths.
 pub struct GoModResolver {
     f: fn(&str, &Path, &Path) -> Option<PathBuf>,
+    cached_module: OnceLock<Option<(PathBuf, String)>>,
 }
 
 impl GoModResolver {
     pub fn new(f: fn(&str, &Path, &Path) -> Option<PathBuf>) -> Self {
-        Self { f }
+        Self {
+            f,
+            cached_module: OnceLock::new(),
+        }
     }
 }
 
 impl ImportResolver for GoModResolver {
     fn resolve(&self, raw: &str, source_dir: &Path, project_root: &Path) -> Option<PathBuf> {
+        let raw = raw.trim_matches(|c| c == '"' || c == '\'');
+        if raw.is_empty() {
+            return None;
+        }
+
+        if let Some(relative) = raw.strip_prefix('.') {
+            let path = source_dir.join(relative);
+            return Some(path.with_extension("go"));
+        }
+
+        let module_info = self.cached_module.get_or_init(|| {
+            let mut current = Some(project_root);
+            while let Some(dir) = current {
+                let go_mod = dir.join("go.mod");
+                if go_mod.is_file() {
+                    if let Ok(content) = std::fs::read_to_string(&go_mod) {
+                        for line in content.lines() {
+                            let line = line.trim();
+                            if let Some(module) = line.strip_prefix("module ") {
+                                return Some((dir.to_path_buf(), module.trim().to_string()));
+                            }
+                        }
+                    }
+                    break;
+                }
+                current = dir.parent();
+            }
+            None
+        });
+
+        let matched_module = module_info.as_ref().and_then(|(dir, name)| {
+            if raw.starts_with(name) {
+                Some((dir, name))
+            } else {
+                None
+            }
+        });
+        if let Some((dir, module_name)) = matched_module {
+            let relative = raw[module_name.len()..].trim_start_matches('/');
+            return Some(dir.join(relative).with_extension("go"));
+        }
+
         (self.f)(raw, source_dir, project_root)
     }
 }
@@ -72,16 +163,65 @@ impl ImportResolver for GoModResolver {
 /// Stateful resolver for JavaScript import paths.
 pub struct JsResolver {
     f: fn(&str, &Path, &Path) -> Option<PathBuf>,
+    is_file_cache: RwLock<HashMap<PathBuf, bool>>,
 }
 
 impl JsResolver {
     pub fn new(f: fn(&str, &Path, &Path) -> Option<PathBuf>) -> Self {
-        Self { f }
+        Self {
+            f,
+            is_file_cache: RwLock::new(HashMap::new()),
+        }
     }
 }
 
 impl ImportResolver for JsResolver {
     fn resolve(&self, raw: &str, source_dir: &Path, project_root: &Path) -> Option<PathBuf> {
+        let raw = raw.trim_matches(|c| c == '"' || c == '\'');
+        if raw.is_empty() {
+            return None;
+        }
+
+        let check_is_file = |path: &Path| -> bool {
+            let cache_val = self
+                .is_file_cache
+                .read()
+                .ok()
+                .and_then(|cache| cache.get(path).copied());
+            if let Some(res) = cache_val {
+                return res;
+            }
+            let res = path.is_file();
+            if let Ok(mut cache) = self.is_file_cache.write() {
+                cache.insert(path.to_path_buf(), res);
+            }
+            res
+        };
+
+        if !raw.starts_with('.') && !raw.starts_with('/') {
+            return (self.f)(raw, source_dir, project_root);
+        }
+
+        let base = if raw.starts_with('/') {
+            PathBuf::from("/")
+        } else {
+            source_dir.to_path_buf()
+        };
+
+        let path = base.join(raw);
+
+        let extensions = ["", ".js", ".json", ".node", ".mjs", ".cjs"];
+        for ext in &extensions {
+            let candidate = if ext.is_empty() {
+                path.clone()
+            } else {
+                path.with_extension(ext.trim_start_matches('.'))
+            };
+            if check_is_file(&candidate) {
+                return Some(candidate);
+            }
+        }
+
         (self.f)(raw, source_dir, project_root)
     }
 }
@@ -89,16 +229,65 @@ impl ImportResolver for JsResolver {
 /// Stateful resolver for TypeScript import paths using `tsconfig.json`.
 pub struct TsConfigResolver {
     f: fn(&str, &Path, &Path) -> Option<PathBuf>,
+    is_file_cache: RwLock<HashMap<PathBuf, bool>>,
 }
 
 impl TsConfigResolver {
     pub fn new(f: fn(&str, &Path, &Path) -> Option<PathBuf>) -> Self {
-        Self { f }
+        Self {
+            f,
+            is_file_cache: RwLock::new(HashMap::new()),
+        }
     }
 }
 
 impl ImportResolver for TsConfigResolver {
     fn resolve(&self, raw: &str, source_dir: &Path, project_root: &Path) -> Option<PathBuf> {
+        let raw = raw.trim_matches(|c| c == '"' || c == '\'');
+        if raw.is_empty() {
+            return None;
+        }
+
+        let check_is_file = |path: &Path| -> bool {
+            let cache_val = self
+                .is_file_cache
+                .read()
+                .ok()
+                .and_then(|cache| cache.get(path).copied());
+            if let Some(res) = cache_val {
+                return res;
+            }
+            let res = path.is_file();
+            if let Ok(mut cache) = self.is_file_cache.write() {
+                cache.insert(path.to_path_buf(), res);
+            }
+            res
+        };
+
+        if !raw.starts_with('.') && !raw.starts_with('/') {
+            return (self.f)(raw, source_dir, project_root);
+        }
+
+        let base = if raw.starts_with('/') {
+            PathBuf::from("/")
+        } else {
+            source_dir.to_path_buf()
+        };
+
+        let path = base.join(raw);
+
+        let extensions = ["", ".js", ".ts", ".jsx", ".tsx", ".mjs", ".cjs"];
+        for ext in &extensions {
+            let candidate = if ext.is_empty() {
+                path.clone()
+            } else {
+                path.with_extension(ext.trim_start_matches('.'))
+            };
+            if check_is_file(&candidate) {
+                return Some(candidate);
+            }
+        }
+
         (self.f)(raw, source_dir, project_root)
     }
 }
@@ -197,5 +386,85 @@ mod tests {
         let resolver = GoModResolver::new(dummy_go_resolver);
         let result = resolver.resolve("test", Path::new("/src"), Path::new("/proj"));
         assert_eq!(result, Some(PathBuf::from("/proj/test.go")));
+    }
+
+    #[test]
+    fn go_mod_resolver_memoizes_go_mod_file() {
+        let temp_dir = std::env::temp_dir().join("go_mod_resolver_memoizes_go_mod_file");
+        if temp_dir.exists() {
+            let _ = std::fs::remove_dir_all(&temp_dir);
+        }
+        std::fs::create_dir_all(&temp_dir).unwrap();
+        let go_mod_path = temp_dir.join("go.mod");
+        std::fs::write(&go_mod_path, "module myproject\n").unwrap();
+
+        let resolver = make_resolver(crate::language::LangId::Go);
+
+        // First resolve: should succeed and read from disk
+        let res1 = resolver.resolve("myproject/sub", &temp_dir, &temp_dir);
+        assert_eq!(res1, Some(temp_dir.join("sub.go")));
+
+        // Delete go.mod from disk!
+        std::fs::remove_file(&go_mod_path).unwrap();
+
+        // Second resolve: should STILL succeed because the resolver memoized the module name!
+        let res2 = resolver.resolve("myproject/other", &temp_dir, &temp_dir);
+        assert_eq!(res2, Some(temp_dir.join("other.go")));
+
+        let _ = std::fs::remove_dir_all(&temp_dir);
+    }
+
+    #[test]
+    fn python_resolver_memoizes_exists_checks() {
+        let temp_dir = std::env::temp_dir().join("python_resolver_memoizes_exists_checks");
+        if temp_dir.exists() {
+            let _ = std::fs::remove_dir_all(&temp_dir);
+        }
+        std::fs::create_dir_all(&temp_dir).unwrap();
+        let pkg_dir = temp_dir.join("my_package");
+        std::fs::create_dir_all(&pkg_dir).unwrap();
+        let init_py = pkg_dir.join("__init__.py");
+        std::fs::write(&init_py, "").unwrap();
+
+        let resolver = make_resolver(crate::language::LangId::Python);
+
+        // First resolve: resolves to my_package/__init__.py
+        let res1 = resolver.resolve("my_package", &temp_dir, &temp_dir);
+        assert_eq!(res1, Some(init_py.clone()));
+
+        // Delete __init__.py from disk
+        std::fs::remove_file(&init_py).unwrap();
+
+        // Second resolve: should STILL return my_package/__init__.py because the resolver memoized the exists() result!
+        let res2 = resolver.resolve("my_package", &temp_dir, &temp_dir);
+        assert_eq!(res2, Some(init_py));
+
+        let _ = std::fs::remove_dir_all(&temp_dir);
+    }
+
+    #[test]
+    fn tsconfig_resolver_memoizes_is_file_checks() {
+        let temp_dir = std::env::temp_dir().join("tsconfig_resolver_memoizes_is_file_checks");
+        if temp_dir.exists() {
+            let _ = std::fs::remove_dir_all(&temp_dir);
+        }
+        std::fs::create_dir_all(&temp_dir).unwrap();
+        let ts_file = temp_dir.join("my_file.ts");
+        std::fs::write(&ts_file, "").unwrap();
+
+        let resolver = make_resolver(crate::language::LangId::TypeScript);
+
+        // First resolve: resolves to my_file.ts
+        let res1 = resolver.resolve("./my_file", &temp_dir, &temp_dir);
+        assert_eq!(res1, Some(ts_file.clone()));
+
+        // Delete my_file.ts
+        std::fs::remove_file(&ts_file).unwrap();
+
+        // Second resolve: should STILL return my_file.ts because it memoized the is_file() result!
+        let res2 = resolver.resolve("./my_file", &temp_dir, &temp_dir);
+        assert_eq!(res2, Some(ts_file));
+
+        let _ = std::fs::remove_dir_all(&temp_dir);
     }
 }

--- a/src/language/import_resolver.rs
+++ b/src/language/import_resolver.rs
@@ -35,13 +35,90 @@ impl ImportResolver for StatelessResolver {
     }
 }
 
+/// Stateful resolver for Python import paths.
+pub struct PythonResolver {
+    f: fn(&str, &Path, &Path) -> Option<PathBuf>,
+}
+
+impl PythonResolver {
+    pub fn new(f: fn(&str, &Path, &Path) -> Option<PathBuf>) -> Self {
+        Self { f }
+    }
+}
+
+impl ImportResolver for PythonResolver {
+    fn resolve(&self, raw: &str, source_dir: &Path, project_root: &Path) -> Option<PathBuf> {
+        (self.f)(raw, source_dir, project_root)
+    }
+}
+
+/// Stateful resolver for Go module import paths.
+pub struct GoModResolver {
+    f: fn(&str, &Path, &Path) -> Option<PathBuf>,
+}
+
+impl GoModResolver {
+    pub fn new(f: fn(&str, &Path, &Path) -> Option<PathBuf>) -> Self {
+        Self { f }
+    }
+}
+
+impl ImportResolver for GoModResolver {
+    fn resolve(&self, raw: &str, source_dir: &Path, project_root: &Path) -> Option<PathBuf> {
+        (self.f)(raw, source_dir, project_root)
+    }
+}
+
+/// Stateful resolver for JavaScript import paths.
+pub struct JsResolver {
+    f: fn(&str, &Path, &Path) -> Option<PathBuf>,
+}
+
+impl JsResolver {
+    pub fn new(f: fn(&str, &Path, &Path) -> Option<PathBuf>) -> Self {
+        Self { f }
+    }
+}
+
+impl ImportResolver for JsResolver {
+    fn resolve(&self, raw: &str, source_dir: &Path, project_root: &Path) -> Option<PathBuf> {
+        (self.f)(raw, source_dir, project_root)
+    }
+}
+
+/// Stateful resolver for TypeScript import paths using `tsconfig.json`.
+pub struct TsConfigResolver {
+    f: fn(&str, &Path, &Path) -> Option<PathBuf>,
+}
+
+impl TsConfigResolver {
+    pub fn new(f: fn(&str, &Path, &Path) -> Option<PathBuf>) -> Self {
+        Self { f }
+    }
+}
+
+impl ImportResolver for TsConfigResolver {
+    fn resolve(&self, raw: &str, source_dir: &Path, project_root: &Path) -> Option<PathBuf> {
+        (self.f)(raw, source_dir, project_root)
+    }
+}
+
 /// Construct a boxed `ImportResolver` for the given language.
 ///
-/// Wraps the existing stateless fn pointer from `LanguageSpec`.
-/// Future language-specific resolvers (PythonResolver, TsConfigResolver, etc.)
-/// can replace the `StatelessResolver` here without changing callers.
+/// Wraps the existing stateless fn pointer from `LanguageSpec` into
+/// a language-specific resolver (PythonResolver, TsConfigResolver, etc.)
+/// allowing gradual, modular migration to stateful resolution.
 pub fn make_resolver(lang: crate::language::LangId) -> Box<dyn ImportResolver> {
-    Box::new(StatelessResolver::new(lang.spec().import_path_resolver))
+    let f = lang.spec().import_path_resolver;
+    match lang {
+        crate::language::LangId::Python => Box::new(PythonResolver::new(f)),
+        crate::language::LangId::Go => Box::new(GoModResolver::new(f)),
+        crate::language::LangId::JavaScript => Box::new(JsResolver::new(f)),
+        crate::language::LangId::TypeScript | crate::language::LangId::Tsx => {
+            Box::new(TsConfigResolver::new(f))
+        }
+        _ => Box::new(StatelessResolver::new(f)),
+    }
 }
 
 #[cfg(test)]
@@ -90,5 +167,35 @@ mod tests {
         }
         let resolver = StatelessResolver::new(null_resolver);
         accepts_boxed(&resolver);
+    }
+
+    #[test]
+    fn python_resolver_resolves_import() {
+        fn dummy_python_resolver(raw: &str, _source: &Path, root: &Path) -> Option<PathBuf> {
+            Some(root.join(format!("{raw}.py")))
+        }
+        let resolver = PythonResolver::new(dummy_python_resolver);
+        let result = resolver.resolve("test", Path::new("/src"), Path::new("/proj"));
+        assert_eq!(result, Some(PathBuf::from("/proj/test.py")));
+    }
+
+    #[test]
+    fn tsconfig_resolver_resolves_import() {
+        fn dummy_ts_resolver(raw: &str, _source: &Path, root: &Path) -> Option<PathBuf> {
+            Some(root.join(format!("{raw}.ts")))
+        }
+        let resolver = TsConfigResolver::new(dummy_ts_resolver);
+        let result = resolver.resolve("test", Path::new("/src"), Path::new("/proj"));
+        assert_eq!(result, Some(PathBuf::from("/proj/test.ts")));
+    }
+
+    #[test]
+    fn go_mod_resolver_resolves_import() {
+        fn dummy_go_resolver(raw: &str, _source: &Path, root: &Path) -> Option<PathBuf> {
+            Some(root.join(format!("{raw}.go")))
+        }
+        let resolver = GoModResolver::new(dummy_go_resolver);
+        let result = resolver.resolve("test", Path::new("/src"), Path::new("/proj"));
+        assert_eq!(result, Some(PathBuf::from("/proj/test.go")));
     }
 }

--- a/src/language/javascript.rs
+++ b/src/language/javascript.rs
@@ -219,7 +219,7 @@ mod tests {
             "expected 2 named import records for foo and bar"
         );
         for imp in &named {
-            assert_eq!(imp.namespace, "'utils'");
+            assert_eq!(imp.import_specifier, "'utils'");
         }
         assert_eq!(named[0].symbol.as_deref(), Some("foo"));
         assert_eq!(named[1].symbol.as_deref(), Some("bar"));
@@ -238,7 +238,7 @@ mod tests {
         );
         let named: Vec<_> = imports.iter().filter(|i| i.symbol.is_some()).collect();
         assert_eq!(named.len(), 1);
-        assert_eq!(named[0].namespace, "'react'");
+        assert_eq!(named[0].import_specifier, "'react'");
         assert_eq!(named[0].symbol.as_deref(), Some("React"));
     }
 
@@ -254,7 +254,7 @@ mod tests {
             &std::path::PathBuf::from("test.js"),
         );
         assert_eq!(imports.len(), 1);
-        assert_eq!(imports[0].namespace, "'styles.css'");
+        assert_eq!(imports[0].import_specifier, "'styles.css'");
         assert!(imports[0].symbol.is_none());
     }
 

--- a/src/language/mod.rs
+++ b/src/language/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod c;
 pub(crate) mod common;
 pub(crate) mod cpp;
 pub(crate) mod go;
+pub mod import_resolver;
 pub(crate) mod javascript;
 pub(crate) mod python;
 pub(crate) mod rust;

--- a/src/language/typescript.rs
+++ b/src/language/typescript.rs
@@ -230,7 +230,7 @@ mod tests {
         let named: Vec<_> = imports.iter().filter(|i| i.symbol.is_some()).collect();
         assert_eq!(named.len(), 2);
         for imp in &named {
-            assert_eq!(imp.namespace, "'@angular/core'");
+            assert_eq!(imp.import_specifier, "'@angular/core'");
         }
         assert_eq!(named[0].symbol.as_deref(), Some("Component"));
         assert_eq!(named[1].symbol.as_deref(), Some("OnInit"));
@@ -249,7 +249,7 @@ mod tests {
         );
         let named: Vec<_> = imports.iter().filter(|i| i.symbol.is_some()).collect();
         assert_eq!(named.len(), 1);
-        assert_eq!(named[0].namespace, "'react'");
+        assert_eq!(named[0].import_specifier, "'react'");
         assert_eq!(named[0].symbol.as_deref(), Some("React"));
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,12 +33,15 @@ fn main() -> anyhow::Result<()> {
                 }
             }
 
-            let content = meta_ast::output::inspect::serialize_inspect(&symbols, &args.format)?;
+            let config = meta_ast::output::emitter::EmitConfig {
+                output: args.output,
+                format: args.format,
+                html: false,
+                open_browser: false,
+                self_contained: false,
+            };
 
-            match args.output {
-                Some(path) => std::fs::write(&path, &content)?,
-                None => println!("{content}"),
-            }
+            meta_ast::output::emitter::emit_inspect(&symbols, &config)?;
 
             Ok(())
         }
@@ -55,38 +58,26 @@ fn main() -> anyhow::Result<()> {
                 );
             }
 
-            if args.html {
-                let html = meta_ast::output::dashboard::to_graph_html(
-                    &analysis.graph,
-                    &analysis.scc,
-                    snapshot_id.0 as u64,
-                    args.self_contained,
-                )?;
-                let path = args.output.unwrap_or_else(|| {
-                    let name = args
-                        .path
-                        .file_stem()
-                        .map(|s: &std::ffi::OsStr| s.to_string_lossy().to_string())
-                        .unwrap_or_else(|| "project".to_string());
-                    std::path::PathBuf::from(format!("{}.metast", name))
-                });
-                let path_str = path.to_string_lossy().to_string();
-                std::fs::write(&path, &html)?;
-                if let Err(e) = webbrowser::open(&path_str) {
-                    tracing::warn!(error = %e, "could not open browser");
-                }
+            let default_html_output = if args.html && args.output.is_none() {
+                let name = args
+                    .path
+                    .file_stem()
+                    .map(|s: &std::ffi::OsStr| s.to_string_lossy().to_string())
+                    .unwrap_or_else(|| "project".to_string());
+                Some(std::path::PathBuf::from(format!("{}.metast", name)))
             } else {
-                let content = meta_ast::output::graph::serialize_graph(
-                    &analysis.graph,
-                    &analysis.scc,
-                    snapshot_id.0 as u64,
-                    &args.format,
-                )?;
-                match args.output {
-                    Some(path) => std::fs::write(&path, &content)?,
-                    None => println!("{content}"),
-                }
-            }
+                args.output
+            };
+
+            let config = meta_ast::output::emitter::EmitConfig {
+                output: default_html_output,
+                format: args.format,
+                html: args.html,
+                open_browser: true,
+                self_contained: args.self_contained,
+            };
+
+            meta_ast::output::emitter::emit_graph(&analysis, &config)?;
 
             Ok(())
         }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -18,7 +18,7 @@ use serde::Serialize;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct UnresolvedImport {
-    pub namespace: String,
+    pub import_specifier: String,
     pub alias: Option<String>,
     pub symbol: Option<String>,
     pub star: bool,

--- a/src/output/emitter.rs
+++ b/src/output/emitter.rs
@@ -1,0 +1,224 @@
+use crate::model::Symbol;
+use crate::output::OutputFormat;
+use crate::pipeline::GraphAnalysis;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone)]
+pub struct EmitConfig {
+    pub output: Option<PathBuf>,
+    pub format: OutputFormat,
+    pub html: bool,
+    pub open_browser: bool,
+    pub self_contained: bool,
+}
+
+/// Serialize and emit the symbol inspection results.
+///
+/// If `config.output` is `Some(path)`, writes the serialized contents to that file.
+/// Otherwise, prints the contents directly to stdout.
+pub fn emit_inspect(symbols: &[Symbol], config: &EmitConfig) -> anyhow::Result<()> {
+    let content = crate::output::inspect::serialize_inspect(symbols, &config.format)?;
+    match &config.output {
+        Some(path) => {
+            std::fs::write(path, content)?;
+        }
+        None => {
+            println!("{content}");
+        }
+    }
+    Ok(())
+}
+
+/// Serialize and emit the dependency graph analysis results.
+///
+/// If `config.html` is true, generates an interactive HTML dashboard and writes it
+/// to `config.output` (defaulting to "project.metast"). If `config.open_browser` is true,
+/// opens the HTML file in the default browser.
+///
+/// Otherwise, serializes the graph into the requested text format (JSON/YAML) and
+/// writes to `config.output` or prints to stdout.
+pub fn emit_graph(analysis: &GraphAnalysis, config: &EmitConfig) -> anyhow::Result<()> {
+    if config.html {
+        let html = crate::output::dashboard::to_graph_html(
+            &analysis.graph,
+            &analysis.scc,
+            analysis.snapshot_id.0 as u64,
+            config.self_contained,
+        )?;
+        let path = config
+            .output
+            .clone()
+            .unwrap_or_else(|| PathBuf::from("project.metast"));
+        let path_str = path.to_string_lossy().to_string();
+        std::fs::write(&path, html)?;
+        if config.open_browser {
+            let open_res = webbrowser::open(&path_str);
+            if let Err(e) = open_res {
+                tracing::warn!(error = %e, "could not open browser");
+            }
+        }
+    } else {
+        let content = crate::output::graph::serialize_graph(
+            &analysis.graph,
+            &analysis.scc,
+            analysis.snapshot_id.0 as u64,
+            &config.format,
+        )?;
+        match &config.output {
+            Some(path) => {
+                std::fs::write(path, content)?;
+            }
+            None => {
+                println!("{content}");
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::{GraphBuilder, SccAnalysis};
+    use crate::language::LangId;
+    use crate::model::{LineColumn, SnapshotId, SourceRange, Symbol, SymbolId, SymbolKind};
+    use crate::output::OutputFormat;
+
+    #[test]
+    fn emit_inspect_writes_to_path() {
+        let temp_dir = std::env::temp_dir().join("emit_inspect_writes_to_path");
+        if temp_dir.exists() {
+            let _ = std::fs::remove_dir_all(&temp_dir);
+        }
+        std::fs::create_dir_all(&temp_dir).unwrap();
+        let file_path = temp_dir.join("output.json");
+        let symbols = vec![Symbol {
+            id: SymbolId(1),
+            name: "test".into(),
+            kind: SymbolKind::Function,
+            language: LangId::Python,
+            file_path: PathBuf::from("a.py"),
+            source_range: SourceRange {
+                byte_start: 0,
+                byte_end: 10,
+                start: LineColumn { line: 1, column: 0 },
+                end: LineColumn {
+                    line: 1,
+                    column: 10,
+                },
+            },
+            visibility: None,
+            signature: None,
+            docstring: None,
+            is_async: false,
+        }];
+        let config = EmitConfig {
+            output: Some(file_path.clone()),
+            format: OutputFormat::Json,
+            html: false,
+            open_browser: false,
+            self_contained: false,
+        };
+        emit_inspect(&symbols, &config).unwrap();
+        assert!(file_path.exists());
+        let content = std::fs::read_to_string(file_path).unwrap();
+        assert!(content.contains("test"));
+        let _ = std::fs::remove_dir_all(&temp_dir);
+    }
+
+    #[test]
+    fn emit_inspect_prints_to_stdout_when_no_path() {
+        let symbols = vec![Symbol {
+            id: SymbolId(1),
+            name: "test".into(),
+            kind: SymbolKind::Function,
+            language: LangId::Python,
+            file_path: PathBuf::from("a.py"),
+            source_range: SourceRange {
+                byte_start: 0,
+                byte_end: 10,
+                start: LineColumn { line: 1, column: 0 },
+                end: LineColumn {
+                    line: 1,
+                    column: 10,
+                },
+            },
+            visibility: None,
+            signature: None,
+            docstring: None,
+            is_async: false,
+        }];
+        let config = EmitConfig {
+            output: None,
+            format: OutputFormat::Json,
+            html: false,
+            open_browser: false,
+            self_contained: false,
+        };
+        emit_inspect(&symbols, &config).unwrap();
+    }
+
+    #[test]
+    fn emit_graph_html_writes_file() {
+        let temp_dir = std::env::temp_dir().join("emit_graph_html_writes_file");
+        if temp_dir.exists() {
+            let _ = std::fs::remove_dir_all(&temp_dir);
+        }
+        std::fs::create_dir_all(&temp_dir).unwrap();
+        let file_path = temp_dir.join("graph.html");
+
+        let builder = GraphBuilder::new(SnapshotId(1));
+        let graph = builder.build();
+        let scc = SccAnalysis::analyze(&graph.graph);
+        let analysis = GraphAnalysis {
+            graph,
+            scc,
+            snapshot_id: SnapshotId(1),
+        };
+
+        let config = EmitConfig {
+            output: Some(file_path.clone()),
+            format: OutputFormat::Json,
+            html: true,
+            open_browser: false,
+            self_contained: false,
+        };
+        emit_graph(&analysis, &config).unwrap();
+        assert!(file_path.exists());
+        let content = std::fs::read_to_string(file_path).unwrap();
+        assert!(content.contains("<!DOCTYPE html>"));
+        let _ = std::fs::remove_dir_all(&temp_dir);
+    }
+
+    #[test]
+    fn emit_graph_text_json_output() {
+        let temp_dir = std::env::temp_dir().join("emit_graph_text_json_output");
+        if temp_dir.exists() {
+            let _ = std::fs::remove_dir_all(&temp_dir);
+        }
+        std::fs::create_dir_all(&temp_dir).unwrap();
+        let file_path = temp_dir.join("graph.json");
+
+        let builder = GraphBuilder::new(SnapshotId(1));
+        let graph = builder.build();
+        let scc = SccAnalysis::analyze(&graph.graph);
+        let analysis = GraphAnalysis {
+            graph,
+            scc,
+            snapshot_id: SnapshotId(1),
+        };
+
+        let config = EmitConfig {
+            output: Some(file_path.clone()),
+            format: OutputFormat::Json,
+            html: false,
+            open_browser: false,
+            self_contained: false,
+        };
+        emit_graph(&analysis, &config).unwrap();
+        assert!(file_path.exists());
+        let content = std::fs::read_to_string(file_path).unwrap();
+        assert!(content.contains("nodes"));
+        let _ = std::fs::remove_dir_all(&temp_dir);
+    }
+}

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,4 +1,5 @@
 pub mod dashboard;
+pub mod emitter;
 pub mod graph;
 pub mod inspect;
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1,10 +1,9 @@
-use std::collections::HashMap;
 use std::path::Path;
 
 use crate::error::Diagnostic;
 use crate::graph::{CodeGraph, GraphBuilder, SccAnalysis};
 use crate::input;
-use crate::model::{FileId, SnapshotId};
+use crate::model::SnapshotId;
 
 /// Result of the full graph analysis pipeline.
 pub struct GraphAnalysis {
@@ -23,74 +22,15 @@ pub fn analyze_graph(
     snapshot_id: SnapshotId,
 ) -> anyhow::Result<(GraphAnalysis, Vec<Diagnostic>)> {
     let files = input::discover_files(root, None)?;
-
     let extraction = crate::extractor::extract(&files);
-
     let mut diagnostics: Vec<Diagnostic> = extraction
         .files
         .iter()
         .flat_map(|f| f.diagnostics.iter().cloned())
         .collect();
 
-    let mut builder = GraphBuilder::new(snapshot_id);
-    for (path, lang) in &files {
-        builder.add_file(path.clone(), *lang);
-    }
-
-    for file in &extraction.files {
-        for symbol in &file.symbols {
-            if let Err(e) = builder.add_symbol(symbol) {
-                diagnostics.push(Diagnostic {
-                    path: file.path.clone(),
-                    severity: crate::error::Severity::Warning,
-                    message: format!("failed to add symbol to graph: {e}"),
-                    source_range: None,
-                });
-            }
-        }
-    }
-
-    let mut path_to_file_id: HashMap<std::path::PathBuf, FileId> = HashMap::new();
-    for file in &extraction.files {
-        if let Some(fid) = builder.file_id_for_path(&file.path) {
-            path_to_file_id.insert(file.path.clone(), fid);
-        }
-    }
-
-    for file in &extraction.files {
-        let Some(&source_fid) = path_to_file_id.get(&file.path) else {
-            continue;
-        };
-        let source_dir = file.path.parent().unwrap_or(std::path::Path::new("."));
-        for import in &file.imports {
-            let resolver = file.lang.spec().import_path_resolver;
-            if let Some(target) = resolver(&import.namespace, source_dir, root) {
-                builder.add_import(source_fid, target);
-            }
-        }
-    }
-
-    let import_adjacency = builder.import_adjacency();
-    let ctx = crate::graph::resolver::ResolutionContext::from_extractions(
-        &extraction.files,
-        &path_to_file_id,
-        import_adjacency,
-    );
-    let scope_cache = crate::graph::resolver::FlattenedScopeCache::build(&ctx, &mut diagnostics);
-
-    let ref_edges = crate::graph::resolver::resolve_all_references(
-        &extraction.files,
-        &path_to_file_id,
-        &scope_cache,
-        &mut diagnostics,
-    );
-
-    for (from, to) in ref_edges {
-        builder.add_reference(from, to);
-    }
-
-    let graph = builder.build();
-    let scc = SccAnalysis::analyze(&graph.graph);
+    let (graph, scc) =
+        GraphBuilder::from_extractions(&extraction.files, root, snapshot_id, &mut diagnostics);
 
     Ok((
         GraphAnalysis {

--- a/tests/integration/pipeline_test.rs
+++ b/tests/integration/pipeline_test.rs
@@ -240,7 +240,7 @@ fn cross_file_reference_rust_crate() {
         for import in &file.imports {
             if let Some(dir) = file.path.parent() {
                 let resolver = file.lang.spec().import_path_resolver;
-                if let Some(target) = resolver(&import.namespace, dir, root) {
+                if let Some(target) = resolver(&import.import_specifier, dir, root) {
                     builder.add_import(source_fid, target);
                 }
             }
@@ -327,7 +327,7 @@ fn cross_file_reference_typescript() {
         for import in &file.imports {
             if let Some(dir) = file.path.parent() {
                 let resolver = file.lang.spec().import_path_resolver;
-                if let Some(target) = resolver(&import.namespace, dir, root) {
+                if let Some(target) = resolver(&import.import_specifier, dir, root) {
                     builder.add_import(source_fid, target);
                 }
             }
@@ -446,7 +446,7 @@ fn edge_circular_does_not_infinite_loop() {
         for import in &file.imports {
             if let Some(dir) = file.path.parent() {
                 let resolver = file.lang.spec().import_path_resolver;
-                if let Some(target) = resolver(&import.namespace, dir, root) {
+                if let Some(target) = resolver(&import.import_specifier, dir, root) {
                     builder.add_import(source_fid, target);
                 }
             }
@@ -528,7 +528,7 @@ fn edge_transitive_resolution() {
         for import in &file.imports {
             if let Some(dir) = file.path.parent() {
                 let resolver = file.lang.spec().import_path_resolver;
-                if let Some(target) = resolver(&import.namespace, dir, root) {
+                if let Some(target) = resolver(&import.import_specifier, dir, root) {
                     builder.add_import(source_fid, target);
                 }
             }
@@ -936,8 +936,8 @@ fn extract_python_multiline_import() {
     assert_eq!(result.files.len(), 1);
     let imports = &result.files[0].imports;
     assert_eq!(imports.len(), 2);
-    assert_eq!(imports[0].namespace, "foo");
-    assert_eq!(imports[1].namespace, "foo");
+    assert_eq!(imports[0].import_specifier, "foo");
+    assert_eq!(imports[1].import_specifier, "foo");
 
     std::fs::remove_dir_all(&tmp).unwrap();
 }
@@ -965,7 +965,7 @@ fn extract_js_multiline_import() {
         imports.len()
     );
     for imp in imports {
-        assert_eq!(imp.namespace, "'./module'");
+        assert_eq!(imp.import_specifier, "'./module'");
     }
 
     std::fs::remove_dir_all(&tmp).unwrap();
@@ -988,7 +988,7 @@ fn extract_rust_multiline_use() {
     let imports = &result.files[0].imports;
     assert!(!imports.is_empty(), "should have imports");
     for imp in imports {
-        assert_eq!(imp.namespace, "crate::utils");
+        assert_eq!(imp.import_specifier, "crate::utils");
     }
 
     std::fs::remove_dir_all(&tmp).unwrap();


### PR DESCRIPTION
This pull request introduces several significant improvements and refactorings to the codebase, focusing on enhancing import resolution flexibility, improving the graph builder pipeline, and updating the import model for clarity and consistency. The most important changes are summarized below.

**1. Import Resolution Architecture and Model Updates**

* Introduced a new stateful import resolution architecture using the `ImportResolver` trait, enabling language-specific, stateful logic (such as config-file parsing and disk caching) for resolving import paths. This is documented in detail in `docs/STRUCTURE.md` and referenced in the architecture doc. [[1]](diffhunk://#diff-70955eb31aecd71c3b2d02a4adefcb42bb5f0a98cc7a2dfc63af0eea8ce133b1L237-R268) [[2]](diffhunk://#diff-ff21b6b9a3a33e9d9056ac96882cc348d7077612b5931068f7459707b21eb3d1L17-R17)
* Added the `import_resolver` module to the language subsystem, and implemented a factory pattern to dynamically construct resolvers for each language.
* Updated the `UnresolvedImport` model: renamed the `namespace` field to `import_specifier` for clarity and consistency across the codebase.
* Refactored all usages, tests, and extraction logic to use the new `import_specifier` field instead of `namespace`. [[1]](diffhunk://#diff-6537bb9450bb06c97631e83e5114d59e93bb13dbf21887fb713e64b7efae8b6aL471-R471) [[2]](diffhunk://#diff-5a93ec4a89f6838655ba3ccaa203a67c4c84c878157d35d92131d00d31e6105bL208-R208) [[3]](diffhunk://#diff-5a93ec4a89f6838655ba3ccaa203a67c4c84c878157d35d92131d00d31e6105bL228-R228) [[4]](diffhunk://#diff-5a93ec4a89f6838655ba3ccaa203a67c4c84c878157d35d92131d00d31e6105bL244-R245) [[5]](diffhunk://#diff-f96f069fd1af5ec9ca2979221afe2ca37f844ea25720bce3389b2fa03fb75ba0L222-R222) [[6]](diffhunk://#diff-f96f069fd1af5ec9ca2979221afe2ca37f844ea25720bce3389b2fa03fb75ba0L241-R241) [[7]](diffhunk://#diff-f96f069fd1af5ec9ca2979221afe2ca37f844ea25720bce3389b2fa03fb75ba0L257-R257) [[8]](diffhunk://#diff-45f8c4bf3464c86c95d1f2c2cefb11a18cea50c6ae27740fb8b2a93d073477b0L233-R233) [[9]](diffhunk://#diff-45f8c4bf3464c86c95d1f2c2cefb11a18cea50c6ae27740fb8b2a93d073477b0L252-R252)

**2. Graph Builder Pipeline Improvements**

* Added a new `GraphBuilder::from_extractions` method that assembles a complete `CodeGraph` and SCC analysis from extraction results in a single, robust pipeline. This method handles file and symbol registration, import edge resolution using the new language-specific resolvers, cross-file reference resolution, and SCC computation, with improved error handling and diagnostics accumulation.
* Added comprehensive tests for the new pipeline, covering correct node counts, SCC analysis, diagnostic accumulation, and cross-file import resolution.

**3. Output Emission Refactoring**

* Refactored output emission in `main.rs` to use a unified `EmitConfig` and new `emitter` interface, simplifying logic for both inspect and graph/dashboard output modes, and improving maintainability. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL36-R44) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL58-R80)

**4. Documentation Enhancements**

* Expanded and clarified documentation in `docs/STRUCTURE.md` to describe the new stateful import resolution seam, caching strategies, and the process for adding new languages. Adjusted section numbering for clarity. [[1]](diffhunk://#diff-70955eb31aecd71c3b2d02a4adefcb42bb5f0a98cc7a2dfc63af0eea8ce133b1L237-R268) [[2]](diffhunk://#diff-70955eb31aecd71c3b2d02a4adefcb42bb5f0a98cc7a2dfc63af0eea8ce133b1L249-R280)

These changes collectively modernize the import resolution system, streamline the graph-building process, and improve both code clarity and extensibility for future language support.