### PR TITLE
docs: update documentation for metacall-deploy feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,9 +90,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bstr"
@@ -106,15 +106,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cast"
@@ -124,9 +124,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -316,9 +316,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -412,15 +412,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -551,12 +549,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -579,9 +571,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+checksum = "b915661dd01db3f05050265b2477bcc6527b3792388e2749b41623cc592be67d"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -601,15 +593,13 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
- "serde",
- "serde_core",
 ]
 
 [[package]]
 name = "insta"
-version = "1.47.2"
+version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+checksum = "86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82"
 dependencies = [
  "console",
  "once_cell",
@@ -690,13 +680,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -705,12 +694,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -738,9 +721,9 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "matchers"
@@ -753,9 +736,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "meta-ast"
@@ -925,16 +908,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -945,9 +918,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -980,9 +953,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1003,9 +976,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rustc_version"
@@ -1111,9 +1084,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "simd_cesu8"
@@ -1145,9 +1118,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "stable_deref_trait"
@@ -1190,9 +1163,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1430,12 +1403,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1476,28 +1443,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
-dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
-]
-
-[[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1508,9 +1457,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1518,9 +1467,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1531,52 +1480,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.98"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1645,100 +1560,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
-
-[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1759,9 +1580,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -1782,18 +1603,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/TODO.md
+++ b/TODO.md
@@ -1,20 +1,28 @@
 # TODO
 
 ## High
-- [ ] Handle All it's will work fine '.unwrap()' and '.expect()' in the codebase, and replace them with proper error handling.
-- [ ] Add more tests for edge cases and error scenarios, especially for malformed files and supported languages.
-- [ ] Implement a more robust error handling strategy across the codebase, especially in the graph builder and orchestrator, to ensure that errors are logged and handled gracefully without crashing the entire process.
+- [ ] Handle all `.unwrap()` and `.expect()` calls in the codebase and replace them with proper error handling.
+- [ ] Add more tests for edge cases and error scenarios, especially for malformed files and all supported languages.
+- [ ] Implement a more robust error handling strategy across the codebase, especially in the graph builder and orchestrator, to ensure errors are logged and handled gracefully without crashing the entire process.
+
 ## Medium
-- [ ] Better inline Documentation for Phase 1 code
-- [ ] Update inline Documentation of Phase 2 and representation PR code too
-- [ ] Add a README about the project goals and scope and Potential Use Cases with some benchmarking.
-- [ ] Better Path Normalization for Each Language to better handle externals and relative imports, and to improve cross-language reference resolution.
-- [ ] Language module deduplication and refactor the boilerplate code 'declarative macro usage'.
+- [ ] Better inline documentation for Phase 1 code.
+- [ ] Update inline documentation of Phase 2 and representation PR code.
+- [ ] Add a README about the project goals, scope, and potential use cases with benchmarking.
+- [ ] Better path normalization for each language to improve handling of externals and relative imports, and cross-language reference resolution.
+- [ ] Language module deduplication - refactor boilerplate code via declarative macros.
 - [ ] Merge Build and Test CI workflows into a single workflow with multiple jobs to reduce overhead and improve feedback loop.
+- [ ] Add `metacall-deploy` feature to `Cargo.toml` gating the deploy subcommand and all manifest generation logic.
+- [ ] Implement Cross-Language Call Site scanner: detect `metacall_load_from_file`, `metacall_load_from_memory`, `metacall_load_from_package`, `metacall_load_from_configuration` call sites across all language packs.
+- [ ] Deploy Manifest generator: emit one `metacall.{tag}.json` per detected language group and a root `metacall.json` composing them.
+- [ ] Mesh Annotation emitter: emit `metacall.mesh.json` from SCC Deployment Unit analysis, classifying independent Function Mesh candidates vs. co-deployment-required groups.
+- [ ] `meta-ast deploy --check`: diff generated manifests against existing `metacall.json` and report divergences as structured diagnostics.
+- [ ] Low-confidence annotation for unresolvable Cross-Language Call Site arguments (dynamic tag or path values).
+
 ## Low
-- [ ] Add more languages, starting with C#, and then expanding to Ruby, PHP,Java, and others based on demand but mainly we need C# and Java.
-- [ ] Micro-optimizations in the graph builder, especially around reference resolution and Resolver.
-- [ ] Orchestrator `main.rs` needs Micro-optimizations and better error handling, especially around file I/O and parallel processing.
+- [ ] Add more languages, starting with C# and Java, then Ruby, PHP, and others based on demand.
+- [ ] Micro-optimizations in the graph builder, especially around reference resolution and the resolver.
+- [ ] Orchestrator `main.rs` needs micro-optimizations and better error handling around file I/O and parallel processing.
 - [ ] Distribution bash scripts for easy install.
 - [ ] Improve CLI ergonomics with better flags, help messages, and error reporting.
-- [ ] A future improvement could merge queries (symbol + import + reference) , but the effort-to-reward ratio is low for now.
+- [ ] A future improvement could merge queries (symbol + import + reference), but the effort-to-reward ratio is low for now.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,12 +3,12 @@
 ## 1. Design goals
 
 - Standalone-first static analysis (no runtime execution).
-- Inspect-compatible contract.
 - Deterministic and resilient extraction under partial syntax errors.
 - Incremental-by-design workflow for watch/update scenarios.
+- Language-agnostic core; MetaCall deployment support is an opt-in feature.
 
 ## 2. High-level pipeline
- 
+
 1. Source discovery and language detection.
 2. Tree-sitter parse per file.
 3. Query-based symbol extraction per language pack.
@@ -16,8 +16,9 @@
 5. Dependency graph construction (initial node + file edges).
 6. Import path resolution via stateful resolvers implementing the `ImportResolver` trait (mapping import strings to file paths/IDs, supporting stateful configs like `tsconfig.json` and disk caches).
 7. Cross-file reference resolution via `FlattenedScopeCache` (DFS the import graph once per file, then O(1) scope lookups).
-8. SCC analysis (Tarjan) and deployability annotation.
+8. SCC analysis (Tarjan) and Deployment Unit annotation.
 9. Output emission (JSON, YAML, or interactive HTML dashboard).
+10. _(with `metacall-deploy` feature)_ Cross-Language Call Site detection, Deploy Manifest generation, and Mesh Annotation emission.
 
 ## 3. Component boundaries
 
@@ -28,14 +29,15 @@
 - **Graph layer:** directed graph assembly + SCC algorithms. External dependencies (stdlib, third-party packages) that are referenced but not part of the project are represented as `ExternalNode` entries (`graph/node.rs:83`), carrying the raw import path and language. They appear in the graph but have no file-backed symbol data.
 - **Pipeline layer:** full graph analysis orchestration (`pipeline.rs`).
 - **Resolver layer:** cross-file reference resolution via `FlattenedScopeCache` (`graph/resolver.rs`).
-- **Output layer:** inspect-compatible serialization and optional adapters.
+- **Output layer:** serialization and optional adapters.
 - **Interface layer:** CLI + library API (future: C ABI).
+- **Deploy layer** _(feature-gated: `metacall-deploy`)_: Cross-Language Call Site scanner, Deploy Manifest writer, Root Manifest assembler, Mesh Annotation emitter.
 
 Detailed module layout, data structures, and dependency direction are defined in `STRUCTURE.md`.
 
 ## 4. Data contracts (summary)
 
-Primary inspect-compatible entity groups:
+Primary symbol extraction output:
 
 - `funcs`
 - `classes`
@@ -46,12 +48,19 @@ Static extensions:
 - `source_range`
 - `docstring` (where available)
 
-Detailed graph contract is defined in `specs/graph-model.md`, including `language_id`, project-root-relative `path`, `snapshot_id`, `file_id`, `visibility`, and `DataNode` semantics.
+Deploy output _(feature-gated: `metacall-deploy`)_:
+
+- `metacall.{tag}.json` per detected language group (Deploy Manifest)
+- `metacall.json` root manifest (Root Manifest)
+- `metacall.mesh.json` (Mesh Annotation - SCC-derived Deployment Unit advisory)
+
+Detailed graph contract is defined in `specs/graph-model.md`.
 
 ## 5. Error handling model
 
 - Parse errors are recoverable when Tree-sitter yields partial trees.
 - Extraction errors are scoped to file/language unit where possible.
+- Unresolvable Cross-Language Call Sites (dynamic tag/path arguments) are annotated as low-confidence entries in the Mesh Annotation, not silently dropped.
 - Fatal process-level errors are reserved for invalid configuration or unrecoverable IO/system failures.
 
 ## 6. Incremental analysis model
@@ -69,10 +78,9 @@ The CLI supports JSON and YAML for programmatic consumption, plus an interactive
 - **JSON / YAML:** Controlled by the `--format` flag. JSON is the default. YAML requires no extra setup - just pass `--format yaml`.
 - **HTML dashboard:** Separate concern, activated with `--html`. Generates a single `.html` file with an embedded Cytoscape.js graph. The browser auto-opens unless you redirect. Use `--self-contained` (requires `embed-cytoscape` feature) to bundle the JS library directly for offline use.
 
-The dashboard turns SCC analysis into something you can actually see. Nodes in cyclic clusters are colored red. Independent units are green. Instead of reading JSON blobs, you click around, expand symbols, and see exactly where the cycles are. This is the difference between "your code has cycles" and "here, this is the knot you need to untangle."
+The dashboard turns SCC analysis into something you can actually see. Nodes in cyclic clusters (co-deployment required) are colored red. Independent Deployment Units are green. This is the difference between "your code has cycles" and "here is the exact knot you need to untangle before you can split this into independent mesh units."
 
 ## 8. Compatibility and integration
 
-- Output contract remains stable for MetaCall inspect-style consumers.
-- Optional integration layers (C ABI, Dgraph) are feature-scoped and do not block standalone operation.
+- Optional integration layers (C ABI, `metacall-deploy`, Dgraph) are feature-scoped and do not block standalone operation.
 - Discussion and contributions: [Discord](https://discord.gg/VvSZRsBK)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -18,7 +18,7 @@
 7. Cross-file reference resolution via `FlattenedScopeCache` (DFS the import graph once per file, then O(1) scope lookups).
 8. SCC analysis (Tarjan) and Deployment Unit annotation.
 9. Output emission (JSON, YAML, or interactive HTML dashboard).
-10. _(with `metacall-deploy` feature)_ Cross-Language Call Site detection, Deploy Manifest generation, and Mesh Annotation emission.
+10. _(Roadmap Phase 5, requires `metacall-deploy` feature)_ Cross-Language Call Site detection, Deploy Manifest generation, and Mesh Annotation emission.
 
 ## 3. Component boundaries
 
@@ -26,12 +26,12 @@
 - **Parser layer:** Tree-sitter parser lifecycle and tree ownership.
 - **Extractor layer:** language-specific query packs and capture mapping.
 - **Model layer:** normalized symbol/domain structs.
-- **Graph layer:** directed graph assembly + SCC algorithms. External dependencies (stdlib, third-party packages) that are referenced but not part of the project are represented as `ExternalNode` entries (`graph/node.rs:83`), carrying the raw import path and language. They appear in the graph but have no file-backed symbol data.
+- **Graph layer:** directed graph assembly + SCC algorithms. External dependencies (stdlib, third-party packages) that are referenced but not part of the project are represented as `ExternalNode` entries (`graph/node.rs:85`), carrying the raw import path and language. They appear in the graph but have no file-backed symbol data.
 - **Pipeline layer:** full graph analysis orchestration (`pipeline.rs`).
 - **Resolver layer:** cross-file reference resolution via `FlattenedScopeCache` (`graph/resolver.rs`).
 - **Output layer:** serialization and optional adapters.
 - **Interface layer:** CLI + library API (future: C ABI).
-- **Deploy layer** _(feature-gated: `metacall-deploy`)_: Cross-Language Call Site scanner, Deploy Manifest writer, Root Manifest assembler, Mesh Annotation emitter.
+- **Deploy layer** _(PLANNED - Roadmap Phase 5, feature-gated: `metacall-deploy`)_: Cross-Language Call Site scanner, Deploy Manifest writer, Root Manifest assembler, Mesh Annotation emitter. **Not yet implemented.**
 
 Detailed module layout, data structures, and dependency direction are defined in `STRUCTURE.md`.
 
@@ -48,11 +48,13 @@ Static extensions:
 - `source_range`
 - `docstring` (where available)
 
-Deploy output _(feature-gated: `metacall-deploy`)_:
+Deploy output _(PLANNED - Roadmap Phase 5, feature-gated: `metacall-deploy`)_:
 
 - `metacall.{tag}.json` per detected language group (Deploy Manifest)
 - `metacall.json` root manifest (Root Manifest)
 - `metacall.mesh.json` (Mesh Annotation - SCC-derived Deployment Unit advisory)
+
+**Note:** The `metacall-deploy` feature is not yet implemented. No code exists behind this feature gate.
 
 Detailed graph contract is defined in `specs/graph-model.md`.
 
@@ -63,11 +65,13 @@ Detailed graph contract is defined in `specs/graph-model.md`.
 - Unresolvable Cross-Language Call Sites (dynamic tag/path arguments) are annotated as low-confidence entries in the Mesh Annotation, not silently dropped.
 - Fatal process-level errors are reserved for invalid configuration or unrecoverable IO/system failures.
 
-## 6. Incremental analysis model
+## 6. Incremental analysis model _(PLANNED)_
 
 - Baseline mode: re-parse changed file and recompute impacted graph region.
 - Optimized mode: apply `InputEdit` + changed range reduction.
 - Optimization is benchmark-triggered and must not compromise correctness.
+
+**Current status:** Incremental parsing is not yet implemented. The pipeline currently runs full re-analysis on every invocation. This section describes the planned architecture for watch/update scenarios (Roadmap Phase 4 pending items).
 
 Parallel parse + extract uses rayon per-file; graph assembly is sequential. See `STRUCTURE.md` section 5 for pipeline phase details.
 
@@ -82,5 +86,5 @@ The dashboard turns SCC analysis into something you can actually see. Nodes in c
 
 ## 8. Compatibility and integration
 
-- Optional integration layers (C ABI, `metacall-deploy`, Dgraph) are feature-scoped and do not block standalone operation.
+- Optional integration layers (C ABI, `metacall-deploy`, Dgraph) are feature-scoped and do not block standalone operation. **Note:** C ABI and `metacall-deploy` are planned but not yet implemented.
 - Discussion and contributions: [Discord](https://discord.gg/VvSZRsBK)

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -80,7 +80,9 @@ https://lefthook.dev/install/
 
 lefthook install
 ```
+
 a dev script will be provided later to automate this process
+
 ### pre-commit (parallel, fast)
 
 1. `cargo fmt --all -- --check` - formatting gate.

--- a/docs/DEV_CRATE_DECISIONS.md
+++ b/docs/DEV_CRATE_DECISIONS.md
@@ -69,7 +69,6 @@
 - `tracing`, `tracing-subscriber` - structured observability.
 - `cbindgen` - C ABI header generation when ABI phase begins.
 
-
 ## 6. Alternatives and trade-offs
 
 - Graph: custom adjacency maps can be faster but increase maintenance cost.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,25 +1,30 @@
 # meta-ast Documentation
 
-This directory contains the implementation-facing technical documentation for `meta-ast`.
+This directory contains the implementation-facing technical documentation for
+`meta-ast`.
 
-Later we will have an MDBOOK-style user guide in `docs/user-guide` but this section is focused on design and implementation artifacts for traceability and onboarding.
-
-The structure is intentionally traceable: proposal → specs → architecture → structure → ADRs → roadmap → validation artifacts so this bureaucratized manner is easier to debug and trace.
+The structure is intentionally traceable: specs -> architecture -> structure ->
+ADRs -> roadmap -> validation artifacts, so design decisions are easy to trace
+back to requirements and forward to tests.
 
 ## Document map
 
-- `ARCHITECTURE.md` - system architecture, component boundaries, runtime flow, output formats, and dashboard visualization.
-- `structure.md` - code structure, data structures, design patterns, module layout, and implementation order.
+- `ARCHITECTURE.md` - system architecture, component boundaries, runtime flow,
+  output formats, and the `metacall-deploy` feature layer.
+- `STRUCTURE.md` - code structure, data structures, design patterns, module layout,
+  and implementation order.
 - `DEV_CRATE_DECISIONS.md` - crate selection rationale and trade-offs.
 - `CI_CD.md` - CI/CD architecture and quality gates.
-- `ROADMAP.md` - phase-aligned implementation milestones and measurable gates.
+- `ROADMAP.md` - phase-aligned implementation milestones and measurable exit gates.
 
 ## Specs
 
 - `specs/requirements.md` - normative requirements and acceptance criteria.
-- `specs/graph-model.md` - symbol graph and datagraph contracts, including `language_id`, project-root-relative `path`, `snapshot_id`, `file_id`, `visibility`, and `DataNode` semantics.
+- `specs/graph-model.md` - symbol graph and datagraph contracts, including
+  `language_id`, project-root-relative `path`, `snapshot_id`, `file_id`,
+  `visibility`, and `DataNode` semantics.
 - `specs/symbol-extraction.md` - language-pack extraction contracts.
-- `specs/traceability.md` - mapping from proposal deliverables to implementation/docs/tests.
+- `specs/traceability.md` - mapping from deliverables to implementation/docs/tests.
 
 ## Architecture decisions (ADRs)
 
@@ -35,9 +40,15 @@ The structure is intentionally traceable: proposal → specs → architecture �
 
 ## Scope policy
 
-- **MVP (must ship):** symbol extraction, inspect-compatible JSON, dependency graph + SCC, cross-platform CI.
-- **Stretch:** intra-procedural dataflow beyond simple def-use, live Dgraph sink, advanced cross-language type matching.
+- **MVP (must ship):** symbol extraction, dependency graph + SCC/Deployment Unit
+  analysis, cross-platform CI.
+- **`metacall-deploy` feature:** Cross-Language Call Site detection, Deploy Manifest
+  generation, Root Manifest assembly, Mesh Annotation from SCC.
+- **Stretch:** intra-procedural dataflow beyond simple def-use, live Dgraph sink,
+  advanced cross-language type matching, expanded language support.
 
 ## Update policy
 
-When implementation changes any public contract (schema, CLI behavior, graph semantics, language support), update the corresponding file in this directory in the same pull request.
+When implementation changes any public contract (schema, CLI behavior, graph
+semantics, language support), update the corresponding file in this directory in
+the same pull request.

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,17 +26,24 @@ back to requirements and forward to tests.
 - `specs/symbol-extraction.md` - language-pack extraction contracts.
 - `specs/traceability.md` - mapping from deliverables to implementation/docs/tests.
 
-## Architecture decisions (ADRs)
+## Architecture Decision Records (ADRs)
 
-- `rfcs/0001-language-loading-model.md`
-- `rfcs/0002-error-semantics-and-recovery.md`
-- `rfcs/0003-incremental-parsing-strategy.md`
-- `rfcs/0004-graph-representation-and-scc.md`
-- `rfcs/0005-output-contract-policy.md`
-- `rfcs/0006-type-inference-scope.md`
-- `rfcs/0007-dgraph-integration-scope.md`
-- `rfcs/0008-graph-module.md`
-- `rfcs/0009-cross-file-dependency-mapping.md`
+- `adr/0001-stateful-import-resolver.md` - Stateful import resolver trait seam
+- `adr/0002-scope-resolution-heuristics.md` - Scope resolution heuristics
+- `adr/0003-unresolved-import-policy.md` - Unresolved import handling policy
+- `adr/0004-global-scope-synthetic-symbols.md` - Global scope synthetic symbol generation
+
+## Requests for Comments (RFCs)
+
+- `rfcs/0001-language-loading-model.md` - Language loading model
+- `rfcs/0002-error-semantics-and-recovery.md` - Error semantics and recovery
+- `rfcs/0003-incremental-parsing-strategy.md` - Incremental parsing strategy
+- `rfcs/0004-graph-representation-and-scc.md` - Graph representation and SCC
+- `rfcs/0005-output-contract-policy.md` - Output contract policy
+- `rfcs/0006-type-inference-scope.md` - Type inference scope
+- `rfcs/0007-dgraph-integration-scope.md` - Dgraph integration scope
+- `rfcs/0008-graph-module.md` - Graph module design
+- `rfcs/0009-cross-file-dependency-mapping.md` - Cross-file dependency mapping
 
 ## Scope policy
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -41,7 +41,7 @@ Exit gates:
 1. Export format validated.
 2. Snapshot/version semantics documented and tested.
 
-## Phase 4 - CLI polish, output formats, visualization [NOT STARTED]
+## Phase 4 - CLI polish, output formats, visualization [IN PROGRESS]
 
 Goals:
 
@@ -53,13 +53,13 @@ Goals:
 
 Exit gates:
 
-1. `--format json|yaml` works for analysis output.
-2. `--html` generates a self-contained dashboard with SCC/Deployment Unit coloring,
-   auto-opens in browser.
-3. `--self-contained` embeds Cytoscape.js offline (requires `embed-cytoscape` feature).
-4. Watch-mode stability tests pass.
-5. C ABI smoke tests pass.
-6. Incremental performance target evidence captured.
+1. ~~`--format json|yaml` works for analysis output.~~ DONE
+2. ~~`--html` generates a self-contained dashboard with SCC/Deployment Unit coloring,
+   auto-opens in browser.~~ DONE
+3. ~~`--self-contained` embeds Cytoscape.js offline (requires `embed-cytoscape` feature).~~ DONE
+4. Watch-mode stability tests pass. NOT YET STARTED
+5. C ABI smoke tests pass. NOT YET STARTED
+6. Incremental performance target evidence captured. NOT YET STARTED
 
 ## Phase 5 - MetaCall Deploy Manifests [NOT STARTED]
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,9 +4,10 @@
 
 Goals:
 
-- Parser lifecycle implementation for all 8 languages: Python, JavaScript, TypeScript, TSX, C, C++, Rust, Go.
+- Parser lifecycle implementation for all initial languages: Python, JavaScript,
+  TypeScript, TSX, C, C++, Rust, Go.
 - Symbol extraction and normalized IR.
-- Inspect-compatible JSON output (`funcs`, `classes`, `objects`).
+- Structured JSON/YAML output (`funcs`, `classes`, `objects`).
 
 Exit gates:
 
@@ -19,13 +20,14 @@ Exit gates:
 Goals:
 
 - Build directed dependency/reference graph.
-- Compute SCCs and annotate deployability hints.
+- Compute SCCs and annotate Deployment Units (independent vs. co-deployment required).
 
 Exit gates:
 
 1. SCC results match fixture expectations.
 2. Cross-file dependency mapping validated on mixed-language samples.
-3. ReferenceEdges appear in graph output with confidence scores in cross-file resolution tests.
+3. ReferenceEdges appear in graph output with confidence scores in cross-file
+   resolution tests.
 
 ## Phase 3 - Datagraph & optional sink [NOT STARTED]
 
@@ -51,14 +53,59 @@ Goals:
 
 Exit gates:
 
-1. `--format json|yaml` works for both inspect and graph subcommands.
-2. `--html` generates a self-contained dashboard with SCC coloring, auto-opens in browser.
+1. `--format json|yaml` works for analysis output.
+2. `--html` generates a self-contained dashboard with SCC/Deployment Unit coloring,
+   auto-opens in browser.
 3. `--self-contained` embeds Cytoscape.js offline (requires `embed-cytoscape` feature).
 4. Watch-mode stability tests pass.
 5. C ABI smoke tests pass.
 6. Incremental performance target evidence captured.
 
-## Phase 5 - Validation and delivery [NOT STARTED]
+## Phase 5 - MetaCall Deploy Manifests [NOT STARTED]
+
+_Requires `--features metacall-deploy`._
+
+Goals:
+
+- Implement Cross-Language Call Site detection across all supported language ports
+  (`metacall_load_from_file`, `metacall_load_from_memory`, `metacall_load_from_package`,
+  `metacall_load_from_configuration`).
+- Generate per-language Deploy Manifests (`metacall.{tag}.json`) and Root Manifest
+  (`metacall.json`).
+- Emit Mesh Annotation (`metacall.mesh.json`) from SCC Deployment Unit analysis,
+  classifying independent Function Mesh candidates vs. co-deployment-required groups.
+- Implement `--check` validation mode: diff generated manifests against any existing
+  `metacall.json` in the project tree.
+- Inline `metacall_load_from_configuration` targets when present; annotate as
+  low-confidence when target is absent from the analyzed tree.
+
+Exit gates:
+
+1. Deploy Manifests generated match expected fixtures for all projects in
+   `assets/examples/`.
+2. Mesh Annotation correctly classifies Deployment Units for `auth-function-mesh`
+   fixture (two independent units: `{encrypt, sign}` and `{decrypt, verify}`).
+3. `--check` detects manifest/source divergence and reports it as a structured
+   diagnostic.
+4. Dynamic call site arguments (non-literal tag or path) emit low-confidence
+   annotation rather than a hard failure.
+
+## Phase 6 - Language expansion [NOT STARTED]
+
+Goals:
+
+- Extend language support beyond the initial 8, prioritizing C# and Java.
+- Each new language requires: grammar crate, query pack (symbols + imports +
+  references), import resolver, visibility rules, and fixture tests.
+- Cross-language Call Site detection extended to new language ports as they ship.
+
+Exit gates:
+
+1. C# and Java parse on fixtures.
+2. All new language packs pass extraction and cross-file dependency tests.
+3. `metacall-deploy` feature detects call sites in new port bindings.
+
+## Phase 7 - Validation and delivery [NOT STARTED]
 
 Goals:
 
@@ -76,5 +123,8 @@ Exit gates:
 
 ## Scope boundaries
 
-- MVP priority: correctness, parity output, graph/SCC, portability.
-- Stretch priority: cross-Language Support,more depth,deep dataflow, live sink integration, advanced resolution heuristics.
+- MVP priority: correctness, symbol extraction, graph/SCC, portability.
+- `metacall-deploy` priority: Cross-Language Call Site detection, Deploy Manifest
+  generation, Mesh Annotation from SCC analysis.
+- Stretch priority: more languages, deeper dataflow, live sink integration, advanced
+  resolution heuristics.

--- a/docs/STRUCTURE.md
+++ b/docs/STRUCTURE.md
@@ -20,7 +20,7 @@ src/
 │
 ├── language/
 │   ├── mod.rs                LangId enum, LanguageSpec struct, DefaultVisibility, DocCommentConfig
-│   ├── common.rs             extract_with_spec, associate_docstrings, resolve_import_path_from_symbol_node
+│   ├── common.rs             extract_with_spec, extract_imports_and_references_with_spec, associate_docstrings
 │   ├── python.rs             Python queries + extraction
 │   ├── javascript.rs         JavaScript queries + extraction
 │   ├── typescript.rs         TypeScript queries + extraction
@@ -28,7 +28,8 @@ src/
 │   ├── c.rs                  C queries + extraction
 │   ├── cpp.rs                C++ queries + extraction
 │   ├── rust.rs               Rust queries + extraction
-│   └── go.rs                 Go queries + extraction
+│   ├── go.rs                 Go queries + extraction
+│   └── import_resolver.rs    ImportResolver trait, stateful resolvers (Python, Go, JS, TS)
 │
 ├── input/
 │   └── mod.rs                File discovery, filtering, language routing
@@ -43,12 +44,13 @@ src/
 │   ├── mod.rs                DiGraph construction, node/edge types, re-exports
 │   ├── node.rs               NodeData enum (File / Symbol / External)
 │   ├── edge.rs               EdgeKind enum (Ownership / Import / Reference) with confidence
-│   ├── builder.rs            GraphBuilder, EdgeNormalizer, import_adjacency, external_index
+│   ├── builder.rs            GraphBuilder, from_extractions, import_adjacency, external_index
 │   ├── scc.rs                Tarjan SCC + DeployabilityHint
 │   └── resolver.rs           FlattenedScopeCache, ResolutionContext, resolve_all_references
 │
 ├── output/
 │   ├── mod.rs                OutputFormat enum (Json / Yaml) with serialize dispatch
+│   ├── emitter.rs            EmitConfig, emit_inspect(), emit_graph() - CLI output dispatch
 │   ├── inspect.rs            Inspect-compatible JSON/YAML emission
 │   ├── graph.rs              GraphOutput + SCC serialization (metadata, nodes, edges, sccs)
 │   └── dashboard.rs          Interactive HTML dashboard (Cytoscape.js, --html, --self-contained)
@@ -157,17 +159,18 @@ Node and edge types:
 
 | Node | Fields |
 |------|--------|
-| `FileNode` | id, path (project-root-relative), language_id, snapshot_id |
+| `FileNode` | id, path (project-root-relative), language, snapshot_id |
 | `SymbolNode` | id, name, kind, file_id, visibility, source_range |
 | `ExternalNode` | raw_path, language |
 
 | Edge | Direction |
 |------|-----------|
-| `OwnershipEdge` | FileNode -> SymbolNode, SymbolNode -> SymbolNode (nesting) |
-| `ImportEdge` | FileNode -> FileNode |
-| `ReferenceEdge` | SymbolNode -> SymbolNode |
+| `Ownership` | FileNode -> SymbolNode, SymbolNode -> SymbolNode (nesting) |
+| `Import` | FileNode -> FileNode |
+| `Reference` | SymbolNode -> SymbolNode |
 
 Graph invariants:
+
 1. Every SymbolNode maps to exactly one FileNode.
 2. Ownership edges form an acyclic containment structure.
 3. SCC applies to dependency/reference subgraph only (Ownership excluded).
@@ -186,7 +189,7 @@ pub struct InspectOutput {
 }
 ```
 
-Each entry type includes: `name`, `source_range`, optional `signature`, `visibility`, `docstring`, `async` flag.
+Each entry type includes: `name`, `source_range`, optional `signature`, `visibility`, `docstring`. `FuncEntry` additionally includes an `async` flag.
 
 ---
 
@@ -250,6 +253,7 @@ pub trait ImportResolver: Send + Sync {
 ```
 
 #### Hybrid Resolution Bridge
+
 1. **`LanguageSpec`** remains static and `const` (containing a stateless `import_path_resolver` fn pointer).
 2. **`ImportResolver`** represents a stateful trait interface.
 3. Concrete adapters bridge the two:
@@ -258,7 +262,9 @@ pub trait ImportResolver: Send + Sync {
 4. **`make_resolver(LangId) -> Box<dyn ImportResolver>`**: Factory function constructing the stateful resolver for each language dynamically.
 
 #### Stateful Caching and Memoization Engines
+
 To guarantee maximum throughput and avoid redundant filesystem traversal during large-scale workspace parsing, the stateful resolvers employ optimized, thread-safe caching strategies:
+
 - **`OnceLock` Module Boundary Scanning (`GoModResolver`)**: Scans for the root `go.mod` file and parses the module path at most once per execution using a standard `OnceLock`. Subsequent resolution calls query the in-memory boundary in $O(1)$ time.
 - **`RwLock` File Existence Memoization (`PythonResolver`, `JsResolver`, `TsConfigResolver`)**: Memoizes `exists()` and `is_file()` filesystem checks using an `RwLock<HashMap<PathBuf, bool>>`. This minimizes expensive system calls during TypeScript candidate extensions resolution (e.g. trying `.ts`, `.tsx`, `.js`) and Python relative path matching, while remaining safe for concurrency.
 - **Stateless Fallback**: When candidate paths do not match or cannot be resolved using stateful logic, all resolvers gracefully fallback to their underlying stateless `LanguageSpec` function pointer, ensuring 100% backward compatibility.
@@ -482,44 +488,44 @@ tests/
     │   ├── simple_functions.py
     │   ├── classes.py
     │   ├── async_decorators.py
-    │   ├── imports.py
+    │   ├── deep_nesting.py
     │   ├── partial_syntax_error.py
-    │   └── expected/
-    │       └── *.snap.json          Insta snapshot files
+    │   └── sample.py
     ├── javascript/
     │   ├── functions.js
-    │   ├── arrow_functions.js
     │   ├── classes.js
-    │   ├── imports_exports.js
-    │   └── expected/
+    │   └── large_classes.js
     ├── typescript/
-    │   ├── interfaces.ts
-    │   ├── enums_ts.ts
-    │   ├── type_aliases.ts
-    │   └── expected/
+    │   └── interfaces.ts
     ├── tsx/
-    │   ├── components.tsx
-    │   └── expected/
+    │   └── components.tsx
     ├── c/
     │   ├── functions.c
-    │   ├── structs_enums.c
-    │   └── expected/
+    │   └── structs_enums.c
     ├── cpp/
     │   ├── classes.cpp
-    │   ├── namespaces.cpp
-    │   ├── templates.cpp
-    │   └── expected/
+    │   └── namespaces.cpp
     ├── rust/
     │   ├── functions.rs
     │   ├── structs_enums.rs
-    │   ├── traits_impls.rs
-    │   └── expected/
-    └── go/
-        ├── functions.go
-        ├── methods.go
-        ├── interfaces.go
-        └── expected/
+    │   └── large_file.rs
+    ├── go/
+    │   ├── functions.go
+    │   ├── methods.go
+    │   └── deep_nesting.go
+    ├── mixed/                      Multi-language single-directory fixtures
+    │   ├── app.py, index.js, main.rs, test.generated.py
+    └── multi/                      Multi-file cross-language fixtures
+        ├── main.py, lib.py, app.js, util.js
+        ├── c_app/, cpp_app/, go_app/, rust_crate/, ts_app/, tsx_app/
+        └── edge_*/                 Edge case fixtures (circular, alias, shadowing, etc.)
 ```
+
+### Snapshot policy
+
+Insta snapshot files live in `src/language/snapshots/` as `.snap` files (not under fixture directories). Each
+language module generates snapshots via inline unit tests. Update workflow: `cargo insta test` then
+`cargo insta review` then commit accepted `.snap` files.
 
 ### Testing Strategy
 
@@ -527,7 +533,7 @@ tests/
 |-------|------|---------|
 | Language detection | Unit tests | Extension-to-LangId mapping |
 | Per-language extraction | Fixture files + unit tests | Query correctness, capture mapping |
-| JSON output contract | `insta` snapshots | Regression detection |
+| JSON output contract | `insta` snapshots in `src/language/snapshots/` | Regression detection |
 | Error recovery | Fixture with invalid syntax | Partial results, no panics |
 | End-to-end pipeline | Integration tests | Full discover -> output flow |
 | Performance | `criterion` benchmarks | Extraction throughput |

--- a/docs/specs/requirements.md
+++ b/docs/specs/requirements.md
@@ -2,13 +2,16 @@
 
 ## 1. Purpose
 
-Define normative requirements for `meta-ast`, a standalone Rust static analyzer for polyglot projects with `metacall_inspect`-compatible output.
+Define normative requirements for `meta-ast`, a standalone Rust static analyzer for
+polyglot source trees. The tool extracts symbol surfaces, builds cross-file dependency
+graphs, and computes SCCs. MetaCall FaaS deployment manifest generation is an
+optional capability behind the `metacall-deploy` feature flag.
 
 ## 2. Functional requirements
 
 ### FR-1: Parsing and language support
 
-The analyzer shall parse source files for:
+The analyzer shall parse source files for a growing set of languages, starting with:
 
 - Python
 - JavaScript
@@ -18,25 +21,18 @@ The analyzer shall parse source files for:
 - Rust
 - Go
 
+Additional languages (C#, Java, and others) are planned in later phases.
+
 ### FR-2: Symbol extraction
 
-The analyzer shall extract top-level symbols and language-appropriate nested symbols into a normalized intermediate representation:
+The analyzer shall extract top-level symbols and language-appropriate nested symbols
+into a normalized intermediate representation:
 
 - Functions
 - Classes / structs / interfaces / traits
 - Objects (constants, globals, module-level bindings)
 
-### FR-3: Inspect parity output
-
-The primary JSON output contract shall include keys:
-
-- `funcs`
-- `classes`
-- `objects`
-
-These keys must remain stable and compatible with MetaCall inspect-style consumers.
-
-### FR-4: Dependency graph
+### FR-3: Dependency graph
 
 The analyzer shall construct a directed graph of symbol-level dependencies:
 
@@ -44,38 +40,70 @@ The analyzer shall construct a directed graph of symbol-level dependencies:
 - Intra-project symbol references
 - Cross-language reference candidates
 
-### FR-5: SCC and deployability insight
+### FR-4: SCC and Deployment Unit identification
 
-The analyzer shall compute strongly connected components (Tarjan) and provide cluster-level deployability insight.
+The analyzer shall compute Strongly Connected Components (Tarjan) and annotate each
+SCC as a Deployment Unit, classifying it as:
 
-### FR-6: Incremental updates
+- Independent (acyclic, Function Mesh separation candidate)
+- Co-deployment required (cyclic, must remain grouped)
 
-The analyzer shall support update workflows from file changes with a target incremental response of under 100ms for files below 5k LOC.
+### FR-5: Incremental updates
 
-### FR-7: CLI and library modes
+The analyzer shall support update workflows from file changes with a target incremental
+response of under 100ms for files below 5k LOC.
+
+### FR-6: CLI and library modes
 
 The project shall expose:
 
 - Rust library interface
-- CLI entrypoint for project analysis and JSON emission
+- CLI entrypoint for project analysis and output emission
 
-### FR-8: C ABI (planned later phase)
+### FR-7: C ABI (planned later phase)
 
 The project shall provide a stable C ABI header (`mc_ast.h`) for embedding scenarios.
 
-### FR-9: datagraph export
+### FR-8: Datagraph export
 
-The project may export a datagraph model suitable for external graph sinks (including Dgraph).
+The project may export a datagraph model suitable for external graph sinks
+(including Dgraph).
+
+### FR-9: Deploy Manifest generation (feature-gated: `metacall-deploy`)
+
+When built with `--features metacall-deploy`, the `deploy` subcommand shall:
+
+- Scan source files for Cross-Language Call Sites
+  (`metacall_load_from_file`, `metacall_load_from_memory`,
+  `metacall_load_from_package`, `metacall_load_from_configuration`)
+- Extract `(language_tag, script_paths[])` pairs from call site arguments
+- Generate one Deploy Manifest (`metacall.{tag}.json`) per detected language group
+- Generate a Root Manifest (`metacall.json`) referencing all per-language manifests
+- Inline referenced `metacall_load_from_configuration` targets when present in tree;
+  emit a low-confidence annotation when the target is absent
+- Validate an existing `metacall.json` against static analysis when `--check` is passed
+
+### FR-10: Mesh Annotation (feature-gated: `metacall-deploy`)
+
+When built with `--features metacall-deploy`, the `deploy` subcommand shall also emit
+`metacall.mesh.json` containing:
+
+- SCC-derived Deployment Units with constituent symbol lists
+- Cross-language boundary flags per unit
+- Independent mesh candidate classification per unit
 
 ## 3. Non-functional requirements
 
 ### NFR-1: Correctness
 
-Incorrect symbol labeling is a high-severity defect. Correctness takes priority over throughput.
+Incorrect symbol labeling is a high-severity defect. Correctness takes priority over
+throughput.
 
 ### NFR-2: Resilience
 
-Malformed source files shall not crash analysis. Partial extraction shall be allowed when parser recovery is possible.
+Malformed source files shall not crash analysis. Partial extraction shall be allowed
+when parser recovery is possible. Unresolvable Cross-Language Call Site arguments
+(dynamic values) shall be annotated, not silently discarded.
 
 ### NFR-3: Portability
 
@@ -87,21 +115,26 @@ Given identical input set and tool version, emitted output shall be deterministi
 
 ### NFR-5: Observability
 
-The implementation shall provide structured diagnostics suitable for CI and local debugging.
+The implementation shall provide structured diagnostics suitable for CI and local
+debugging.
 
 ## 4. Acceptance criteria
 
-1. Parse all MVP languages and emit valid symbol JSON.
+1. Parse all supported languages and emit valid symbol JSON.
 2. Correct SCC identification for multi-language project fixtures.
-3. Output parity for keys `funcs`, `classes`, `objects`.
-4. Incremental-update target under 100ms for <5k LOC files.
-5. CI pipeline green on Linux/macOS/Windows.
+3. Incremental-update target under 100ms for files below 5k LOC.
+4. CI pipeline green on Linux/macOS/Windows.
+5. _(with `metacall-deploy`)_ Deploy Manifests generated match expected fixtures for
+   all example projects in `assets/examples/`.
+6. _(with `metacall-deploy`)_ Mesh Annotation correctly classifies Deployment Units
+   for the `auth-function-mesh` fixture.
 
 ## 5. Out-of-scope for MVP
 
 - Full inter-procedural global dataflow with alias analysis.
 - Sound cross-language type inference.
 - Mandatory online graph database dependency.
+- Dynamic Cross-Language Call Site resolution (runtime tag/path values).
 
 ## 6. Versioning policy
 

--- a/docs/specs/symbol-extraction.md
+++ b/docs/specs/symbol-extraction.md
@@ -3,13 +3,14 @@
 ## 1. Purpose
 
 Define language-pack extraction contracts backed by Tree-sitter grammar queries.
+Each language pack covers symbols, imports, and references. The set of supported
+languages grows over time; see `ROADMAP.md` Phase 6 for the expansion plan.
 
 ## 2. Shared extraction rules
 
 - Prefer grammar field-based extraction where available.
 - Record both byte and line/column ranges.
 - Continue extraction in presence of parser recovery nodes when safe.
-- `Python` , `JS/TS` are prefered at the start of every iteration
 
 ## 3. Language packs
 

--- a/docs/specs/traceability.md
+++ b/docs/specs/traceability.md
@@ -2,24 +2,29 @@
 
 ## Deliverables to docs mapping
 
-| Proposal deliverable | Documentation source | Validation target |
+| Deliverable | Documentation source | Validation target |
 |---|---|---|
 | Rust lib + CLI | `ARCHITECTURE.md`, `ROADMAP.md` | build/test/CLI fixture checks |
 | Language packs | `specs/symbol-extraction.md` | language fixture + snapshot tests |
+| Dependency graph + SCC | `specs/graph-model.md`, ADR-0004, ADR-0008, ADR-0009 | graph fixture SCC assertions |
+| Deployment Unit annotation | `CONTEXT.md`, `specs/graph-model.md` | SCC classification fixture tests |
 | Dataflow (stretch) | `specs/graph-model.md`, ADR-0007 | optional feature tests |
 | Stable C ABI | ADR-0005 + `ROADMAP.md` | C ABI smoke tests |
 | Dgraph sink | ADR-0007 + `specs/graph-model.md` | export contract validation |
-| Inspect parity | `specs/requirements.md`, ADR-0005 | JSON schema/snapshot tests |
+| Deploy Manifests (`metacall-deploy`) | `specs/requirements.md` FR-9 | fixture manifest comparison tests |
+| Mesh Annotation (`metacall-deploy`) | `specs/requirements.md` FR-10 | SCC unit classification tests |
 
 ## Acceptance criteria mapping
 
 | Acceptance criterion | Spec source | Verification plan |
 |---|---|---|
-| Parse all MVP languages | `specs/requirements.md` FR-1 | per-language fixture parsing tests |
+| Parse all supported languages | `specs/requirements.md` FR-1 | per-language fixture parsing tests |
 | Correct SCC identification | `specs/graph-model.md` | graph fixture SCC assertions |
-| Keys parity (`funcs`,`classes`,`objects`) | `specs/requirements.md` FR-3 | output contract tests |
+| Deployment Unit classification | `specs/requirements.md` FR-4 | independent vs. co-deploy fixture assertions |
 | Incremental update target | `ARCHITECTURE.md` + ADR-0003 | benchmark harness and thresholds |
 | Linux/macOS/Windows portability | `CI_CD.md` | CI matrix status |
+| Deploy Manifest fixture match | `specs/requirements.md` FR-9 | `assets/examples/` manifest comparison |
+| Mesh Annotation correctness | `specs/requirements.md` FR-10 | `auth-function-mesh` unit classification |
 
 ## Decision traceability
 
@@ -32,3 +37,5 @@
 | Output contract policy | `rfcs/0005-output-contract-policy.md` |
 | Type inference scope | `rfcs/0006-type-inference-scope.md` |
 | Dgraph scope | `rfcs/0007-dgraph-integration-scope.md` |
+| Graph module design | `rfcs/0008-graph-module.md` |
+| Cross-file dependency mapping | `rfcs/0009-cross-file-dependency-mapping.md` |

--- a/docs/specs/traceability.md
+++ b/docs/specs/traceability.md
@@ -6,8 +6,8 @@
 |---|---|---|
 | Rust lib + CLI | `ARCHITECTURE.md`, `ROADMAP.md` | build/test/CLI fixture checks |
 | Language packs | `specs/symbol-extraction.md` | language fixture + snapshot tests |
-| Dependency graph + SCC | `specs/graph-model.md`, ADR-0004, ADR-0008, ADR-0009 | graph fixture SCC assertions |
-| Deployment Unit annotation | `CONTEXT.md`, `specs/graph-model.md` | SCC classification fixture tests |
+| Dependency graph + SCC | `specs/graph-model.md`, RFC-0004, RFC-0008, RFC-0009 | graph fixture SCC assertions |
+| Deployment Unit annotation | `specs/graph-model.md`, ADR-0004 | SCC classification fixture tests |
 | Dataflow (stretch) | `specs/graph-model.md`, ADR-0007 | optional feature tests |
 | Stable C ABI | ADR-0005 + `ROADMAP.md` | C ABI smoke tests |
 | Dgraph sink | ADR-0007 + `specs/graph-model.md` | export contract validation |

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -19,7 +19,7 @@
 //!
 //! ```
 //! use meta_ast::graph::{GraphBuilder, SccAnalysis, CodeGraph};
-//! use meta_ast::model::{SnapshotId, Symbol};
+//! use meta_ast::model::SnapshotId;
 //!
 //! // Create builder and add files/symbols
 //! let mut builder = GraphBuilder::new(SnapshotId(1));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,10 @@ pub use graph::{
     CodeGraph,
     builder::GraphBuilder,
     edge::{EdgeData, EdgeKind},
-    node::{FileNode, NodeData, SymbolNode},
+    node::{ExternalNode, FileNode, NodeData, SymbolNode},
+    resolver::FlattenedScopeCache,
     scc::{DeployabilityHint, Scc, SccAnalysis},
 };
+
+// Pipeline re-exports
+pub use pipeline::GraphAnalysis;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -15,12 +15,6 @@ thread_local! {
     static PARSERS: RefCell<[Option<Parser>; LangId::COUNT]> = const { RefCell::new([const { None }; LangId::COUNT]) };
 }
 
-#[allow(dead_code)]
-pub(crate) struct ParsedFile {
-    pub tree: tree_sitter::Tree,
-    pub source: Vec<u8>,
-}
-
 fn get_or_init_parser(
     parsers: &mut [Option<Parser>; LangId::COUNT],
     lang: LangId,
@@ -47,15 +41,6 @@ pub(crate) fn parse_tree(lang: LangId, source: &[u8]) -> Result<tree_sitter::Tre
             path: Default::default(),
             message: "parser returned no tree".into(),
         })
-    })
-}
-
-#[allow(dead_code)]
-pub(crate) fn parse(lang: LangId, source: &[u8]) -> Result<ParsedFile, Error> {
-    let tree = parse_tree(lang, source)?;
-    Ok(ParsedFile {
-        tree,
-        source: source.to_vec(),
     })
 }
 
@@ -107,72 +92,24 @@ mod tests {
         assert_eq!(javascript.root_node().kind(), "program");
     }
 
-    fn has_error_node(node: &tree_sitter::Node) -> bool {
-        if node.is_error() {
-            return true;
-        }
-        for child in node.children(&mut node.walk()) {
-            if has_error_node(&child) {
-                return true;
-            }
-        }
-        false
-    }
-
-    #[test]
-    fn parse_valid_python() {
-        let result = parse(LangId::Python, b"def hello(): pass");
-        assert!(result.is_ok());
-        let parsed = result.unwrap();
-        assert!(!parsed.tree.root_node().has_error());
-    }
-
-    #[test]
-    fn parse_malformed_python() {
-        let result = parse(LangId::Python, b"def broken(");
-        assert!(result.is_ok());
-        let parsed = result.unwrap();
-        assert!(has_error_node(&parsed.tree.root_node()));
-    }
-
-    #[test]
-    fn parse_empty_source() {
-        let result = parse(LangId::Python, b"");
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn parse_javascript() {
-        let result = parse(LangId::JavaScript, b"function hello() {}");
-        assert!(result.is_ok());
-        let parsed = result.unwrap();
-        assert!(!parsed.tree.root_node().has_error());
-    }
-
     #[test]
     fn error_ratio_valid_source() {
-        let parsed = parse(LangId::Python, b"def hello(): pass").unwrap();
-        let ratio = error_ratio(&parsed.tree, &parsed.source);
+        let tree = parse_tree(LangId::Python, b"def hello(): pass").unwrap();
+        let ratio = error_ratio(&tree, b"def hello(): pass");
         assert!(ratio < 0.1);
     }
 
     #[test]
     fn error_ratio_malformed() {
-        let parsed = parse(LangId::Python, b"def broken(").unwrap();
-        let ratio = error_ratio(&parsed.tree, &parsed.source);
+        let tree = parse_tree(LangId::Python, b"def broken(").unwrap();
+        let ratio = error_ratio(&tree, b"def broken(");
         assert!(ratio > 0.0);
     }
 
     #[test]
     fn error_ratio_empty_source() {
-        let parsed = parse(LangId::Python, b"").unwrap();
-        let ratio = error_ratio(&parsed.tree, &parsed.source);
+        let tree = parse_tree(LangId::Python, b"").unwrap();
+        let ratio = error_ratio(&tree, b"");
         assert_eq!(ratio, 0.0);
-    }
-
-    #[test]
-    fn tree_root_node_kind() {
-        let parsed = parse(LangId::Python, b"def hello(): pass").unwrap();
-        assert_eq!(parsed.tree.root_node().kind(), "module");
     }
 }


### PR DESCRIPTION
Update TODO, ARCHITECTURE, README, ROADMAP, and specification documents to include details on the new `metacall-deploy` feature, covering call site detection, manifest generation, and SCC-based mesh annotation.