### PR TITLE
docs: Update architecture, ADRs, and project requirements

### DIFF
--- a/docs/STRUCTURE.md
+++ b/docs/STRUCTURE.md
@@ -337,9 +337,9 @@ Parse errors do not abort extraction. The pipeline accumulates `Vec<Diagnostic>`
 
 `rayon = "1.10"` is used for file-level parallelism in the parse + extract phase.
 
-- `Parser` and `Tree` are `Send + Sync` (safe for parallel use).
-- A fresh `Parser` is created per rayon task (creation is ~malloc + zero-init; `set_language` is a pointer assignment to a static grammar table).
-- No parser pooling needed - per-task creation is simpler and equally fast.
+- A thread-local pool of `Parser` instances (one per language) is maintained within each worker thread via `thread_local!` and `RefCell` caching. This avoids sharing the non-`Sync` `Parser` across threads.
+- Emitted `Tree` and symbol models are `Send` and are safely returned from rayon workers to the main thread for graph assembly.
+- Caching `Parser` instances avoids redundant grammar re-initialization and allocation overhead on every task.
 
 ### 5.2 Pipeline Phases
 

--- a/docs/adr/0002-scope-resolution-heuristics.md
+++ b/docs/adr/0002-scope-resolution-heuristics.md
@@ -1,5 +1,10 @@
 # 0002-scope-resolution-heuristics
 
-We established two distinct modes for symbol reference resolution: Strict Scope Resolution and Heuristic Scope Resolution. 
+We resolve symbol references across files using a single, unified scope resolution strategy: transitive BFS lookup over the import graph.
 
-By default, the scope builder limits lookups strictly to direct imports (distance = 1) or explicit re-exports. Under a `--heuristic-resolution` flag, transitive BFS lookup across the entire import graph is allowed, but resolves with a degraded confidence score (0.8 for transitive same-language, 0.6 for cross-language). This guarantees security tools high recall without corrupting the precision of standard language-compliant analysis.
+Rather than maintaining separate "strict" and "heuristic" CLI flags, we build a flattened scope cache for each file. The resolver crawls the import graph using a breadth-first search (BFS). Confidence scores decay based on import distance and language boundaries:
+- **1.0**: Reference is local (distance = 0) or direct, same-language (distance = 1).
+- **0.8**: Reference is transitive, same-language (distance > 1).
+- **0.6**: Reference is cross-language (distance >= 1).
+
+This keeps the CLI interface clean and guarantees security or dependency tools high recall by default, while still capturing precision through the decayed confidence scores.

--- a/docs/adr/0004-global-scope-synthetic-symbols.md
+++ b/docs/adr/0004-global-scope-synthetic-symbols.md
@@ -1,5 +1,8 @@
 # 0004-global-scope-synthetic-symbols
 
-We introduced a synthetic `Module Body Symbol` (named `"<global>"` or `"<module>"`) for files containing top-level global execution blocks to represent module-level dependencies.
+We proposed introducing a synthetic `Module Body Symbol` (named `"<global>"` or `"<module>"`) for files containing top-level global execution blocks to represent module-level dependencies. Under that proposed schema, references occurring outside any class, function, or method boundary would be owned by this synthetic symbol.
 
-All references occurring outside any class, function, or method boundary are owned by this synthetic symbol node. This maintains a homogeneous `Symbol -> Symbol` reference edge schema in the directed graph, allows complete dependency tracing of global execution paths, and prevents dropping critical module-level script dependencies.
+**Current MVP Status**:
+We do not yet generate this synthetic symbol. In the current implementation, references that occur at the top-level (outside of functions or classes) have a `None` source symbol and are skipped during scope resolution. 
+
+Implementing the synthetic module body symbol is deferred to a future phase to maintain simplicity in the initial graph schema.

--- a/docs/rfcs/0001-language-loading-model.md
+++ b/docs/rfcs/0001-language-loading-model.md
@@ -1,4 +1,4 @@
-# ADR 0001: Language Loading Model
+# RFC 0001: Language Loading Model
 
 ## Status
 

--- a/docs/rfcs/0002-error-semantics-and-recovery.md
+++ b/docs/rfcs/0002-error-semantics-and-recovery.md
@@ -1,4 +1,4 @@
-# ADR 0002: Error Semantics and Recovery
+# RFC 0002: Error Semantics and Recovery
 
 ## Status
 

