### PR TITLE
ci(docs): deploy mdbook via actions/deploy-pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,6 +28,12 @@ jobs:
     name: mdbook
     runs-on: ubuntu-latest
     continue-on-error: true
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
 
@@ -50,9 +56,17 @@ jobs:
         if: steps.check.outputs.exists == 'true'
         run: mdbook build docs/
 
-      - name: Deploy to GitHub Pages
+      - name: Configure Pages
         if: steps.check.outputs.exists == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: peaceiris/actions-gh-pages@v4
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        if: steps.check.outputs.exists == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs/book
+          path: ./docs/book
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        if: steps.check.outputs.exists == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
The mdbook build succeeds but the Pages deploy fails with 403: Pages is set to the GitHub Actions build type, and peaceiris pushes to a gh-pages branch, which the token is not allowed to do.

Switch to the native flow: configure-pages + upload-pages-artifact + deploy-pages.