### PR TITLE
feat(language): add Ruby support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thanks for wanting to contribute. This file explains how the project works and what happens to your change once you open a pull request. It is written for humans.
 
-`meta-ast` is a static analysis engine written in Rust. It parses 8 languages with tree-sitter, extracts symbols, builds cross-language dependency graphs, and detects import cycles. It never executes the code it analyzes. The README covers the tool itself; `docs/` covers the architecture.
+`meta-ast` is a static analysis engine written in Rust. It parses 9 languages with tree-sitter, extracts symbols, builds cross-language dependency graphs, and detects import cycles. It never executes the code it analyzes. The README covers the tool itself; `docs/` covers the architecture.
 
 ## Table of contents
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -150,9 +150,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -193,9 +193,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.4"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -203,9 +203,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
  "anstream",
  "anstyle",
@@ -263,22 +263,6 @@ name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
-
-[[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -356,14 +340,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
-name = "displaydoc"
-version = "0.2.6"
+name = "dispatch2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "objc2",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -374,9 +368,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "encode_unicode"
@@ -627,9 +621,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.31"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f8a7b8211e695a1d0cd91cace480d4d0bd57667ab10277cc412c5f7f4884f83"
+checksum = "0b17771570a2b94107741a7b033f19132c2eee21d59d21b24d2ced26500bd66e"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -864,6 +858,7 @@ dependencies = [
  "tree-sitter-go",
  "tree-sitter-javascript",
  "tree-sitter-python",
+ "tree-sitter-ruby",
  "tree-sitter-rust",
  "tree-sitter-typescript",
  "webbrowser",
@@ -955,6 +950,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -968,6 +985,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags",
  "objc2",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -1540,6 +1558,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-ruby"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be0484ea4ef6bb9c575b4fdabde7e31340a8d2dbc7d52b321ac83da703249f95"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-rust"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1668,15 +1696,15 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
+checksum = "ef62a3d5f7b2411119a11b6f62570dbff91d7105e011a20fb83fbf8f5761c40f"
 dependencies = [
- "core-foundation",
  "jni",
  "log",
  "ndk-context",
  "objc2",
+ "objc2-app-kit",
  "objc2-foundation",
  "url",
  "web-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ tree-sitter-cpp = "0.23.4"
 tree-sitter-go = "0.25.0"
 tree-sitter-javascript = "0.25.0"
 tree-sitter-python = "0.25.0"
+tree-sitter-ruby = "0.23.1"
 tree-sitter-rust = "0.24.2"
 tree-sitter-typescript = "0.23.2"
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Built as part of **Google Summer of Code 2026** for the **MetaCall** organization by **[Khaled Alam](https://github.com/k5602)**.
 
-Supports **8 languages**: Python, JavaScript, TypeScript, TSX, C, C++, Rust, Go.
+Supports **9 languages**: Python, JavaScript, TypeScript, TSX, C, C++, Rust, Go, Ruby.
 
 ---
 
@@ -68,8 +68,8 @@ The binary is at `./target/release/meta-ast`.
 `meta-ast` exists to give polyglot codebases a single, fast, language-agnostic
 view of their structure without executing any user code. Its objectives:
 
-- **Parse 8 languages with one tool.** Python, JavaScript, TypeScript, TSX, C,
-  C++, Rust, and Go flow through a uniform tree-sitter pipeline. A mixed
+- **Parse 9 languages with one tool.** Python, JavaScript, TypeScript, TSX, C,
+  C++, Rust, Go, and Ruby flow through a uniform tree-sitter pipeline. A mixed
   Python/JS/Rust project is one graph, not three glued together.
 - **Normalize to a stable IR.** Every declaration becomes a `Symbol` with a
   consistent shape and a stable JSON/YAML output contract. Downstream tooling

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -100,7 +100,7 @@ src/deploy/
 
 ### Language coverage
 
-Queries cover all 8 supported languages: Python, JavaScript, TypeScript, TSX, C, C++, Rust, and Go.
+Queries cover all 9 supported languages: Python, JavaScript, TypeScript, TSX, C, C++, Rust, Go, and Ruby.
 
 ### Client invocation resolution
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -71,7 +71,7 @@ _Requires `--features metacall-deploy`. Full documentation in [DEPLOY.md](DEPLOY
 
 Goals:
 
-- Implement cross-language call-site detection across all 8 supported language ports
+- Implement cross-language call-site detection across all 9 supported language ports
   (`metacall_load_from_file`, `metacall_load_from_memory`, `metacall_load_from_package`,
   `metacall_load_from_configuration`), including CommonJS `require()` for JS/TS and
   bare-name call detection for Rust after `use` import.

--- a/docs/STRUCTURE.md
+++ b/docs/STRUCTURE.md
@@ -30,6 +30,7 @@ src/
 │   ├── cpp.rs                C++ queries + extraction
 │   ├── rust.rs               Rust queries + extraction
 │   ├── go.rs                 Go queries + extraction
+│   ├── ruby.rs               Ruby queries + extraction
 │   └── import_resolver.rs    ImportResolver trait, stateful resolvers (Python, Go, JS, TS)
 │
 ├── input/
@@ -265,6 +266,7 @@ pub enum LangId {
     Cpp,
     Rust,
     Go,
+    Ruby,
 }
 ```
 
@@ -328,6 +330,7 @@ No trait objects, no runtime plugins. Compile-time completeness checking via exh
 | `.cc`, `.cpp`, `.cxx` | `Cpp` |
 | `.rs` | `Rust` |
 | `.go` | `Go` |
+| `.rb`, `.gemspec` | `Ruby` |
 
 ---
 
@@ -478,6 +481,7 @@ Tree-sitter queries are hardcoded constants in each language pack. If a query fa
 | `tree-sitter-cpp` | 0.23.4 | C++ grammar |
 | `tree-sitter-rust` | 0.24.2 | Rust grammar |
 | `tree-sitter-go` | 0.25.0 | Go grammar |
+| `tree-sitter-ruby` | 0.23.1 | Ruby grammar |
 | `petgraph` | 0.8.3 | Directed graph + Tarjan SCC |
 | `serde` + `serde_json` | 1.0 | JSON serialization |
 | `yaml_serde` | 0.10 | YAML serialization |

--- a/src/deploy/dependency.rs
+++ b/src/deploy/dependency.rs
@@ -33,6 +33,7 @@ pub fn classify_external(external: &ExternalNode, project_root: &Path) -> Extern
         }
         LangId::Rust => classify_rust(external, project_root),
         LangId::Go => classify_go(external, project_root),
+        LangId::Ruby => classify_ruby(external, project_root),
         LangId::C | LangId::Cpp => classify_c_cpp_best_effort(external, project_root),
     }
 }
@@ -282,6 +283,33 @@ fn classify_go(external: &ExternalNode, root: &Path) -> ExternalClassification {
     }
 }
 
+fn classify_ruby(external: &ExternalNode, root: &Path) -> ExternalClassification {
+    let lf = root.join("Gemfile.lock");
+    if lf.exists() {
+        return ExternalClassification::Classified {
+            package_name: external.raw_path.clone(),
+            version: parse_version_from_gemfile_lock(&lf, &external.raw_path),
+            language: LangId::Ruby,
+            source: DependencySource::Lockfile,
+        };
+    }
+
+    let mf = root.join("Gemfile");
+    if mf.exists() {
+        return ExternalClassification::Classified {
+            package_name: external.raw_path.clone(),
+            version: None,
+            language: LangId::Ruby,
+            source: DependencySource::Manifest,
+        };
+    }
+
+    ExternalClassification::Unresolved {
+        raw_path: external.raw_path.clone(),
+        reason: "no Gemfile.lock or Gemfile found".into(),
+    }
+}
+
 fn classify_c_cpp_best_effort(external: &ExternalNode, root: &Path) -> ExternalClassification {
     // C/C++ has no universal convention. Try conanfile.txt, then vcpkg.json.
     // If neither exists, silently fall back to Unresolved.
@@ -381,6 +409,22 @@ fn parse_version_from_go_sum(path: &Path, package: &str) -> Option<String> {
     None
 }
 
+fn parse_version_from_gemfile_lock(path: &Path, name: &str) -> Option<String> {
+    let content = std::fs::read_to_string(path).ok()?;
+    // Gemfile.lock lists each gem as "  <name> (<version>)" under a specs
+    // section. The name has no quotes; match the indented line exactly.
+    for line in content.lines() {
+        let line = line.trim_start();
+        if let Some(rest) = line
+            .strip_prefix(&format!("{name} ("))
+            .and_then(|rest| rest.strip_suffix(')'))
+        {
+            return Some(rest.trim().to_string());
+        }
+    }
+    None
+}
+
 /// Extract the first semver-like substring from a line.
 fn extract_semver(line: &str) -> Option<String> {
     let mut chars = line.chars().peekable();
@@ -414,4 +458,84 @@ fn extract_semver(line: &str) -> Option<String> {
     }
     let _ = start;
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn external_node(raw_path: &str) -> ExternalNode {
+        ExternalNode {
+            raw_path: raw_path.to_string(),
+            language: LangId::Ruby,
+            classification: None,
+        }
+    }
+
+    fn test_dir(name: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!("meta_ast_ruby_dep_{name}"));
+        if dir.exists() {
+            let _ = std::fs::remove_dir_all(&dir);
+        }
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn parse_version_from_gemfile_lock_extracts_version() {
+        let dir = test_dir("parse");
+        let lf = dir.join("Gemfile.lock");
+        std::fs::write(
+            &lf,
+            "GEM\n  remote: https://rubygems.org/\n  specs:\n    rails (7.0.8.4)\n      actioncable (= 7.0.8.4)\n",
+        )
+        .unwrap();
+
+        assert_eq!(
+            parse_version_from_gemfile_lock(&lf, "rails"),
+            Some("7.0.8.4".to_string())
+        );
+        assert_eq!(parse_version_from_gemfile_lock(&lf, "missing"), None);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn classify_ruby_uses_gemfile_lock() {
+        let dir = test_dir("classify_lock");
+        std::fs::write(
+            dir.join("Gemfile.lock"),
+            "GEM\n  specs:\n    rails (7.0.8.4)\n",
+        )
+        .unwrap();
+
+        let classification = classify_ruby(&external_node("rails"), &dir);
+        match classification {
+            ExternalClassification::Classified {
+                package_name,
+                version,
+                language,
+                source,
+            } => {
+                assert_eq!(package_name, "rails");
+                assert_eq!(version.as_deref(), Some("7.0.8.4"));
+                assert_eq!(language, LangId::Ruby);
+                assert_eq!(source, DependencySource::Lockfile);
+            }
+            other => panic!("expected Classified, got {other:?}"),
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn classify_ruby_unresolved_without_gemfile() {
+        let missing = std::env::temp_dir().join("meta_ast_ruby_dep_missing_dir");
+        let classification = classify_ruby(&external_node("rails"), &missing);
+        match classification {
+            ExternalClassification::Unresolved { raw_path, reason } => {
+                assert_eq!(raw_path, "rails");
+                assert_eq!(reason, "no Gemfile.lock or Gemfile found");
+            }
+            other => panic!("expected Unresolved, got {other:?}"),
+        }
+    }
 }

--- a/src/deploy/scanner.rs
+++ b/src/deploy/scanner.rs
@@ -231,6 +231,19 @@ static GO_QUERY: LazyLock<Query> = LazyLock::new(|| {
     )
 });
 
+static RUBY_QUERY: LazyLock<Query> = LazyLock::new(|| {
+    crate::language::common::compile_query(
+        &tree_sitter_ruby::LANGUAGE.into(),
+        r#"
+(call
+  method: (identifier) @fn_name
+  arguments: (argument_list) @args
+  (#match? @fn_name "^(metacall_load_from_.*|metacall|metacall_await|metacallfms)$"))
+"#,
+        "Ruby deploy",
+    )
+});
+
 pub fn scan_file(id: LangId, tree: &Tree, source: &[u8], path: &Path) -> Vec<CallSite> {
     let query = match id {
         LangId::Python => &*PYTHON_QUERY,
@@ -241,6 +254,7 @@ pub fn scan_file(id: LangId, tree: &Tree, source: &[u8], path: &Path) -> Vec<Cal
         LangId::Cpp => &*CPP_QUERY,
         LangId::Rust => &*RUST_QUERY,
         LangId::Go => &*GO_QUERY,
+        LangId::Ruby => &*RUBY_QUERY,
     };
 
     let mut cursor = QueryCursor::new();

--- a/src/deploy/tags.rs
+++ b/src/deploy/tags.rs
@@ -10,6 +10,7 @@ pub fn metacall_tag(lang: LangId) -> &'static str {
         LangId::Cpp => "cpp",
         LangId::Rust => "rs",
         LangId::Go => "go",
+        LangId::Ruby => "rb",
     }
 }
 
@@ -23,6 +24,7 @@ pub fn from_metacall_tag(tag: &str) -> Option<LangId> {
         "cpp" => Some(LangId::Cpp),
         "rs" => Some(LangId::Rust),
         "go" => Some(LangId::Go),
+        "rb" => Some(LangId::Ruby),
         _ => None,
     }
 }
@@ -41,5 +43,6 @@ mod tests {
         assert_eq!(metacall_tag(LangId::Cpp), "cpp");
         assert_eq!(metacall_tag(LangId::Rust), "rs");
         assert_eq!(metacall_tag(LangId::Go), "go");
+        assert_eq!(metacall_tag(LangId::Ruby), "rb");
     }
 }

--- a/src/language/dataflow.rs
+++ b/src/language/dataflow.rs
@@ -13,6 +13,7 @@
 //! |------------|--------------|
 //! | Rust       | Implemented  |
 //! | Python     | Implemented  |
+//! | Ruby       | TODO         |
 //! | JS/TS/TSX  | TODO         |
 //! | Go         | TODO         |
 //! | C/C++      | TODO         |
@@ -51,6 +52,8 @@ pub fn extract_dataflow(
         LangId::Go => (Vec::new(), Vec::new()),
         // TODO: Implement C/C++ dataflow extraction
         LangId::C | LangId::Cpp => (Vec::new(), Vec::new()),
+        // TODO: Implement Ruby dataflow extraction
+        LangId::Ruby => (Vec::new(), Vec::new()),
     }
 }
 

--- a/src/language/mod.rs
+++ b/src/language/mod.rs
@@ -1,4 +1,4 @@
-//! Language system: compile-time enum dispatch over 8 language packs.
+//! Language system: compile-time enum dispatch over 9 language packs.
 //!
 //! `LangId` enum selects a `LanguageSpec` via exhaustive `match`.
 //! Each `LanguageSpec` bundles a grammar constructor, tree-sitter query
@@ -14,6 +14,7 @@ pub(crate) mod go;
 pub mod import_resolver;
 pub(crate) mod javascript;
 pub(crate) mod python;
+pub(crate) mod ruby;
 pub(crate) mod rust;
 pub(crate) mod tsx;
 pub(crate) mod typescript;
@@ -64,10 +65,11 @@ pub enum LangId {
     Cpp,
     Rust,
     Go,
+    Ruby,
 }
 
 impl LangId {
-    pub const COUNT: usize = 8;
+    pub const COUNT: usize = 9;
 
     pub fn all() -> [LangId; Self::COUNT] {
         [
@@ -79,6 +81,7 @@ impl LangId {
             LangId::Cpp,
             LangId::Rust,
             LangId::Go,
+            LangId::Ruby,
         ]
     }
 
@@ -131,6 +134,7 @@ pub fn spec_for(id: LangId) -> &'static LanguageSpec {
         LangId::Cpp => &cpp::CPP_SPEC,
         LangId::Rust => &rust::RUST_SPEC,
         LangId::Go => &go::GO_SPEC,
+        LangId::Ruby => &ruby::RUBY_SPEC,
     }
 }
 
@@ -184,12 +188,16 @@ mod tests {
     #[test]
     fn lang_id_display() {
         assert_eq!(format!("{}", LangId::Python), "python");
+        assert_eq!(format!("{}", LangId::Ruby), "ruby");
     }
 
     #[test]
     fn lang_id_serde_snake_case() {
         let json = serde_json::to_string(&LangId::Python).unwrap();
         assert_eq!(json, "\"python\"");
+
+        let json = serde_json::to_string(&LangId::Ruby).unwrap();
+        assert_eq!(json, "\"ruby\"");
     }
 
     #[test]
@@ -220,7 +228,7 @@ mod tests {
 
     #[test]
     fn lang_id_count_matches_variant_count() {
-        assert_eq!(LangId::COUNT, 8);
+        assert_eq!(LangId::COUNT, 9);
         assert_eq!(LangId::all().len(), LangId::COUNT);
     }
 
@@ -282,5 +290,6 @@ mod tests {
         assert_eq!(LangId::Cpp.metacall_tag(), "cpp");
         assert_eq!(LangId::Rust.metacall_tag(), "rs");
         assert_eq!(LangId::Go.metacall_tag(), "go");
+        assert_eq!(LangId::Ruby.metacall_tag(), "rb");
     }
 }

--- a/src/language/ruby.rs
+++ b/src/language/ruby.rs
@@ -1,0 +1,311 @@
+//! Ruby language pack: symbol, import, and reference extraction.
+//!
+//! Resolves Ruby symbols from `method`, `singleton_method`, `class`,
+//! `module`, and constant `assignment` nodes. Resolves `require` and
+//! `require_relative` call imports and bare-call references.
+//!
+//! `require` names resolve against the project `lib/` and `app/`
+//! directories, then the source directory. A gem-like name that resolves
+//! nowhere is returned as-is so the graph builder creates an external node.
+//! `require_relative` names resolve against the source directory only.
+//!
+//! Documented limitations:
+//! - No dataflow extraction. The Ruby stub lives in `dataflow.rs`.
+//! - `=begin...=end` block comments are not treated as docstrings.
+//! - `attr_reader`, `alias`, `include`, and `extend` are not handled.
+//! - Extension-less `Gemfile` and `Rakefile` are not detected.
+
+use crate::language::{DefaultVisibility, DocCommentConfig, LanguageSpec};
+use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
+
+fn resolve_ruby_candidate(path: PathBuf) -> Option<PathBuf> {
+    if path.is_file() {
+        return Some(path);
+    }
+    if path.with_extension("rb").is_file() {
+        return Some(path.with_extension("rb"));
+    }
+    if path.with_extension("so").is_file() {
+        return Some(path.with_extension("so"));
+    }
+    None
+}
+
+fn resolve_ruby_import(raw: &str, source_dir: &Path, project_root: &Path) -> Option<PathBuf> {
+    let raw = raw.trim_matches(|c| c == '"' || c == '\'');
+    if raw.is_empty() {
+        return None;
+    }
+
+    if raw.starts_with('.') {
+        return resolve_ruby_candidate(source_dir.join(raw));
+    }
+
+    for base in [
+        project_root.join("lib"),
+        project_root.join("app"),
+        source_dir.to_path_buf(),
+    ] {
+        if let Some(path) = resolve_ruby_candidate(base.join(raw)) {
+            return Some(path);
+        }
+    }
+
+    Some(PathBuf::from(raw))
+}
+
+static RUBY_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
+    crate::language::common::compile_query(
+        &tree_sitter_ruby::LANGUAGE.into(),
+        r#"
+(method
+  name: (identifier) @name
+  parameters: (method_parameters)? @signature
+) @kind.function
+
+(singleton_method
+  name: (identifier) @name
+  parameters: (method_parameters)? @signature
+) @kind.method
+
+(class
+  name: (constant) @name
+) @kind.class
+
+(module
+  name: (constant) @name
+) @kind.module
+
+(assignment
+  left: (constant) @name
+) @kind.constant
+"#,
+        "Ruby",
+    )
+});
+
+const RUBY_IMPORT_QUERY_STR: &str = r#"
+(call
+  method: (identifier) @import.method
+  arguments: (argument_list . (string) @import.path .)
+  (#match? @import.method "^(require|require_relative)$"))
+"#;
+
+const RUBY_REFERENCE_QUERY_STR: &str = r#"
+(call
+  method: (identifier) @reference.name
+  (#not-match? @reference.name "^(require|require_relative)$"))
+(call
+  receiver: (constant) @reference.name)
+(call
+  receiver: (scope_resolution) @reference.name)
+(scope_resolution
+  name: (constant) @reference.name)
+"#;
+
+static RUBY_IMPORT_REF_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
+    crate::language::common::compile_query(
+        &tree_sitter_ruby::LANGUAGE.into(),
+        &format!("{}\n{}", RUBY_IMPORT_QUERY_STR, RUBY_REFERENCE_QUERY_STR),
+        "Ruby combined import+ref",
+    )
+});
+
+fn ruby_query() -> &'static tree_sitter::Query {
+    &RUBY_QUERY
+}
+
+fn ruby_import_ref_query() -> &'static tree_sitter::Query {
+    &RUBY_IMPORT_REF_QUERY
+}
+
+pub(crate) const RUBY_SPEC: LanguageSpec = LanguageSpec {
+    extensions: &["rb", "gemspec"],
+    grammar_fn: || tree_sitter_ruby::LANGUAGE.into(),
+    query_fn: ruby_query,
+    import_path_resolver: resolve_ruby_import,
+    import_ref_query_fn: ruby_import_ref_query,
+    class_like_parents: &["class", "module"],
+    ancestor_visibility_rules: &[],
+    visibility_from_name: None,
+    import_statement_kinds: &[],
+    default_visibility: DefaultVisibility::PublicByDefault,
+    doc_comment_config: Some(DocCommentConfig {
+        line_prefixes: &["#"],
+        block_open: None,
+        block_close: "",
+        strip_continuation_marker: false,
+    }),
+};
+
+#[cfg(test)]
+mod tests {
+    use crate::language::{
+        LangId, extract_imports_and_references_for, extract_symbols_for, grammar_for,
+    };
+    use crate::model::SymbolKind;
+    use std::path::PathBuf;
+
+    fn parse(source: &[u8]) -> tree_sitter::Tree {
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&grammar_for(LangId::Ruby)).unwrap();
+        parser.parse(source, None).unwrap()
+    }
+
+    #[test]
+    fn ruby_grammar_loads() {
+        let _ = grammar_for(LangId::Ruby);
+    }
+
+    #[test]
+    fn extract_method_with_signature() {
+        let src = b"def greet(name)\n  \"hi #{name}\"\nend";
+        let tree = parse(src);
+        let symbols = extract_symbols_for(LangId::Ruby, &tree, src);
+        assert_eq!(symbols.len(), 1);
+        assert_eq!(symbols[0].name, "greet");
+        assert!(matches!(symbols[0].kind, SymbolKind::Function));
+        assert!(symbols[0].signature.as_deref().unwrap().contains("(name)"));
+    }
+
+    #[test]
+    fn extract_singleton_method() {
+        let src = b"class Calc\n  def self.square(x)\n    x * x\n  end\nend";
+        let tree = parse(src);
+        let symbols = extract_symbols_for(LangId::Ruby, &tree, src);
+        let square = symbols.iter().find(|s| s.name == "square").unwrap();
+        assert!(matches!(square.kind, SymbolKind::Method));
+    }
+
+    #[test]
+    fn extract_class_and_module() {
+        let src = b"module Util\n  class Helper\n  end\nend";
+        let tree = parse(src);
+        let symbols = extract_symbols_for(LangId::Ruby, &tree, src);
+        let util = symbols.iter().find(|s| s.name == "Util").unwrap();
+        assert!(matches!(util.kind, SymbolKind::Module));
+        let helper = symbols.iter().find(|s| s.name == "Helper").unwrap();
+        assert!(matches!(helper.kind, SymbolKind::Class));
+    }
+
+    #[test]
+    fn extract_method_promoted_inside_class() {
+        let src = b"class Foo\n  def bar\n  end\nend";
+        let tree = parse(src);
+        let symbols = extract_symbols_for(LangId::Ruby, &tree, src);
+        let bar = symbols.iter().find(|s| s.name == "bar").unwrap();
+        assert!(matches!(bar.kind, SymbolKind::Method));
+    }
+
+    #[test]
+    fn extract_constant_assignment() {
+        let src = b"MAX_SIZE = 1024";
+        let tree = parse(src);
+        let symbols = extract_symbols_for(LangId::Ruby, &tree, src);
+        assert_eq!(symbols.len(), 1);
+        assert_eq!(symbols[0].name, "MAX_SIZE");
+        assert!(matches!(symbols[0].kind, SymbolKind::Constant));
+    }
+
+    #[test]
+    fn extract_docstring_from_comment() {
+        let src = b"# Adds two numbers.\ndef add(a, b)\n  a + b\nend";
+        let tree = parse(src);
+        let symbols = extract_symbols_for(LangId::Ruby, &tree, src);
+        let add = symbols.iter().find(|s| s.name == "add").unwrap();
+        assert!(
+            add.docstring
+                .as_deref()
+                .unwrap()
+                .contains("Adds two numbers.")
+        );
+    }
+
+    #[test]
+    fn extract_require_import() {
+        let src = b"require 'json'";
+        let tree = parse(src);
+        let (imports, _) =
+            extract_imports_and_references_for(LangId::Ruby, &tree, src, &PathBuf::from("test.rb"));
+        assert_eq!(imports.len(), 1);
+        assert_eq!(imports[0].import_specifier, "'json'");
+        assert!(imports[0].symbol.is_none());
+    }
+
+    #[test]
+    fn extract_require_relative_import() {
+        let src = b"require_relative './helper'";
+        let tree = parse(src);
+        let (imports, _) =
+            extract_imports_and_references_for(LangId::Ruby, &tree, src, &PathBuf::from("test.rb"));
+        assert_eq!(imports.len(), 1);
+        assert_eq!(imports[0].import_specifier, "'./helper'");
+    }
+
+    #[test]
+    fn require_calls_do_not_leak_as_references() {
+        let src = b"require 'json'\nputs 'hi'";
+        let tree = parse(src);
+        let (imports, references) =
+            extract_imports_and_references_for(LangId::Ruby, &tree, src, &PathBuf::from("test.rb"));
+        assert_eq!(imports.len(), 1);
+        assert!(references.iter().any(|r| r.name == "puts"));
+        assert!(!references.iter().any(|r| r.name == "require"));
+    }
+
+    #[test]
+    fn extract_bare_call_reference() {
+        let src = b"calc_total(items)";
+        let tree = parse(src);
+        let (_, references) =
+            extract_imports_and_references_for(LangId::Ruby, &tree, src, &PathBuf::from("test.rb"));
+        assert!(references.iter().any(|r| r.name == "calc_total"));
+    }
+
+    #[test]
+    fn extract_constant_receiver_reference() {
+        let src = b"Math.sqrt(4)";
+        let tree = parse(src);
+        let (_, references) =
+            extract_imports_and_references_for(LangId::Ruby, &tree, src, &PathBuf::from("test.rb"));
+        assert!(references.iter().any(|r| r.name == "Math"));
+        assert!(references.iter().any(|r| r.name == "sqrt"));
+    }
+
+    #[test]
+    fn resolve_ruby_import_bare_gem_name() {
+        let source_dir = PathBuf::from("/tmp/src");
+        let project_root = PathBuf::from("/tmp/project");
+        let result = super::resolve_ruby_import("json", &source_dir, &project_root);
+        assert_eq!(result, Some(PathBuf::from("json")));
+    }
+
+    #[test]
+    fn resolve_ruby_import_relative_joins_source_dir() {
+        let source_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/ruby");
+        let project_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let result =
+            super::resolve_ruby_import("./classes_and_modules", &source_dir, &project_root);
+        assert_eq!(
+            result,
+            Some(
+                source_dir
+                    .join("./classes_and_modules")
+                    .with_extension("rb")
+            )
+        );
+    }
+
+    #[test]
+    fn ruby_insta_snapshot() {
+        let src = std::fs::read_to_string(
+            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("tests/fixtures/ruby/classes_and_modules.rb"),
+        )
+        .unwrap();
+        let tree = parse(src.as_bytes());
+        let symbols = extract_symbols_for(LangId::Ruby, &tree, src.as_bytes());
+        insta::assert_json_snapshot!(symbols);
+    }
+}

--- a/src/language/snapshots/meta_ast__language__ruby__tests__ruby_insta_snapshot.snap
+++ b/src/language/snapshots/meta_ast__language__ruby__tests__ruby_insta_snapshot.snap
@@ -1,0 +1,347 @@
+---
+source: src/language/ruby.rs
+assertion_line: 324
+expression: symbols
+---
+[
+  {
+    "name": "Widget",
+    "kind": "Module",
+    "source_range": {
+      "byte_start": 127,
+      "byte_end": 911,
+      "start": {
+        "line": 5,
+        "column": 0
+      },
+      "end": {
+        "line": 47,
+        "column": 3
+      }
+    },
+    "visibility": null,
+    "signature": null,
+    "docstring": "The Widget namespace groups all widget-related classes.",
+    "is_async": false
+  },
+  {
+    "name": "VERSION",
+    "kind": "Constant",
+    "source_range": {
+      "byte_start": 143,
+      "byte_end": 167,
+      "start": {
+        "line": 6,
+        "column": 2
+      },
+      "end": {
+        "line": 6,
+        "column": 26
+      }
+    },
+    "visibility": null,
+    "signature": null,
+    "docstring": null,
+    "is_async": false
+  },
+  {
+    "name": "Report",
+    "kind": "Class",
+    "source_range": {
+      "byte_start": 224,
+      "byte_end": 907,
+      "start": {
+        "line": 9,
+        "column": 2
+      },
+      "end": {
+        "line": 46,
+        "column": 5
+      }
+    },
+    "visibility": null,
+    "signature": null,
+    "docstring": "A Report renders widget metrics to text or JSON.",
+    "is_async": false
+  },
+  {
+    "name": "FORMATS",
+    "kind": "Constant",
+    "source_range": {
+      "byte_start": 241,
+      "byte_end": 271,
+      "start": {
+        "line": 10,
+        "column": 4
+      },
+      "end": {
+        "line": 10,
+        "column": 34
+      }
+    },
+    "visibility": null,
+    "signature": null,
+    "docstring": null,
+    "is_async": false
+  },
+  {
+    "name": "initialize",
+    "kind": "Method",
+    "source_range": {
+      "byte_start": 277,
+      "byte_end": 357,
+      "start": {
+        "line": 12,
+        "column": 4
+      },
+      "end": {
+        "line": 15,
+        "column": 7
+      }
+    },
+    "visibility": null,
+    "signature": "(title, rows = [])",
+    "docstring": null,
+    "is_async": false
+  },
+  {
+    "name": "total",
+    "kind": "Method",
+    "source_range": {
+      "byte_start": 410,
+      "byte_end": 443,
+      "start": {
+        "line": 18,
+        "column": 4
+      },
+      "end": {
+        "line": 20,
+        "column": 7
+      }
+    },
+    "visibility": null,
+    "signature": null,
+    "docstring": "Compute the total value across all rows.",
+    "is_async": false
+  },
+  {
+    "name": "render",
+    "kind": "Method",
+    "source_range": {
+      "byte_start": 505,
+      "byte_end": 548,
+      "start": {
+        "line": 23,
+        "column": 4
+      },
+      "end": {
+        "line": 25,
+        "column": 7
+      }
+    },
+    "visibility": null,
+    "signature": null,
+    "docstring": "Render the report using the configured formatter.",
+    "is_async": false
+  },
+  {
+    "name": "to_json",
+    "kind": "Method",
+    "source_range": {
+      "byte_start": 601,
+      "byte_end": 649,
+      "start": {
+        "line": 28,
+        "column": 4
+      },
+      "end": {
+        "line": 30,
+        "column": 7
+      }
+    },
+    "visibility": null,
+    "signature": null,
+    "docstring": "Serialize the report to a JSON document.",
+    "is_async": false
+  },
+  {
+    "name": "from_file",
+    "kind": "Method",
+    "source_range": {
+      "byte_start": 709,
+      "byte_end": 757,
+      "start": {
+        "line": 33,
+        "column": 4
+      },
+      "end": {
+        "line": 35,
+        "column": 7
+      }
+    },
+    "visibility": null,
+    "signature": "(path)",
+    "docstring": "Build a report directly from a local file path.",
+    "is_async": false
+  },
+  {
+    "name": "payload",
+    "kind": "Method",
+    "source_range": {
+      "byte_start": 776,
+      "byte_end": 832,
+      "start": {
+        "line": 39,
+        "column": 4
+      },
+      "end": {
+        "line": 41,
+        "column": 7
+      }
+    },
+    "visibility": null,
+    "signature": null,
+    "docstring": null,
+    "is_async": false
+  },
+  {
+    "name": "format_rows",
+    "kind": "Method",
+    "source_range": {
+      "byte_start": 838,
+      "byte_end": 901,
+      "start": {
+        "line": 43,
+        "column": 4
+      },
+      "end": {
+        "line": 45,
+        "column": 7
+      }
+    },
+    "visibility": null,
+    "signature": "(rows)",
+    "docstring": null,
+    "is_async": false
+  },
+  {
+    "name": "Auth",
+    "kind": "Module",
+    "source_range": {
+      "byte_start": 965,
+      "byte_end": 1293,
+      "start": {
+        "line": 50,
+        "column": 0
+      },
+      "end": {
+        "line": 68,
+        "column": 3
+      }
+    },
+    "visibility": null,
+    "signature": null,
+    "docstring": "The Auth namespace wraps the remote auth service.",
+    "is_async": false
+  },
+  {
+    "name": "ENDPOINT",
+    "kind": "Constant",
+    "source_range": {
+      "byte_start": 979,
+      "byte_end": 1023,
+      "start": {
+        "line": 51,
+        "column": 2
+      },
+      "end": {
+        "line": 51,
+        "column": 46
+      }
+    },
+    "visibility": null,
+    "signature": null,
+    "docstring": null,
+    "is_async": false
+  },
+  {
+    "name": "Token",
+    "kind": "Class",
+    "source_range": {
+      "byte_start": 1073,
+      "byte_end": 1289,
+      "start": {
+        "line": 54,
+        "column": 2
+      },
+      "end": {
+        "line": 67,
+        "column": 5
+      }
+    },
+    "visibility": null,
+    "signature": null,
+    "docstring": "A Token manages an opaque session secret.",
+    "is_async": false
+  },
+  {
+    "name": "initialize",
+    "kind": "Method",
+    "source_range": {
+      "byte_start": 1089,
+      "byte_end": 1178,
+      "start": {
+        "line": 55,
+        "column": 4
+      },
+      "end": {
+        "line": 58,
+        "column": 7
+      }
+    },
+    "visibility": null,
+    "signature": "(secret)",
+    "docstring": null,
+    "is_async": false
+  },
+  {
+    "name": "fresh?",
+    "kind": "Method",
+    "source_range": {
+      "byte_start": 1184,
+      "byte_end": 1231,
+      "start": {
+        "line": 60,
+        "column": 4
+      },
+      "end": {
+        "line": 62,
+        "column": 7
+      }
+    },
+    "visibility": null,
+    "signature": null,
+    "docstring": null,
+    "is_async": false
+  },
+  {
+    "name": "for",
+    "kind": "Method",
+    "source_range": {
+      "byte_start": 1237,
+      "byte_end": 1283,
+      "start": {
+        "line": 64,
+        "column": 4
+      },
+      "end": {
+        "line": 66,
+        "column": 7
+      }
+    },
+    "visibility": null,
+    "signature": "(secret)",
+    "docstring": null,
+    "is_async": false
+  }
+]

--- a/tests/fixtures/ruby/classes_and_modules.rb
+++ b/tests/fixtures/ruby/classes_and_modules.rb
@@ -1,0 +1,75 @@
+require 'json'
+require 'net/http'
+require_relative './widget_store'
+
+# The Widget namespace groups all widget-related classes.
+module Widget
+  VERSION = '1.2.0'.freeze
+
+  # A Report renders widget metrics to text or JSON.
+  class Report
+    FORMATS = %w[json yaml].freeze
+
+    def initialize(title, rows = [])
+      @title = title
+      @rows = rows
+    end
+
+    # Compute the total value across all rows.
+    def total
+      @rows.sum
+    end
+
+    # Render the report using the configured formatter.
+    def render
+      format_rows(@rows)
+    end
+
+    # Serialize the report to a JSON document.
+    def to_json
+      JSON.generate(payload)
+    end
+
+    # Build a report directly from a local file path.
+    def self.from_file(path)
+      new(path)
+    end
+
+    private
+
+    def payload
+      { title: @title, rows: @rows }
+    end
+
+    def format_rows(rows)
+      rows.map(&:to_s).join("\n")
+    end
+  end
+end
+
+# The Auth namespace wraps the remote auth service.
+module Auth
+  ENDPOINT = 'https://auth.example.com'.freeze
+
+  # A Token manages an opaque session secret.
+  class Token
+    def initialize(secret)
+      @secret = secret
+      @expires_at = Time.now + 3600
+    end
+
+    def fresh?
+      @expires_at > Time.now
+    end
+
+    def self.for(secret)
+      new(secret)
+    end
+  end
+end
+
+report = Widget::Report.from_file('data/report.json')
+client = HTTP::Client.new(Auth::ENDPOINT)
+root = Math.sqrt(report.total)
+puts client.inspect
+puts root

--- a/tests/fixtures/ruby/gem.gemspec
+++ b/tests/fixtures/ruby/gem.gemspec
@@ -1,0 +1,22 @@
+require_relative 'lib/my_gem/version'
+
+Gem::Specification.new do |spec|
+  spec.name          = 'my_gem'
+  spec.version       = MyGem::VERSION
+  spec.authors       = ['Ada Lovelace']
+  spec.email         = ['ada@example.com']
+  spec.summary       = 'A small gem that does useful things.'
+  spec.description   = 'A small gem that does useful things, described at length.'
+  spec.homepage      = 'https://example.com/my_gem'
+  spec.license       = 'MIT'
+  spec.required_ruby_version = '>= 3.0.0'
+
+  spec.files         = Dir.chdir(__dir__) { Dir['lib/**/*.rb', 'README.md'] }
+  spec.require_paths = ['lib']
+
+  spec.metadata['source_code_uri'] = 'https://github.com/example/my_gem'
+
+  spec.add_dependency 'json', '~> 2.6'
+  spec.add_dependency 'yaml', '>= 0.2'
+  spec.add_development_dependency 'rake', '~> 13.0'
+end

--- a/tests/fixtures/ruby/imports.rb
+++ b/tests/fixtures/ruby/imports.rb
@@ -1,0 +1,31 @@
+require 'json'
+require 'yaml'
+require 'uri'
+
+require_relative './local_helper'
+
+# Read and parse a JSON document from disk.
+def load_document(path)
+  content = File.read(path)
+  JSON.parse(content)
+end
+
+# Load configuration from a YAML file.
+def load_config(path)
+  YAML.safe_load(File.read(path))
+end
+
+def build_url(host, port)
+  base = "http://#{host}:#{port}"
+  endpoint(base, '/health')
+end
+
+def endpoint(base, path)
+  URI.join(base, path).to_s
+end
+
+def main
+  config = load_config('config.yaml')
+  url = build_url(config['host'], config['port'])
+  puts url
+end

--- a/tests/fixtures/ruby/methods.rb
+++ b/tests/fixtures/ruby/methods.rb
@@ -1,0 +1,24 @@
+# Greet a user by name.
+def greet(name)
+  puts "Hello, #{name}"
+end
+
+def add(a, b)
+  a + b
+end
+
+def configure(url, port = 8080)
+  puts "Connecting to #{url} on port #{port}"
+end
+
+# Fetch a path with retry and timeout options.
+def fetch(path, retries: 3, timeout: 5)
+  retries.times { puts path }
+  puts "timeout=#{timeout}"
+end
+
+def main
+  greet('world')
+  add(1, 2)
+  configure('localhost')
+end


### PR DESCRIPTION
## What this PR does

Ruby is now extractable: symbols, `require`/`require_relative` imports, references, and the full deploy path (tag, call-site scanner, Gemfile.lock lookup). This closes the gap the RFCs kept mentioning, where Ruby was "MetaCall-supported but not extracted."

## What's in it

- New pack `src/language/ruby.rs`: methods, singleton methods, classes, modules, constants. Methods inside `class`/`module` bodies get promoted to `Method` instead of `Function`, same trick Python uses.
- Imports: only `require` and `require_relative` calls with string arguments. The reference query explicitly excludes them, so Ruby files don't spam "unresolved reference: require" warnings.
- Resolver: `lib/` then `app/` then the source dir, with `.rb`/`.so` fallback. A gem name that resolves nowhere comes back as-is so the graph builds an external node, like JS does.
- `LangId::Ruby` appended last. The parser pool indexes that enum, so variant order is load-bearing.
- Deploy: `"rb"` tag in both directions, a `metacall()` call-site query, and version lookup from Gemfile.lock.
- Dataflow: empty stub, matching the six languages that don't have real dataflow yet.
- Fixtures, insta snapshot, docs (STRUCTURE, DEPLOY, README, CONTRIBUTING, ROADMAP).

## Verification

All the usual gates, all green:

- `cargo build --features watch --features metacall-deploy --features dataflow`
- `cargo test --all-features` (324 lib + 106 integration)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo +1.94.0 fmt --check`
- `cargo deny check licenses bans`
- Manual: `inspect`/`graph`/`deploy` against `tests/fixtures/ruby`. A Ruby orchestrator calling `metacall_load_from_file('py', ...)` yields an `rb` pod and cross-language edges pointing at the `py` pod.

## Known gaps (next PR, probably)

- Dataflow extraction is a stub.
- `=begin`/`=end` block comments are not docstrings; only `#` comments are.
- `attr_reader`, `alias`, `include`, `extend` are ignored.
- Only `.rb` and `.gemspec` are registered. `.rake`, `.rbw`, `.erb`, and extension-less `Gemfile`/`Rakefile` are not detected.