--- a/docs/rfcs/0003-incremental-parsing-strategy.md
+++ b/docs/rfcs/0003-incremental-parsing-strategy.md
@@ -1,4 +1,4 @@
-# ADR 0003: Incremental Parsing Strategy
+# RFC 0003: Incremental Parsing Strategy
 
 ## Status
 

--- a/docs/rfcs/0004-graph-representation-and-scc.md
+++ b/docs/rfcs/0004-graph-representation-and-scc.md
@@ -1,4 +1,4 @@
-# ADR 0004: Graph Representation and SCC
+# RFC 0004: Graph Representation and SCC
 
 ## Status
 

--- a/docs/rfcs/0005-output-contract-policy.md
+++ b/docs/rfcs/0005-output-contract-policy.md
@@ -1,4 +1,4 @@
-# ADR 0005: Output Contract Policy
+# RFC 0005: Output Contract Policy
 
 ## Status
 

--- a/docs/rfcs/0006-type-inference-scope.md
+++ b/docs/rfcs/0006-type-inference-scope.md
@@ -1,4 +1,4 @@
-# ADR 0006: Type Inference Scope
+# RFC 0006: Type Inference Scope
 
 ## Status
 

--- a/docs/rfcs/0007-dgraph-integration-scope.md
+++ b/docs/rfcs/0007-dgraph-integration-scope.md
@@ -1,4 +1,4 @@
-# ADR 0007: Dgraph Integration Scope
+# RFC 0007: Dgraph Integration Scope
 
 ## Status
 

--- a/docs/specs/requirements.md
+++ b/docs/specs/requirements.md
@@ -48,10 +48,9 @@ SCC as a Deployment Unit, classifying it as:
 - Independent (acyclic, Function Mesh separation candidate)
 - Co-deployment required (cyclic, must remain grouped)
 
-### FR-5: Incremental updates
+### FR-5: Incremental updates (Planned)
 
-The analyzer shall support update workflows from file changes with a target incremental
-response of under 100ms for files below 5k LOC.
+The analyzer is designed to support update workflows from file changes with a target incremental response of under 100ms for files below 5k LOC. Note: This is planned for Phase 4 of the roadmap and is not yet implemented.
 
 ### FR-6: CLI and library modes
 
@@ -60,18 +59,17 @@ The project shall expose:
 - Rust library interface
 - CLI entrypoint for project analysis and output emission
 
-### FR-7: C ABI (planned later phase)
+### FR-7: C ABI (Planned)
 
-The project shall provide a stable C ABI header (`mc_ast.h`) for embedding scenarios.
+The project will provide a stable C ABI header (`mc_ast.h`) for embedding scenarios in a later phase.
 
-### FR-8: Datagraph export
+### FR-8: Datagraph export (Planned)
 
-The project may export a datagraph model suitable for external graph sinks
-(including Dgraph).
+The project will support exporting a datagraph model suitable for external graph sinks (including Dgraph) in a later phase.
 
-### FR-9: Deploy Manifest generation (feature-gated: `metacall-deploy`)
+### FR-9: Deploy Manifest generation (feature-gated: `metacall-deploy`, Planned)
 
-When built with `--features metacall-deploy`, the `deploy` subcommand shall:
+When built with `--features metacall-deploy`, the `deploy` subcommand will support generating manifests:
 
 - Scan source files for Cross-Language Call Sites
   (`metacall_load_from_file`, `metacall_load_from_memory`,
@@ -83,14 +81,18 @@ When built with `--features metacall-deploy`, the `deploy` subcommand shall:
   emit a low-confidence annotation when the target is absent
 - Validate an existing `metacall.json` against static analysis when `--check` is passed
 
-### FR-10: Mesh Annotation (feature-gated: `metacall-deploy`)
+*Note: This feature is planned for Phase 5 of the roadmap and is not yet implemented.*
 
-When built with `--features metacall-deploy`, the `deploy` subcommand shall also emit
+### FR-10: Mesh Annotation (feature-gated: `metacall-deploy`, Planned)
+
+When built with `--features metacall-deploy`, the `deploy` subcommand will also emit
 `metacall.mesh.json` containing:
 
 - SCC-derived Deployment Units with constituent symbol lists
 - Cross-language boundary flags per unit
 - Independent mesh candidate classification per unit
+
+*Note: This feature is planned for Phase 5 of the roadmap and is not yet implemented.*
 
 ## 3. Non-functional requirements
 
@@ -122,15 +124,16 @@ debugging.
 
 1. Parse all supported languages and emit valid symbol JSON.
 2. Correct SCC identification for multi-language project fixtures.
-3. Incremental-update target under 100ms for files below 5k LOC.
-4. CI pipeline green on Linux/macOS/Windows.
-5. _(with `metacall-deploy`)_ Deploy Manifests generated match expected fixtures for
-   all example projects in `assets/examples/`.
-6. _(with `metacall-deploy`)_ Mesh Annotation correctly classifies Deployment Units
-   for the `auth-function-mesh` fixture.
+3. CI pipeline green on Linux/macOS/Windows.
+4. *(Planned)* Incremental-update target under 100ms for files below 5k LOC.
+5. *(Planned with `metacall-deploy`)* Deploy Manifests generated match expected fixtures for all example projects in `assets/examples/`.
+6. *(Planned with `metacall-deploy`)* Mesh Annotation correctly classifies Deployment Units for the `auth-function-mesh` fixture.
 
 ## 5. Out-of-scope for MVP
 
+- Incremental watch-mode and C ABI embedding (post-MVP).
+- `metacall-deploy` manifest/mesh generation and `--check` mode (post-MVP).
+- Dgraph sink/export adapter (post-MVP).
 - Full inter-procedural global dataflow with alias analysis.
 - Sound cross-language type inference.
 - Mandatory online graph database dependency.

--- a/docs/specs/traceability.md
+++ b/docs/specs/traceability.md
@@ -6,11 +6,11 @@
 |---|---|---|
 | Rust lib + CLI | `ARCHITECTURE.md`, `ROADMAP.md` | build/test/CLI fixture checks |
 | Language packs | `specs/symbol-extraction.md` | language fixture + snapshot tests |
-| Dependency graph + SCC | `specs/graph-model.md`, RFC-0004, RFC-0008, RFC-0009 | graph fixture SCC assertions |
-| Deployment Unit annotation | `specs/graph-model.md`, ADR-0004 | SCC classification fixture tests |
-| Dataflow (stretch) | `specs/graph-model.md`, ADR-0007 | optional feature tests |
-| Stable C ABI | ADR-0005 + `ROADMAP.md` | C ABI smoke tests |
-| Dgraph sink | ADR-0007 + `specs/graph-model.md` | export contract validation |
+| Dependency graph + SCC | `specs/graph-model.md`, `rfcs/0004-graph-representation-and-scc.md`, `rfcs/0008-graph-module.md`, `rfcs/0009-cross-file-dependency-mapping.md` | graph fixture SCC assertions |
+| Deployment Unit annotation | `specs/graph-model.md`, `rfcs/0004-graph-representation-and-scc.md` | SCC classification fixture tests |
+| Dataflow (stretch) | `specs/graph-model.md`, `rfcs/0007-dgraph-integration-scope.md` | optional feature tests |
+| Stable C ABI | `ROADMAP.md` (Phase 4) | C ABI smoke tests |
+| Dgraph sink | `rfcs/0007-dgraph-integration-scope.md` + `specs/graph-model.md` | export contract validation |
 | Deploy Manifests (`metacall-deploy`) | `specs/requirements.md` FR-9 | fixture manifest comparison tests |
 | Mesh Annotation (`metacall-deploy`) | `specs/requirements.md` FR-10 | SCC unit classification tests |
 
@@ -21,7 +21,7 @@
 | Parse all supported languages | `specs/requirements.md` FR-1 | per-language fixture parsing tests |
 | Correct SCC identification | `specs/graph-model.md` | graph fixture SCC assertions |
 | Deployment Unit classification | `specs/requirements.md` FR-4 | independent vs. co-deploy fixture assertions |
-| Incremental update target | `ARCHITECTURE.md` + ADR-0003 | benchmark harness and thresholds |
+| Incremental update target | `ARCHITECTURE.md` + `rfcs/0003-incremental-parsing-strategy.md` | benchmark harness and thresholds |
 | Linux/macOS/Windows portability | `CI_CD.md` | CI matrix status |
 | Deploy Manifest fixture match | `specs/requirements.md` FR-9 | `assets/examples/` manifest comparison |
 | Mesh Annotation correctness | `specs/requirements.md` FR-10 | `auth-function-mesh` unit classification |


### PR DESCRIPTION
- Clarify concurrency model in `STRUCTURE.md`
- Refine scope resolution strategy in `0002-scope-resolution-heuristics.md`
- Defer synthetic module symbol implementation in `0004-global-scope-synthetic-symbols.md`
- Reclassify ADRs as RFCs and update plan status in specifications