### PR TITLE
feat: wire --language, configurable --max-pod-size, encapsulate CodeGraph, O(1) edge normalization

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,11 +30,8 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     permissions:
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      contents: read
+      actions: read
     steps:
       - uses: actions/checkout@v4
 
@@ -57,17 +54,27 @@ jobs:
         if: steps.check.outputs.exists == 'true'
         run: mdbook build docs/
 
-      - name: Configure Pages
-        if: steps.check.outputs.exists == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/configure-pages@v5
-
       - name: Upload Pages artifact
-        if: steps.check.outputs.exists == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: steps.check.outputs.exists == 'true' && github.ref == 'refs/heads/main'
         uses: actions/upload-pages-artifact@v3
         with:
           path: ./docs/book
 
+  pages-deploy:
+    name: pages-deploy
+    runs-on: ubuntu-latest
+    needs: mdbook
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
       - name: Deploy to GitHub Pages
         id: deployment
-        if: steps.check.outputs.exists == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/deploy-pages@v4

--- a/benches/graph.rs
+++ b/benches/graph.rs
@@ -9,12 +9,12 @@ use std::path::PathBuf;
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use meta_ast::graph::node::{FileNode, SymbolNode};
-use meta_ast::graph::{EdgeData, EdgeKind, GraphBuilder, NodeData, SccAnalysis};
+use meta_ast::graph::{CodeGraph, EdgeData, EdgeKind, GraphBuilder, NodeData, SccAnalysis};
 use meta_ast::language::LangId;
 use meta_ast::model::{
     LineColumn, SourceRange, Symbol, SymbolId, SymbolKind, Visibility, ids::SnapshotId,
 };
-use petgraph::graph::DiGraph;
+use petgraph::graph::{DiGraph, NodeIndex};
 use std::hint::black_box;
 
 /// Create a test symbol with the given ID and name.
@@ -500,6 +500,45 @@ fn bench_full_datagraph_pipeline(c: &mut Criterion) {
     group.finish();
 }
 
+/// Benchmark post-build edge normalization on a hub-and-spokes graph.
+///
+/// The setup adds `out_degree` distinct Import edges from a hub node. The
+/// timed region re-inserts those same triples through `add_edge_normalized`,
+/// which exercises the duplicate-dedup path. This isolates the cost of the
+/// dedup lookup from edge insertion.
+fn bench_postbuild_edge_normalization(c: &mut Criterion) {
+    let mut group = c.benchmark_group("postbuild_edge_normalization");
+
+    for out_degree in [100, 1000].iter() {
+        group.bench_with_input(
+            BenchmarkId::from_parameter(out_degree),
+            out_degree,
+            |b, &out_degree| {
+                let mut graph = CodeGraph::new(SnapshotId::new(1).unwrap());
+                let hub = graph.add_node(NodeData::File(create_test_file_node(1, "hub.rs")));
+                let mut triples: Vec<(NodeIndex, NodeIndex)> = Vec::with_capacity(out_degree);
+                for i in 0..out_degree {
+                    let target = graph.add_node(NodeData::File(create_test_file_node(
+                        (i + 2) as u32,
+                        &format!("target_{}.rs", i),
+                    )));
+                    graph.add_edge_normalized(hub, target, EdgeKind::Import, 0.5);
+                    triples.push((hub, target));
+                }
+
+                b.iter(|| {
+                    for &(source, target) in &triples {
+                        graph.add_edge_normalized(source, target, EdgeKind::Import, 0.9);
+                    }
+                    black_box(graph.edge_count());
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
 /// Benchmark adding Data nodes and Flow edges to the graph.
 fn bench_dataflow_nodes_and_edges(c: &mut Criterion) {
     let mut group = c.benchmark_group("dataflow_nodes_edges");
@@ -556,5 +595,6 @@ criterion_group!(
     bench_datagraph_export,
     bench_full_datagraph_pipeline,
     bench_dataflow_nodes_and_edges,
+    bench_postbuild_edge_normalization,
 );
 criterion_main!(graph_benches);

--- a/benches/graph.rs
+++ b/benches/graph.rs
@@ -503,9 +503,10 @@ fn bench_full_datagraph_pipeline(c: &mut Criterion) {
 /// Benchmark post-build edge normalization on a hub-and-spokes graph.
 ///
 /// The setup adds `out_degree` distinct Import edges from a hub node. The
-/// timed region re-inserts those same triples through `add_edge_normalized`,
-/// which exercises the duplicate-dedup path. This isolates the cost of the
-/// dedup lookup from edge insertion.
+/// timed region re-inserts those same endpoint pairs through
+/// `add_edge_normalized`, which exercises the duplicate-dedup path only.
+/// Setup inserts happen outside the timed region; the fresh-insert path is
+/// not timed. This isolates the cost of the dedup lookup from edge insertion.
 fn bench_postbuild_edge_normalization(c: &mut Criterion) {
     let mut group = c.benchmark_group("postbuild_edge_normalization");
 
@@ -516,18 +517,18 @@ fn bench_postbuild_edge_normalization(c: &mut Criterion) {
             |b, &out_degree| {
                 let mut graph = CodeGraph::new(SnapshotId::new(1).unwrap());
                 let hub = graph.add_node(NodeData::File(create_test_file_node(1, "hub.rs")));
-                let mut triples: Vec<(NodeIndex, NodeIndex)> = Vec::with_capacity(out_degree);
+                let mut edges: Vec<(NodeIndex, NodeIndex)> = Vec::with_capacity(out_degree);
                 for i in 0..out_degree {
                     let target = graph.add_node(NodeData::File(create_test_file_node(
                         (i + 2) as u32,
                         &format!("target_{}.rs", i),
                     )));
                     graph.add_edge_normalized(hub, target, EdgeKind::Import, 0.5);
-                    triples.push((hub, target));
+                    edges.push((hub, target));
                 }
 
                 b.iter(|| {
-                    for &(source, target) in &triples {
+                    for &(source, target) in &edges {
                         graph.add_edge_normalized(source, target, EdgeKind::Import, 0.9);
                     }
                     black_box(graph.edge_count());

--- a/benches/graph.rs
+++ b/benches/graph.rs
@@ -397,7 +397,7 @@ fn bench_full_pipeline_small(c: &mut Criterion) {
 
                 // Build and analyze
                 let graph = builder.build();
-                let scc = SccAnalysis::analyze(&graph.graph);
+                let scc = SccAnalysis::analyze(graph.graph());
 
                 black_box((graph.node_count(), scc.has_cycles()));
             });
@@ -523,7 +523,7 @@ fn bench_dataflow_nodes_and_edges(c: &mut Criterion) {
                             end: LineColumn { line: 0, column: 0 },
                         },
                     });
-                    let idx = graph.graph.add_node(dnode);
+                    let idx = graph.add_node(dnode);
                     node_indices.push(idx);
                 }
                 for i in 0..(size - 1) {

--- a/benches/incremental.rs
+++ b/benches/incremental.rs
@@ -50,11 +50,11 @@ fn bench_cold_vs_warm(c: &mut Criterion) {
     group.sample_size(10);
 
     group.bench_function("cold_analyze_graph", |b| {
-        b.iter(|| analyze_graph(&root, SnapshotId::new(1).unwrap()).unwrap());
+        b.iter(|| analyze_graph(&root, SnapshotId::new(1).unwrap(), None).unwrap());
     });
 
     let mut state = WatchState::new();
-    incremental_reanalyze(&root, &mut state).unwrap();
+    incremental_reanalyze(&root, None, &mut state).unwrap();
 
     let modified = root.join("mod_42.py");
     let original = std::fs::read_to_string(&modified).unwrap();
@@ -72,13 +72,13 @@ fn bench_cold_vs_warm(c: &mut Criterion) {
                 }
             },
             |_| {
-                incremental_reanalyze(&root, &mut state).unwrap();
+                incremental_reanalyze(&root, None, &mut state).unwrap();
             },
         );
     });
 
     std::fs::write(&modified, &original).unwrap();
-    let _ = incremental_reanalyze(&root, &mut state).unwrap();
+    let _ = incremental_reanalyze(&root, None, &mut state).unwrap();
 
     group.finish();
 }

--- a/docs/src/ARCHITECTURE.md
+++ b/docs/src/ARCHITECTURE.md
@@ -89,7 +89,7 @@ The CLI supports JSON and YAML for programmatic consumption, plus an interactive
 - **JSON / YAML:** Controlled by the `-f, --format` flag. JSON is the default. YAML requires no extra setup - just pass `--format yaml`.
 - **HTML dashboard:** Separate concern, activated with `--html`. Generates a single `.html` file with an interactive Cytoscape.js graph loaded from a CDN (cached by the browser after first fetch). The browser auto-opens unless you redirect.
 - **Datagraph JSON:** Activated with `--datagraph` (requires `--features dataflow`). Exports detailed data/flow node definitions and def-use relations.
-- **Language Override:** Force a specific language with `-l, --language <lang>`.
+- **Language Filter:** Only analyze files detected as this language with `-l, --language <lang>`.
 
 The dashboard turns SCC analysis into something you can actually see. Nodes in cyclic clusters (co-deployment required) are colored red. Independent Deployment Units are green. This is the difference between "your code has cycles" and "here is the exact knot you need to untangle before you can split this into independent mesh units."
 

--- a/docs/src/DEPLOY.md
+++ b/docs/src/DEPLOY.md
@@ -31,6 +31,7 @@ meta-ast deploy <path> --check
 | `-o, --out <dir>` | `.` | Directory to write generated artifacts |
 | `-f, --format <json\|yaml>` | `json` | Serialization format |
 | `--check` | off | Fairness check mode: exits non-zero on missing RPC stubs |
+| `--max-pod-size <N>` | `20` | Files per pod before rebalancing triggers |
 
 ---
 
@@ -144,7 +145,7 @@ When both an Import edge and a Reference edge connect the same pod pair, confide
 `cut.rs` implements two cut rules:
 
 1. **Cross-language SCC cuts:** Cuts the lowest-confidence internal edge when an SCC spans multiple languages (`CutReason::CrossLanguageScc`). The manifest marks these as RPC stubs.
-2. **Oversized pod cuts:** Greedy single-pass cut on pods exceeding `DEFAULT_MAX_POD_SIZE` (20 files).
+2. **Oversized pod cuts:** Greedy single-pass cut on pods exceeding the pod size limit (`DEFAULT_MAX_POD_SIZE`, 20 files by default). Override the limit with `--max-pod-size <N>`.
 
 ---
 

--- a/docs/src/specs/graph-model.md
+++ b/docs/src/specs/graph-model.md
@@ -78,6 +78,14 @@ Graph serialization for external consumers shall preserve:
 
 Sink adapters (e.g., Dgraph) that must preserve semantic equivalence.
 
+The serialized `language` field on file and external nodes uses the canonical
+lowercase language names, in enum declaration order:
+
+`python`, `javascript`, `typescript`, `tsx`, `c`, `cpp`, `rust`, `go`, `ruby`
+
+These values also parse back through the CLI `--language` flag. The same names
+apply to the strum `Display`/`AsRefStr` and serde representations of `LangId`.
+
 ## 7. Known limitations
 
 - Cross-language resolution is initially best-effort string/scope matching.

--- a/src/deploy/client_call.rs
+++ b/src/deploy/client_call.rs
@@ -86,7 +86,7 @@ pub(crate) fn resolve_client_calls(
     // Path -> FileId, used to filter Phase A candidates by loaded file.
     let mut path_to_file_id: HashMap<PathBuf, FileId> = HashMap::new();
     for (&fid, &idx) in &graph.file_to_index {
-        if let NodeData::File(f) = &graph.graph[idx] {
+        if let NodeData::File(f) = &graph.graph()[idx] {
             path_to_idx.insert(f.path.clone(), idx);
             path_to_file_id.insert(f.path.clone(), fid);
         }
@@ -167,7 +167,7 @@ pub(crate) fn resolve_client_calls(
             else {
                 continue;
             };
-            if let NodeData::File(f) = &graph.graph[file_idx]
+            if let NodeData::File(f) = &graph.graph()[file_idx]
                 && !loaded.iter().any(|(fid, _)| *fid == f.id)
             {
                 loaded.push((f.id, tag));
@@ -359,7 +359,7 @@ mod tests {
 
         fn add_file(&mut self, path: &str, lang: LangId) -> (FileId, NodeIndex) {
             let id = FileId::new(self.graph.file_to_index.len() as u32 + 1).unwrap();
-            let idx = self.graph.graph.add_node(NodeData::File(FileNode::new(
+            let idx = self.graph.add_node(NodeData::File(FileNode::new(
                 id,
                 PathBuf::from(path),
                 lang,
@@ -377,7 +377,6 @@ mod tests {
             lang: LangId,
         ) -> NodeIndex {
             let idx = self
-                .graph
                 .graph
                 .add_node(NodeData::Symbol(SymbolNode::from_symbol(sym, file_id)));
             self.graph.symbol_to_index.insert(sym.id, idx);

--- a/src/deploy/cut.rs
+++ b/src/deploy/cut.rs
@@ -65,6 +65,7 @@ pub fn find_cross_language_cuts(
     }
 
     let mut cuts = Vec::new();
+    let g = graph.graph();
 
     for comp in &scc.components {
         if !comp.is_cyclic {
@@ -80,7 +81,7 @@ pub fn find_cross_language_cuts(
         // NodeData variant that carries a language to avoid missing such cycles.
         let mut langs = HashSet::new();
         for &node_idx in &comp.nodes {
-            match graph.graph.node_weight(node_idx) {
+            match g.node_weight(node_idx) {
                 Some(NodeData::Symbol(s)) => {
                     if let Some(&lang) = file_languages.get(&s.file_id) {
                         langs.insert(lang);
@@ -102,21 +103,21 @@ pub fn find_cross_language_cuts(
 
         // Find the lowest-confidence cross-language edge inside this SCC.
         let mut best_edge: Option<(FileId, FileId, f32)> = None;
-        for edge_idx in graph.graph.edge_indices() {
-            let weight = &graph.graph[edge_idx];
+        for edge_idx in g.edge_indices() {
+            let weight = &g[edge_idx];
             if !weight.participates_in_scc() {
                 continue;
             }
-            let Some((u, v)) = graph.graph.edge_endpoints(edge_idx) else {
+            let Some((u, v)) = g.edge_endpoints(edge_idx) else {
                 continue;
             };
             if !comp_nodes.contains(&u) || !comp_nodes.contains(&v) {
                 continue;
             }
-            let Some(src_fid) = node_to_file_id(&graph.graph[u]) else {
+            let Some(src_fid) = node_to_file_id(&g[u]) else {
                 continue;
             };
-            let Some(dst_fid) = node_to_file_id(&graph.graph[v]) else {
+            let Some(dst_fid) = node_to_file_id(&g[v]) else {
                 continue;
             };
             if file_languages.get(&src_fid) != file_languages.get(&dst_fid) {
@@ -158,20 +159,21 @@ pub fn find_oversized_pod_cut(pod: &Pod, graph: &CodeGraph, max_size: usize) -> 
 
     let files_set: HashSet<FileId> = pod.files.iter().copied().collect();
     let mut best_edge: Option<(FileId, FileId, f32)> = None;
+    let g = graph.graph();
 
     // Single pass over all edges -- filter to intra-pod edges only.
-    for edge_idx in graph.graph.edge_indices() {
-        let weight = &graph.graph[edge_idx];
+    for edge_idx in g.edge_indices() {
+        let weight = &g[edge_idx];
         if !weight.participates_in_scc() {
             continue;
         }
-        let Some((u, v)) = graph.graph.edge_endpoints(edge_idx) else {
+        let Some((u, v)) = g.edge_endpoints(edge_idx) else {
             continue;
         };
-        let Some(src_fid) = node_to_file_id(&graph.graph[u]) else {
+        let Some(src_fid) = node_to_file_id(&g[u]) else {
             continue;
         };
-        let Some(dst_fid) = node_to_file_id(&graph.graph[v]) else {
+        let Some(dst_fid) = node_to_file_id(&g[v]) else {
             continue;
         };
         // Only edges where both endpoints are in this pod.
@@ -203,7 +205,7 @@ pub fn find_oversized_pod_cut(pod: &Pod, graph: &CodeGraph, max_size: usize) -> 
 mod tests {
     use super::*;
     use crate::deploy::pod::partition_into_pods;
-    use crate::graph::edge::{EdgeData, EdgeKind};
+    use crate::graph::edge::EdgeKind;
     use crate::graph::node::{FileNode, NodeData};
     use crate::graph::scc::SccAnalysis;
     use crate::language::LangId;
@@ -220,7 +222,7 @@ mod tests {
         let mut fids = Vec::with_capacity(n);
         for i in 0..n {
             let id = FileId::new(i as u32 + 1).unwrap();
-            let idx = graph.graph.add_node(NodeData::File(FileNode::new(
+            let idx = graph.add_node(NodeData::File(FileNode::new(
                 id,
                 PathBuf::from(format!("f{i}.py")),
                 LangId::Python,
@@ -231,19 +233,20 @@ mod tests {
         }
 
         let idx_of = |fid: FileId| -> NodeIndex { *graph.file_to_index.get(&fid).unwrap() };
+        let weak_edge = if n >= 2 {
+            Some((idx_of(fids[0]), idx_of(fids[n - 1])))
+        } else {
+            None
+        };
+        let mut link_edges: Vec<(NodeIndex, NodeIndex)> = Vec::new();
         for i in 0..n.saturating_sub(1) {
-            graph.graph.add_edge(
-                idx_of(fids[i]),
-                idx_of(fids[i + 1]),
-                EdgeData::new(EdgeKind::Import),
-            );
+            link_edges.push((idx_of(fids[i]), idx_of(fids[i + 1])));
         }
-        if n >= 2 {
-            graph.graph.add_edge(
-                idx_of(fids[0]),
-                idx_of(fids[n - 1]),
-                EdgeData::with_confidence(EdgeKind::Import, 0.3),
-            );
+        for (src, dst) in &link_edges {
+            graph.add_edge_normalized(*src, *dst, EdgeKind::Import, 1.0);
+        }
+        if let Some((src, dst)) = weak_edge {
+            graph.add_edge_normalized(src, dst, EdgeKind::Import, 0.3);
         }
 
         let pod = Pod {
@@ -285,13 +288,13 @@ mod tests {
         let mut graph = CodeGraph::new(SnapshotId::new(1).unwrap());
         let py_id = FileId::new(1).unwrap();
         let go_id = FileId::new(2).unwrap();
-        let py_idx = graph.graph.add_node(NodeData::File(FileNode::new(
+        let py_idx = graph.add_node(NodeData::File(FileNode::new(
             py_id,
             PathBuf::from("orch.py"),
             LangId::Python,
             SnapshotId::new(1).unwrap(),
         )));
-        let go_idx = graph.graph.add_node(NodeData::File(FileNode::new(
+        let go_idx = graph.add_node(NodeData::File(FileNode::new(
             go_id,
             PathBuf::from("auth.go"),
             LangId::Go,
@@ -300,17 +303,13 @@ mod tests {
         graph.file_to_index.insert(py_id, py_idx);
         graph.file_to_index.insert(go_id, go_idx);
 
-        graph
-            .graph
-            .add_edge(py_idx, go_idx, EdgeData::new(EdgeKind::Import));
-        graph
-            .graph
-            .add_edge(go_idx, py_idx, EdgeData::new(EdgeKind::Import));
+        graph.add_edge_normalized(py_idx, go_idx, EdgeKind::Import, 1.0);
+        graph.add_edge_normalized(go_idx, py_idx, EdgeKind::Import, 1.0);
 
-        let scc = SccAnalysis::analyze(&graph.graph);
+        let scc = SccAnalysis::analyze(graph.graph());
         let mut file_languages: HashMap<FileId, LangId> = HashMap::new();
         for (&fid, &idx) in &graph.file_to_index {
-            if let NodeData::File(f) = &graph.graph[idx] {
+            if let NodeData::File(f) = &graph.graph()[idx] {
                 file_languages.insert(fid, f.language);
             }
         }

--- a/src/deploy/cut.rs
+++ b/src/deploy/cut.rs
@@ -233,6 +233,8 @@ mod tests {
         }
 
         let idx_of = |fid: FileId| -> NodeIndex { *graph.file_to_index.get(&fid).unwrap() };
+        // Precompute edge endpoints first: idx_of borrows graph immutably
+        // and cannot coexist with the &mut graph of add_edge_normalized.
         let weak_edge = if n >= 2 {
             Some((idx_of(fids[0]), idx_of(fids[n - 1])))
         } else {

--- a/src/deploy/dependency.rs
+++ b/src/deploy/dependency.rs
@@ -59,17 +59,19 @@ pub fn resolve_dependencies(
         }
     }
 
-    for edge_idx in graph.graph.edge_indices() {
-        let weight = &graph.graph[edge_idx];
+    let g = graph.graph();
+
+    for edge_idx in g.edge_indices() {
+        let weight = &g[edge_idx];
         if weight.kind != crate::graph::EdgeKind::Import {
             continue;
         }
-        let Some((src, dst)) = graph.graph.edge_endpoints(edge_idx) else {
+        let Some((src, dst)) = g.edge_endpoints(edge_idx) else {
             continue;
         };
 
         // Source must be a file in a known pod.
-        let src_fid = match &graph.graph[src] {
+        let src_fid = match &g[src] {
             crate::graph::NodeData::File(f) => f.id,
             crate::graph::NodeData::Symbol(s) => s.file_id,
             _ => continue,
@@ -79,7 +81,7 @@ pub fn resolve_dependencies(
         };
 
         // Target must be an ExternalNode.
-        let ext = match &graph.graph[dst] {
+        let ext = match &g[dst] {
             crate::graph::NodeData::External(e) => e,
             _ => continue,
         };

--- a/src/deploy/mesh.rs
+++ b/src/deploy/mesh.rs
@@ -68,6 +68,7 @@ pub fn generate_mesh_annotation(
     // (e.g. a metacall_load_from_file call site) so they resolve to a real
     // unit instead of a skipped component index.
     let mut file_to_unit: HashMap<String, usize> = HashMap::new();
+    let g = analysis.graph.graph();
 
     for (idx, scc) in analysis.scc.components.iter().enumerate() {
         let mut symbols = Vec::new();
@@ -75,7 +76,7 @@ pub fn generate_mesh_annotation(
         let mut has_real_node = false;
 
         for &node_idx in &scc.nodes {
-            let node_data = &analysis.graph.graph[node_idx];
+            let node_data = &g[node_idx];
             match node_data {
                 NodeData::Symbol(sym) => {
                     has_real_node = true;
@@ -84,7 +85,7 @@ pub fn generate_mesh_annotation(
                             .graph
                             .file_to_index
                             .get(&sym.file_id)
-                            .and_then(|&f_idx| match &analysis.graph.graph[f_idx] {
+                            .and_then(|&f_idx| match &g[f_idx] {
                                 NodeData::File(f) => Some(f),
                                 _ => None,
                             });
@@ -173,7 +174,7 @@ pub fn generate_mesh_annotation(
     let mut file_to_component: HashMap<String, usize> = HashMap::new();
     for (idx, scc) in analysis.scc.components.iter().enumerate() {
         for &node_idx in &scc.nodes {
-            if let NodeData::File(f) = &analysis.graph.graph[node_idx] {
+            if let NodeData::File(f) = &g[node_idx] {
                 let path_str = f.path.to_string_lossy().replace('\\', "/");
                 file_to_component.insert(path_str, idx);
             }
@@ -189,7 +190,7 @@ pub fn generate_mesh_annotation(
             return Some(uid);
         }
         for &node_idx in &analysis.scc.components[comp].nodes {
-            if let NodeData::File(f) = &analysis.graph.graph[node_idx] {
+            if let NodeData::File(f) = &g[node_idx] {
                 let path_str = f.path.to_string_lossy().replace('\\', "/");
                 if let Some(&uid) = file_to_unit.get(&path_str) {
                     return Some(uid);
@@ -201,13 +202,13 @@ pub fn generate_mesh_annotation(
 
     // Detect cross-language edges from graph, annotated with call-site info.
     let mut seen_edges: HashSet<(usize, usize, &str, &str)> = HashSet::new();
-    for edge_idx in analysis.graph.graph.edge_indices() {
-        let weight = &analysis.graph.graph[edge_idx];
+    for edge_idx in g.edge_indices() {
+        let weight = &g[edge_idx];
         if weight.kind == EdgeKind::Ownership {
             continue;
         }
 
-        let Some((u, v)) = analysis.graph.graph.edge_endpoints(edge_idx) else {
+        let Some((u, v)) = g.edge_endpoints(edge_idx) else {
             continue;
         };
         let (Some(u_comp), Some(v_comp)) =
@@ -217,8 +218,8 @@ pub fn generate_mesh_annotation(
         };
 
         if u_comp != v_comp {
-            let u_lang = get_node_language(&analysis.graph.graph[u], &analysis.graph);
-            let v_lang = get_node_language(&analysis.graph.graph[v], &analysis.graph);
+            let u_lang = get_node_language(&g[u], &analysis.graph);
+            let v_lang = get_node_language(&g[v], &analysis.graph);
 
             // Remap raw SCC indices to emitted unit ids. Edges whose
             // endpoints are skipped components anchor to the unit owning their
@@ -241,7 +242,7 @@ pub fn generate_mesh_annotation(
                 // the edge targets a symbol, prefer a ClientCall site that
                 // names that exact function; otherwise fall back to the load
                 // attribution below.
-                let client_call_site = match &analysis.graph.graph[v] {
+                let client_call_site = match &g[v] {
                     NodeData::Symbol(sym) => call_sites.iter().find_map(|site| {
                         let site_path = site.source_file.to_string_lossy().replace('\\', "/");
                         if file_to_component.get(&site_path) != Some(&u_comp) {
@@ -271,7 +272,7 @@ pub fn generate_mesh_annotation(
                         });
                         if site_target_lang == Some(v_lang) {
                             Some(site_path)
-                        } else if let NodeData::File(dst_file) = &analysis.graph.graph[v] {
+                        } else if let NodeData::File(dst_file) = &g[v] {
                             let dst_name = dst_file
                                 .path
                                 .file_name()
@@ -324,7 +325,7 @@ fn get_node_language<'a>(node: &'a NodeData, graph: &'a crate::graph::CodeGraph)
     match node {
         NodeData::Symbol(s) => {
             if let Some(&f_idx) = graph.file_to_index.get(&s.file_id)
-                && let NodeData::File(f) = &graph.graph[f_idx]
+                && let NodeData::File(f) = &graph.graph()[f_idx]
             {
                 return crate::deploy::tags::metacall_tag(f.language);
             }

--- a/src/deploy/metrics.rs
+++ b/src/deploy/metrics.rs
@@ -60,7 +60,7 @@ pub fn compute_pod_metrics(
     // Build a reverse mapping from FileId -> Path using the graph's file nodes.
     let mut fid_to_path: HashMap<FileId, PathBuf> = HashMap::new();
     for (&fid, &idx) in &graph.file_to_index {
-        if let Some(NodeData::File(f)) = graph.graph.node_weight(idx) {
+        if let Some(NodeData::File(f)) = graph.graph().node_weight(idx) {
             fid_to_path.insert(fid, f.path.clone());
         }
     }

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -21,6 +21,7 @@ pub struct DeployConfig {
     pub out: PathBuf,
     pub format: OutputFormat,
     pub check: bool,
+    pub max_pod_size: usize,
 }
 
 pub fn run_deploy(config: DeployConfig) -> anyhow::Result<()> {
@@ -28,6 +29,9 @@ pub fn run_deploy(config: DeployConfig) -> anyhow::Result<()> {
     tracing::info!("Root path: {}", config.root.display());
     tracing::info!("Output path: {}", config.out.display());
     tracing::info!("Check mode: {}", config.check);
+    if config.max_pod_size == 0 {
+        anyhow::bail!("max_pod_size must be at least 1");
+    }
 
     // 1. Run full pipeline graph analysis (covers extraction + SCC)
     let snapshot_id = crate::model::SnapshotId::new(1).unwrap();
@@ -169,9 +173,7 @@ pub fn run_deploy(config: DeployConfig) -> anyhow::Result<()> {
 
     // 10. Rebalance oversized pods
     for pod in &partition.pods {
-        if let Some(cut) =
-            cut::find_oversized_pod_cut(pod, &analysis.graph, cut::DEFAULT_MAX_POD_SIZE)
-        {
+        if let Some(cut) = cut::find_oversized_pod_cut(pod, &analysis.graph, config.max_pod_size) {
             all_cuts.push(cut);
         }
     }

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -50,8 +50,9 @@ pub fn run_deploy(config: DeployConfig) -> anyhow::Result<()> {
 
     // 4. Build path-to-node-index lookup once
     let mut path_to_idx: HashMap<PathBuf, petgraph::graph::NodeIndex> = HashMap::new();
-    for idx in analysis.graph.graph().node_indices() {
-        if let crate::graph::node::NodeData::File(f) = &analysis.graph.graph()[idx] {
+    let g = analysis.graph.graph();
+    for idx in g.node_indices() {
+        if let crate::graph::node::NodeData::File(f) = &g[idx] {
             path_to_idx.insert(f.path.clone(), idx);
         }
     }

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -32,7 +32,7 @@ pub fn run_deploy(config: DeployConfig) -> anyhow::Result<()> {
     // 1. Run full pipeline graph analysis (covers extraction + SCC)
     let snapshot_id = crate::model::SnapshotId::new(1).unwrap();
     let (mut analysis, mut diagnostics) =
-        crate::pipeline::analyze_graph(&config.root, snapshot_id)?;
+        crate::pipeline::analyze_graph(&config.root, snapshot_id, None)?;
 
     // 2. Collect MetaCall call sites from pipeline extractions (zero duplicate
     // I/O / parsing for the source scan; configuration JSONs referenced by

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -50,8 +50,8 @@ pub fn run_deploy(config: DeployConfig) -> anyhow::Result<()> {
 
     // 4. Build path-to-node-index lookup once
     let mut path_to_idx: HashMap<PathBuf, petgraph::graph::NodeIndex> = HashMap::new();
-    for idx in analysis.graph.graph.node_indices() {
-        if let crate::graph::node::NodeData::File(f) = &analysis.graph.graph[idx] {
+    for idx in analysis.graph.graph().node_indices() {
+        if let crate::graph::node::NodeData::File(f) = &analysis.graph.graph()[idx] {
             path_to_idx.insert(f.path.clone(), idx);
         }
     }
@@ -151,7 +151,7 @@ pub fn run_deploy(config: DeployConfig) -> anyhow::Result<()> {
         );
     }
 
-    analysis.scc = crate::graph::scc::SccAnalysis::analyze(&analysis.graph.graph);
+    analysis.scc = crate::graph::scc::SccAnalysis::analyze(analysis.graph.graph());
 
     // 7. Pod partitioning
     let partition = pod::partition_into_pods(&analysis.graph);
@@ -291,7 +291,7 @@ fn add_metacall_edge(
 ) {
     let graph = &mut analysis.graph;
 
-    let source_file = match &graph.graph[from_idx] {
+    let source_file = match &graph.graph()[from_idx] {
         crate::graph::node::NodeData::File(f) => f.path.clone(),
         _ => return,
     };

--- a/src/deploy/pod.rs
+++ b/src/deploy/pod.rs
@@ -96,22 +96,23 @@ pub fn partition_into_pods(graph: &CodeGraph) -> PodPartition {
     // Union same-language Import+Reference edges.
     let n = file_ids.len();
     let mut uf = UnionFind::new(n);
+    let g = graph.graph();
 
-    for edge_idx in graph.graph.edge_indices() {
-        let weight = &graph.graph[edge_idx];
+    for edge_idx in g.edge_indices() {
+        let weight = &g[edge_idx];
         if !weight.participates_in_scc() {
             // Ownership edges are excluded - same rule as SCC analysis.
             continue;
         }
 
-        let Some((u, v)) = graph.graph.edge_endpoints(edge_idx) else {
+        let Some((u, v)) = g.edge_endpoints(edge_idx) else {
             continue;
         };
 
-        let Some(src_fid) = node_to_file_id(&graph.graph[u]) else {
+        let Some(src_fid) = node_to_file_id(&g[u]) else {
             continue;
         };
-        let Some(dst_fid) = node_to_file_id(&graph.graph[v]) else {
+        let Some(dst_fid) = node_to_file_id(&g[v]) else {
             continue;
         };
 
@@ -163,18 +164,18 @@ pub fn partition_into_pods(graph: &CodeGraph) -> PodPartition {
     // exists.
     let mut client_call_edges: Vec<InterPodEdge> = Vec::new();
 
-    for edge_idx in graph.graph.edge_indices() {
-        let weight = graph.graph[edge_idx];
+    for edge_idx in g.edge_indices() {
+        let weight = g[edge_idx];
         if !weight.participates_in_scc() {
             continue;
         }
-        let Some((u, v)) = graph.graph.edge_endpoints(edge_idx) else {
+        let Some((u, v)) = g.edge_endpoints(edge_idx) else {
             continue;
         };
-        let Some(src_fid) = node_to_file_id(&graph.graph[u]) else {
+        let Some(src_fid) = node_to_file_id(&g[u]) else {
             continue;
         };
-        let Some(dst_fid) = node_to_file_id(&graph.graph[v]) else {
+        let Some(dst_fid) = node_to_file_id(&g[v]) else {
             continue;
         };
 
@@ -192,7 +193,7 @@ pub fn partition_into_pods(graph: &CodeGraph) -> PodPartition {
 
         // Scope-resolution references are always symbol -> symbol; a
         // file -> symbol Reference edge can only be an injected client call.
-        if weight.kind == EdgeKind::Reference && matches!(graph.graph[u], NodeData::File(_)) {
+        if weight.kind == EdgeKind::Reference && matches!(g[u], NodeData::File(_)) {
             client_call_edges.push(InterPodEdge {
                 from_pod: src_pod,
                 to_pod: dst_pod,
@@ -285,7 +286,6 @@ pub fn partition_into_pods(graph: &CodeGraph) -> PodPartition {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::graph::edge::EdgeData;
     use crate::graph::node::FileNode;
     use crate::model::ids::SnapshotId;
     use std::path::PathBuf;
@@ -304,7 +304,7 @@ mod tests {
             (a_js, "a.js", LangId::JavaScript),
             (b_py, "b.py", LangId::Python),
         ] {
-            let idx = graph.graph.add_node(NodeData::File(FileNode::new(
+            let idx = graph.add_node(NodeData::File(FileNode::new(
                 fid,
                 PathBuf::from(path),
                 lang,
@@ -314,10 +314,11 @@ mod tests {
         }
 
         // Cross-language import edge: c.py -> a.js becomes an inter-pod edge.
-        graph.graph.add_edge(
+        graph.add_edge_normalized(
             graph.file_to_index[&c_py],
             graph.file_to_index[&a_js],
-            EdgeData::new(EdgeKind::Import),
+            EdgeKind::Import,
+            1.0,
         );
 
         let partition = partition_into_pods(&graph);

--- a/src/graph/builder.rs
+++ b/src/graph/builder.rs
@@ -536,7 +536,7 @@ impl GraphBuilder {
 
         // Finalize and compute SCC
         let graph = builder.build();
-        let scc = crate::graph::SccAnalysis::analyze(&graph.graph);
+        let scc = crate::graph::SccAnalysis::analyze(graph.graph());
 
         (graph, scc)
     }

--- a/src/graph/builder.rs
+++ b/src/graph/builder.rs
@@ -249,52 +249,6 @@ impl GraphBuilder {
         self.add_edge_internal(from_idx, to_idx, EdgeKind::Import, 1.0);
     }
 
-    /// Adds a MetaCall load edge between files.
-    pub fn add_metacall_load(
-        &mut self,
-        from_path: PathBuf,
-        target_lang: LangId,
-        scripts: &[String],
-        confidence: f64,
-        root: &std::path::Path,
-    ) {
-        let Some(&from_fid) = self.path_to_file.get(&from_path) else {
-            return;
-        };
-        let Some(&from_idx) = self.file_to_index.get(&from_fid) else {
-            return;
-        };
-
-        for script in scripts {
-            let target_path = root.join(script);
-            // Resolve to FileId if it exists
-            if let Some(&to_fid) = self.path_to_file.get(&target_path) {
-                if let Some(&to_idx) = self.file_to_index.get(&to_fid) {
-                    let edge_data = EdgeData::with_confidence(EdgeKind::Import, confidence as f32);
-                    self.graph.add_edge(from_idx, to_idx, edge_data);
-                }
-            } else {
-                // External or not discovered
-                let raw_path = script.clone();
-                if let Some(&to_idx) = self.external_index.get(&raw_path) {
-                    let edge_data = EdgeData::with_confidence(EdgeKind::Import, confidence as f32);
-                    self.graph.add_edge(from_idx, to_idx, edge_data);
-                } else {
-                    let node = ExternalNode {
-                        raw_path: raw_path.clone(),
-                        language: target_lang,
-                        classification: None,
-                    };
-                    let idx = self.graph.add_node(NodeData::External(node));
-                    self.external_index.insert(raw_path, idx);
-
-                    let edge_data = EdgeData::with_confidence(EdgeKind::Import, confidence as f32);
-                    self.graph.add_edge(from_idx, idx, edge_data);
-                }
-            }
-        }
-    }
-
     /// Internal edge addition with flow kind, respecting normalization.
     #[cfg(feature = "dataflow")]
     fn add_edge_internal_with_flow(

--- a/src/graph/builder.rs
+++ b/src/graph/builder.rs
@@ -395,8 +395,17 @@ impl GraphBuilder {
 
     /// Finalizes the graph and returns the constructed CodeGraph.
     pub fn build(self) -> CodeGraph {
+        let edge_index = self
+            .graph
+            .edge_indices()
+            .map(|e| {
+                let (s, t) = self.graph.edge_endpoints(e).expect("edge endpoints exist");
+                ((s, t, self.graph[e].kind), e)
+            })
+            .collect();
         CodeGraph {
             graph: self.graph,
+            edge_index,
             file_to_index: self.file_to_index,
             symbol_to_index: self.symbol_to_index,
             external_index: self.external_index,

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -27,7 +27,7 @@
 //! let graph = builder.build();
 //!
 //! // Run SCC analysis
-//! let scc = SccAnalysis::analyze(&graph.graph);
+//! let scc = SccAnalysis::analyze(graph.graph());
 //! ```
 
 pub mod builder;
@@ -53,7 +53,7 @@ use petgraph::graph::{DiGraph, NodeIndex};
 #[derive(Debug, Clone)]
 pub struct CodeGraph {
     /// The underlying petgraph with our node/edge data types.
-    pub graph: DiGraph<NodeData, EdgeData>,
+    graph: DiGraph<NodeData, EdgeData>,
 
     /// Map from FileId to graph node index for O(1) lookup.
     pub(crate) file_to_index: HashMap<FileId, NodeIndex>,
@@ -78,6 +78,18 @@ impl CodeGraph {
             external_index: HashMap::new(),
             snapshot_id,
         }
+    }
+    /// Immutable access to the underlying petgraph graph for SCC analysis,
+    /// serialization, and deploy algorithms.
+    pub fn graph(&self) -> &DiGraph<NodeData, EdgeData> {
+        &self.graph
+    }
+
+    /// Adds a raw node to the graph. Node additions do not affect edge
+    /// normalization, so this is the only direct mutation needed by
+    /// deploy/test code that injects synthetic nodes post-build.
+    pub fn add_node(&mut self, node: NodeData) -> NodeIndex {
+        self.graph.add_node(node)
     }
     pub fn file_node_index(&self, file_id: FileId) -> Option<NodeIndex> {
         self.file_to_index.get(&file_id).copied()
@@ -346,13 +358,13 @@ mod tests {
     #[test]
     fn add_edge_normalized_handles_multiple_edge_kinds_between_same_nodes() {
         let mut graph = CodeGraph::new(SnapshotId::new(1).unwrap());
-        let n1 = graph.graph.add_node(NodeData::File(FileNode {
+        let n1 = graph.add_node(NodeData::File(FileNode {
             id: FileId::new(1).unwrap(),
             path: PathBuf::from("a.rs"),
             language: LangId::Rust,
             snapshot_id: SnapshotId::new(1).unwrap(),
         }));
-        let n2 = graph.graph.add_node(NodeData::File(FileNode {
+        let n2 = graph.add_node(NodeData::File(FileNode {
             id: FileId::new(2).unwrap(),
             path: PathBuf::from("b.rs"),
             language: LangId::Rust,
@@ -367,7 +379,7 @@ mod tests {
         graph.add_edge_normalized(n1, n2, EdgeKind::Reference, 0.9);
 
         let ref_count = graph
-            .graph
+            .graph()
             .edges_connecting(n1, n2)
             .filter(|e| e.weight().kind == EdgeKind::Reference)
             .count();
@@ -382,7 +394,7 @@ mod tests {
     fn add_edge_normalized_with_flow_preserves_first_flow_kind() {
         use crate::model::{DataNodeId, DataScope, FlowKind};
         let mut graph = CodeGraph::new(SnapshotId::new(1).unwrap());
-        let n1 = graph.graph.add_node(NodeData::Data(DataGraphNode {
+        let n1 = graph.add_node(NodeData::Data(DataGraphNode {
             id: DataNodeId::new(1).unwrap(),
             symbol_id: None,
             name: Some("x".into()),
@@ -390,7 +402,7 @@ mod tests {
             type_hint: None,
             source_range: test_range(),
         }));
-        let n2 = graph.graph.add_node(NodeData::Data(DataGraphNode {
+        let n2 = graph.add_node(NodeData::Data(DataGraphNode {
             id: DataNodeId::new(2).unwrap(),
             symbol_id: None,
             name: Some("y".into()),
@@ -403,7 +415,7 @@ mod tests {
         graph.add_edge_normalized_with_flow(n1, n2, EdgeKind::Flow, 0.8, Some(FlowKind::Argument));
 
         assert_eq!(graph.edge_count(), 1);
-        let edge = graph.graph.edges_connecting(n1, n2).next().unwrap();
+        let edge = graph.graph().edges_connecting(n1, n2).next().unwrap();
         assert_eq!(edge.weight().flow_kind, Some(FlowKind::DefUse));
         assert_eq!(edge.weight().confidence, 0.9);
     }

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -160,7 +160,8 @@ impl CodeGraph {
     ) {
         let key = (source, target, kind);
         if let Some(&edge_idx) = self.edge_index.get(&key) {
-            self.graph[edge_idx].confidence = self.graph[edge_idx].confidence.max(confidence);
+            let edge = &mut self.graph[edge_idx];
+            edge.confidence = edge.confidence.max(confidence);
             return;
         }
         let edge_idx = self.graph.add_edge(
@@ -189,9 +190,10 @@ impl CodeGraph {
     ) {
         let key = (source, target, kind);
         if let Some(&edge_idx) = self.edge_index.get(&key) {
-            self.graph[edge_idx].confidence = self.graph[edge_idx].confidence.max(confidence);
-            if self.graph[edge_idx].flow_kind.is_none() {
-                self.graph[edge_idx].flow_kind = flow_kind;
+            let edge = &mut self.graph[edge_idx];
+            edge.confidence = edge.confidence.max(confidence);
+            if edge.flow_kind.is_none() {
+                edge.flow_kind = flow_kind;
             }
             return;
         }
@@ -372,20 +374,32 @@ mod tests {
     }
 
     #[test]
+    fn build_populated_edge_index_normalizes_post_build_edges() {
+        let mut builder = GraphBuilder::new(SnapshotId::new(1).unwrap());
+        let file_a = builder.add_file(PathBuf::from("a.rs"), LangId::Rust);
+        let file_b = builder.add_file(PathBuf::from("b.rs"), LangId::Rust);
+        builder.add_import(file_a, PathBuf::from("b.rs"));
+        let mut graph = builder.build();
+        assert_eq!(graph.edge_count(), 1);
+
+        let a_idx = graph.file_node_index(file_a).unwrap();
+        let b_idx = graph.file_node_index(file_b).unwrap();
+
+        // Duplicate triple already indexed by build(): must max-merge, not grow.
+        graph.add_edge_normalized(a_idx, b_idx, EdgeKind::Import, 0.5);
+        graph.add_edge_normalized(a_idx, b_idx, EdgeKind::Import, 0.8);
+        assert_eq!(graph.edge_count(), 1);
+
+        // Distinct kind on the same pair is a new edge.
+        graph.add_edge_normalized(a_idx, b_idx, EdgeKind::Reference, 0.9);
+        assert_eq!(graph.edge_count(), 2);
+    }
+
+    #[test]
     fn add_edge_normalized_handles_multiple_edge_kinds_between_same_nodes() {
         let mut graph = CodeGraph::new(SnapshotId::new(1).unwrap());
-        let n1 = graph.add_node(NodeData::File(FileNode {
-            id: FileId::new(1).unwrap(),
-            path: PathBuf::from("a.rs"),
-            language: LangId::Rust,
-            snapshot_id: SnapshotId::new(1).unwrap(),
-        }));
-        let n2 = graph.add_node(NodeData::File(FileNode {
-            id: FileId::new(2).unwrap(),
-            path: PathBuf::from("b.rs"),
-            language: LangId::Rust,
-            snapshot_id: SnapshotId::new(1).unwrap(),
-        }));
+        let n1 = graph.add_node(test_file_node(1, "a.rs"));
+        let n2 = graph.add_node(test_file_node(2, "b.rs"));
 
         // 1. Add Reference edge with confidence 0.7
         graph.add_edge_normalized(n1, n2, EdgeKind::Reference, 0.7);

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -88,6 +88,11 @@ impl CodeGraph {
     /// Adds a raw node to the graph. Node additions do not affect edge
     /// normalization, so this is the only direct mutation needed by
     /// deploy/test code that injects synthetic nodes post-build.
+    ///
+    /// The caller remains responsible for registering the node in the
+    /// index maps (`file_to_index`, `symbol_to_index`, `external_index`)
+    /// when it is a `File`/`Symbol`/`External` node. This method does not
+    /// sync those maps; a bare `Data` node needs no registration.
     pub fn add_node(&mut self, node: NodeData) -> NodeIndex {
         self.graph.add_node(node)
     }

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -47,13 +47,18 @@ pub use scc::{DeployabilityHint, Scc, SccAnalysis};
 
 use crate::language::LangId;
 use crate::model::{FileId, SnapshotId, SymbolId};
-use petgraph::graph::{DiGraph, NodeIndex};
+use petgraph::graph::{DiGraph, EdgeIndex, NodeIndex};
 
 /// The canonical dependency graph for a codebase snapshot.
 #[derive(Debug, Clone)]
 pub struct CodeGraph {
     /// The underlying petgraph with our node/edge data types.
     graph: DiGraph<NodeData, EdgeData>,
+
+    /// O(1) dedup index: (source, target, kind) -> EdgeIndex, kept in sync
+    /// with `graph`. Every edge added through the normalized-add methods is
+    /// registered here; the builder populates it in `GraphBuilder::build`.
+    edge_index: HashMap<(NodeIndex, NodeIndex, EdgeKind), EdgeIndex>,
 
     /// Map from FileId to graph node index for O(1) lookup.
     pub(crate) file_to_index: HashMap<FileId, NodeIndex>,
@@ -73,6 +78,7 @@ impl CodeGraph {
     pub fn new(snapshot_id: SnapshotId) -> Self {
         Self {
             graph: DiGraph::new(),
+            edge_index: HashMap::new(),
             file_to_index: HashMap::new(),
             symbol_to_index: HashMap::new(),
             external_index: HashMap::new(),
@@ -144,6 +150,7 @@ impl CodeGraph {
     }
     /// Adds an edge, normalizing duplicate `(src, dst, kind)` triples by max-merging
     /// confidence so injected edges obey the same invariant as builder-constructed ones.
+    /// The O(1) `edge_index` makes duplicate detection independent of out-degree.
     pub fn add_edge_normalized(
         &mut self,
         source: NodeIndex,
@@ -151,16 +158,12 @@ impl CodeGraph {
         kind: EdgeKind,
         confidence: f32,
     ) {
-        let mut edge_idx = self.graph.first_edge(source, petgraph::Direction::Outgoing);
-        while let Some(e) = edge_idx {
-            let (_src, dst) = self.graph.edge_endpoints(e).unwrap();
-            if dst == target && self.graph[e].kind == kind {
-                self.graph[e].confidence = self.graph[e].confidence.max(confidence);
-                return;
-            }
-            edge_idx = self.graph.next_edge(e, petgraph::Direction::Outgoing);
+        let key = (source, target, kind);
+        if let Some(&edge_idx) = self.edge_index.get(&key) {
+            self.graph[edge_idx].confidence = self.graph[edge_idx].confidence.max(confidence);
+            return;
         }
-        self.graph.add_edge(
+        let edge_idx = self.graph.add_edge(
             source,
             target,
             EdgeData {
@@ -169,11 +172,13 @@ impl CodeGraph {
                 flow_kind: None,
             },
         );
+        self.edge_index.insert(key, edge_idx);
     }
 
     /// Adds a Flow edge with a specific flow kind, normalizing duplicates by
     /// max-merging confidence (same (src, dst, Flow) triple). When a duplicate
-    /// edge exists, the first non-None `flow_kind` is preserved.
+    /// edge exists, the first non-None `flow_kind` is preserved. The lookup is
+    /// O(1) via the dedup index.
     pub fn add_edge_normalized_with_flow(
         &mut self,
         source: NodeIndex,
@@ -182,19 +187,15 @@ impl CodeGraph {
         confidence: f32,
         flow_kind: Option<crate::model::FlowKind>,
     ) {
-        let mut edge_idx = self.graph.first_edge(source, petgraph::Direction::Outgoing);
-        while let Some(e) = edge_idx {
-            let (_src, dst) = self.graph.edge_endpoints(e).unwrap();
-            if dst == target && self.graph[e].kind == kind {
-                self.graph[e].confidence = self.graph[e].confidence.max(confidence);
-                if self.graph[e].flow_kind.is_none() {
-                    self.graph[e].flow_kind = flow_kind;
-                }
-                return;
+        let key = (source, target, kind);
+        if let Some(&edge_idx) = self.edge_index.get(&key) {
+            self.graph[edge_idx].confidence = self.graph[edge_idx].confidence.max(confidence);
+            if self.graph[edge_idx].flow_kind.is_none() {
+                self.graph[edge_idx].flow_kind = flow_kind;
             }
-            edge_idx = self.graph.next_edge(e, petgraph::Direction::Outgoing);
+            return;
         }
-        self.graph.add_edge(
+        let edge_idx = self.graph.add_edge(
             source,
             target,
             EdgeData {
@@ -203,6 +204,7 @@ impl CodeGraph {
                 flow_kind,
             },
         );
+        self.edge_index.insert(key, edge_idx);
     }
 
     pub fn files(&self) -> impl Iterator<Item = (FileId, &FileNode)> + '_ {
@@ -252,6 +254,15 @@ mod tests {
                 column: 10,
             },
         }
+    }
+
+    fn test_file_node(id: u32, path: &str) -> NodeData {
+        NodeData::File(FileNode {
+            id: FileId::new(id).unwrap(),
+            path: PathBuf::from(path),
+            language: LangId::Rust,
+            snapshot_id: SnapshotId::new(1).unwrap(),
+        })
     }
 
     fn test_symbol(id: u32, name: &str) -> Symbol {
@@ -423,5 +434,36 @@ mod tests {
         let edge = graph.graph().edges_connecting(n1, n2).next().unwrap();
         assert_eq!(edge.weight().flow_kind, Some(FlowKind::DefUse));
         assert_eq!(edge.weight().confidence, 0.9);
+    }
+
+    #[test]
+    fn add_edge_normalized_duplicate_never_grows_edge_count() {
+        let mut graph = CodeGraph::new(SnapshotId::new(1).unwrap());
+        let n1 = graph.add_node(test_file_node(1, "a.rs"));
+        let n2 = graph.add_node(test_file_node(2, "b.rs"));
+
+        graph.add_edge_normalized(n1, n2, EdgeKind::Import, 0.5);
+        for confidence in [0.6, 0.3, 0.9, 0.4, 0.7] {
+            graph.add_edge_normalized(n1, n2, EdgeKind::Import, confidence);
+        }
+
+        assert_eq!(graph.edge_count(), 1);
+        let edge = graph.graph().edges_connecting(n1, n2).next().unwrap();
+        assert_eq!(edge.weight().confidence, 0.9);
+    }
+
+    #[test]
+    fn add_edge_normalized_counts_only_distinct_triples() {
+        let mut graph = CodeGraph::new(SnapshotId::new(1).unwrap());
+        let n1 = graph.add_node(test_file_node(1, "a.rs"));
+        let n2 = graph.add_node(test_file_node(2, "b.rs"));
+        let n3 = graph.add_node(test_file_node(3, "c.rs"));
+
+        graph.add_edge_normalized(n1, n2, EdgeKind::Import, 0.5);
+        graph.add_edge_normalized(n1, n2, EdgeKind::Reference, 0.6);
+        graph.add_edge_normalized(n1, n3, EdgeKind::Reference, 0.7);
+        graph.add_edge_normalized(n1, n2, EdgeKind::Import, 0.9);
+
+        assert_eq!(graph.edge_count(), 3);
     }
 }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -32,7 +32,9 @@ pub fn discover_files(
     let mut results = Vec::new();
 
     if root.is_file() {
-        if let Some(lang_id) = detect_language(root) {
+        if let Some(lang_id) = detect_language(root)
+            && languages.is_none_or(|langs| langs.contains(&lang_id))
+        {
             results.push((root.to_path_buf(), lang_id));
         }
         return Ok(results);
@@ -204,6 +206,17 @@ mod tests {
         let files = discover_files(&path, None).unwrap();
         assert_eq!(files.len(), 1);
         assert_eq!(files[0].1, LangId::Python);
+    }
+
+    #[test]
+    fn discover_single_file_honors_language_filter() {
+        let path = PathBuf::from("tests/fixtures/mixed/app.py");
+        let matching = discover_files(&path, Some(&[LangId::Python])).unwrap();
+        assert_eq!(matching.len(), 1);
+        assert_eq!(matching[0].1, LangId::Python);
+
+        let excluded = discover_files(&path, Some(&[LangId::Go])).unwrap();
+        assert!(excluded.is_empty());
     }
 
     #[test]

--- a/src/interface/args.rs
+++ b/src/interface/args.rs
@@ -123,6 +123,10 @@ pub struct DeployArgs {
     /// Output directory for generated manifests and mesh annotation
     #[arg(short, long, default_value = ".")]
     pub out: std::path::PathBuf,
+
+    /// Maximum number of files in a single pod before rebalancing is triggered
+    #[arg(long, default_value_t = crate::deploy::cut::DEFAULT_MAX_POD_SIZE)]
+    pub max_pod_size: usize,
 }
 
 #[cfg(test)]

--- a/src/interface/args.rs
+++ b/src/interface/args.rs
@@ -41,25 +41,14 @@ fn parse_format(s: &str) -> Result<crate::output::OutputFormat, String> {
 
 fn parse_language(s: &str) -> Result<crate::language::LangId, String> {
     let normalized = s.to_lowercase();
-    let matched = crate::language::LangId::from_str(&normalized)
-        .ok()
-        .or_else(|| {
-            crate::language::LangId::all().into_iter().find(|id| {
-                let name = id.to_string();
-                normalized == name.replace('_', "")
-            })
-        });
-    if let Some(id) = matched {
-        return Ok(id);
-    }
-    let names: Vec<_> = crate::language::LangId::all()
-        .into_iter()
-        .map(|l| l.to_string().replace('_', ""))
-        .collect();
-    Err(format!(
-        "invalid language '{s}': expected one of {}",
-        names.join(", ")
-    ))
+    crate::language::LangId::from_str(&normalized).map_err(|_| {
+        let all = crate::language::LangId::all();
+        let names: Vec<_> = all.iter().map(|l| l.as_ref()).collect();
+        format!(
+            "invalid language '{s}': expected one of {}",
+            names.join(", ")
+        )
+    })
 }
 
 #[derive(Parser)]
@@ -168,9 +157,9 @@ mod tests {
     fn parse_language_invalid_returns_all_names() {
         let err = parse_language("pytho").unwrap_err();
         for id in crate::language::LangId::all() {
-            let name: String = id.to_string().replace('_', "");
+            let name: &str = id.as_ref();
             assert!(
-                err.contains(&name),
+                err.contains(name),
                 "error {err:?} should list the valid name {name:?}"
             );
         }

--- a/src/interface/args.rs
+++ b/src/interface/args.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use clap::Parser;
 
 /// Polyglot static analyzer that builds symbol surfaces and cross-file dependency graphs.
@@ -37,6 +39,29 @@ fn parse_format(s: &str) -> Result<crate::output::OutputFormat, String> {
     }
 }
 
+fn parse_language(s: &str) -> Result<crate::language::LangId, String> {
+    let normalized = s.to_lowercase();
+    let matched = crate::language::LangId::from_str(&normalized)
+        .ok()
+        .or_else(|| {
+            crate::language::LangId::all().into_iter().find(|id| {
+                let name = id.to_string();
+                normalized == name.replace('_', "")
+            })
+        });
+    if let Some(id) = matched {
+        return Ok(id);
+    }
+    let names: Vec<_> = crate::language::LangId::all()
+        .into_iter()
+        .map(|l| l.to_string().replace('_', ""))
+        .collect();
+    Err(format!(
+        "invalid language '{s}': expected one of {}",
+        names.join(", ")
+    ))
+}
+
 #[derive(Parser)]
 pub struct InspectArgs {
     /// Root directory or source file to inspect
@@ -47,8 +72,8 @@ pub struct InspectArgs {
     pub output: Option<std::path::PathBuf>,
 
     /// Override automatic language detection and force a specific language
-    #[arg(short, long)]
-    pub language: Option<String>,
+    #[arg(short, long, value_parser = parse_language)]
+    pub language: Option<crate::language::LangId>,
 
     /// Output format for the extracted symbols
     #[arg(short = 'f', long, default_value = "json", value_parser = parse_format)]
@@ -65,8 +90,8 @@ pub struct GraphArgs {
     pub output: Option<std::path::PathBuf>,
 
     /// Override automatic language detection and force a specific language
-    #[arg(short, long)]
-    pub language: Option<String>,
+    #[arg(short, long, value_parser = parse_language)]
+    pub language: Option<crate::language::LangId>,
 
     /// Output serialization format for the graph structure
     #[arg(short = 'f', long, default_value = "json", value_parser = parse_format)]
@@ -109,4 +134,50 @@ pub struct DeployArgs {
     /// Output directory for generated manifests and mesh annotation
     #[arg(short, long, default_value = ".")]
     pub out: std::path::PathBuf,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_language_valid_lowercase() {
+        assert_eq!(
+            parse_language("python"),
+            Ok(crate::language::LangId::Python)
+        );
+        assert_eq!(
+            parse_language("typescript"),
+            Ok(crate::language::LangId::TypeScript)
+        );
+    }
+
+    #[test]
+    fn parse_language_case_insensitive() {
+        assert_eq!(
+            parse_language("Python"),
+            Ok(crate::language::LangId::Python)
+        );
+        assert_eq!(
+            parse_language("TYPESCRIPT"),
+            Ok(crate::language::LangId::TypeScript)
+        );
+    }
+
+    #[test]
+    fn parse_language_invalid_returns_all_names() {
+        let err = parse_language("pytho").unwrap_err();
+        for id in crate::language::LangId::all() {
+            let name: String = id.to_string().replace('_', "");
+            assert!(
+                err.contains(&name),
+                "error {err:?} should list the valid name {name:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_language_empty_returns_err() {
+        assert!(parse_language("").is_err());
+    }
 }

--- a/src/interface/args.rs
+++ b/src/interface/args.rs
@@ -60,7 +60,7 @@ pub struct InspectArgs {
     #[arg(short, long)]
     pub output: Option<std::path::PathBuf>,
 
-    /// Override automatic language detection and force a specific language
+    /// Only analyze files detected as this language
     #[arg(short, long, value_parser = parse_language)]
     pub language: Option<crate::language::LangId>,
 
@@ -78,7 +78,7 @@ pub struct GraphArgs {
     #[arg(short, long)]
     pub output: Option<std::path::PathBuf>,
 
-    /// Override automatic language detection and force a specific language
+    /// Only analyze files detected as this language
     #[arg(short, long, value_parser = parse_language)]
     pub language: Option<crate::language::LangId>,
 

--- a/src/language/mod.rs
+++ b/src/language/mod.rs
@@ -70,8 +70,10 @@ pub enum DefaultVisibility {
 pub enum LangId {
     Python,
     #[strum(serialize = "javascript")]
+    #[serde(rename = "javascript")]
     JavaScript,
     #[strum(serialize = "typescript")]
+    #[serde(rename = "typescript")]
     TypeScript,
     Tsx,
     C,
@@ -227,6 +229,12 @@ mod tests {
 
         let json = serde_json::to_string(&LangId::Ruby).unwrap();
         assert_eq!(json, "\"ruby\"");
+
+        let json = serde_json::to_string(&LangId::JavaScript).unwrap();
+        assert_eq!(json, "\"javascript\"");
+
+        let json = serde_json::to_string(&LangId::TypeScript).unwrap();
+        assert_eq!(json, "\"typescript\"");
     }
 
     #[test]

--- a/src/language/mod.rs
+++ b/src/language/mod.rs
@@ -51,7 +51,18 @@ pub enum DefaultVisibility {
     PrivateByDefault,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, strum::Display, strum::AsRefStr)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    strum::Display,
+    strum::AsRefStr,
+    strum::EnumString,
+)]
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
@@ -173,6 +184,8 @@ pub fn extract_imports_and_references_for<'a>(
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use super::*;
 
     #[test]
@@ -189,6 +202,16 @@ mod tests {
     fn lang_id_display() {
         assert_eq!(format!("{}", LangId::Python), "python");
         assert_eq!(format!("{}", LangId::Ruby), "ruby");
+    }
+
+    #[test]
+    fn lang_id_from_str_round_trip() {
+        for id in LangId::all() {
+            let name: &str = id.as_ref();
+            let parsed = LangId::from_str(name)
+                .unwrap_or_else(|e| panic!("from_str failed for snake_case name {name:?}: {e}"));
+            assert_eq!(parsed, id);
+        }
     }
 
     #[test]

--- a/src/language/mod.rs
+++ b/src/language/mod.rs
@@ -69,7 +69,9 @@ pub enum DefaultVisibility {
 #[repr(usize)]
 pub enum LangId {
     Python,
+    #[strum(serialize = "javascript")]
     JavaScript,
+    #[strum(serialize = "typescript")]
     TypeScript,
     Tsx,
     C,
@@ -202,6 +204,8 @@ mod tests {
     fn lang_id_display() {
         assert_eq!(format!("{}", LangId::Python), "python");
         assert_eq!(format!("{}", LangId::Ruby), "ruby");
+        assert_eq!(format!("{}", LangId::JavaScript), "javascript");
+        assert_eq!(format!("{}", LangId::TypeScript), "typescript");
     }
 
     #[test]
@@ -209,9 +213,11 @@ mod tests {
         for id in LangId::all() {
             let name: &str = id.as_ref();
             let parsed = LangId::from_str(name)
-                .unwrap_or_else(|e| panic!("from_str failed for snake_case name {name:?}: {e}"));
+                .unwrap_or_else(|e| panic!("from_str failed for documented name {name:?}: {e}"));
             assert_eq!(parsed, id);
         }
+        assert_eq!(LangId::from_str("typescript"), Ok(LangId::TypeScript));
+        assert_eq!(LangId::from_str("javascript"), Ok(LangId::JavaScript));
     }
 
     #[test]

--- a/src/language/mod.rs
+++ b/src/language/mod.rs
@@ -211,6 +211,24 @@ mod tests {
     }
 
     #[test]
+    fn lang_id_vocabulary_is_canonical() {
+        let expected = [
+            "python",
+            "javascript",
+            "typescript",
+            "tsx",
+            "c",
+            "cpp",
+            "rust",
+            "go",
+            "ruby",
+        ];
+        let all = LangId::all();
+        let actual: Vec<&str> = all.iter().map(|l| l.as_ref()).collect();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
     fn lang_id_from_str_round_trip() {
         for id in LangId::all() {
             let name: &str = id.as_ref();

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,10 @@ fn main() -> anyhow::Result<()> {
 
     match cli {
         Cli::Inspect(args) => {
-            let files = meta_ast::input::discover_files(&args.path, None)?;
+            let files = meta_ast::input::discover_files(
+                &args.path,
+                args.language.map(|l| vec![l]).as_deref(),
+            )?;
 
             let result = meta_ast::extractor::extract_with_options(
                 &files,
@@ -63,6 +66,7 @@ fn main() -> anyhow::Result<()> {
                     output: args.output.clone(),
                     html: args.html,
                     open_browser: false,
+                    languages: args.language.map(|l| vec![l]),
                 };
 
                 let output = args.output.clone();
@@ -106,7 +110,11 @@ fn main() -> anyhow::Result<()> {
             }
 
             let snapshot_id = SnapshotId::new(1).unwrap();
-            let (analysis, diags) = meta_ast::pipeline::analyze_graph(&args.path, snapshot_id)?;
+            let (analysis, diags) = meta_ast::pipeline::analyze_graph(
+                &args.path,
+                snapshot_id,
+                args.language.map(|l| vec![l]).as_deref(),
+            )?;
 
             for diag in &diags {
                 tracing::warn!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -178,6 +178,7 @@ fn main() -> anyhow::Result<()> {
                 out: args.out,
                 format: args.format,
                 check: args.check,
+                max_pod_size: args.max_pod_size,
             };
             meta_ast::deploy::run_deploy(config)
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,9 +18,10 @@ fn main() -> anyhow::Result<()> {
 
     match cli {
         Cli::Inspect(args) => {
+            let languages = args.language.map(|l| [l]);
             let files = meta_ast::input::discover_files(
                 &args.path,
-                args.language.map(|l| vec![l]).as_deref(),
+                languages.as_ref().map(|a| a.as_slice()),
             )?;
 
             let result = meta_ast::extractor::extract_with_options(
@@ -110,10 +111,11 @@ fn main() -> anyhow::Result<()> {
             }
 
             let snapshot_id = SnapshotId::new(1).unwrap();
+            let languages = args.language.map(|l| [l]);
             let (analysis, diags) = meta_ast::pipeline::analyze_graph(
                 &args.path,
                 snapshot_id,
-                args.language.map(|l| vec![l]).as_deref(),
+                languages.as_ref().map(|a| a.as_slice()),
             )?;
 
             for diag in &diags {

--- a/src/output/emitter.rs
+++ b/src/output/emitter.rs
@@ -165,7 +165,7 @@ mod tests {
 
         let builder = GraphBuilder::new(SnapshotId::new(1).unwrap());
         let graph = builder.build();
-        let scc = SccAnalysis::analyze(&graph.graph);
+        let scc = SccAnalysis::analyze(graph.graph());
         let analysis = GraphAnalysis {
             graph,
             scc,
@@ -197,7 +197,7 @@ mod tests {
 
         let builder = GraphBuilder::new(SnapshotId::new(1).unwrap());
         let graph = builder.build();
-        let scc = SccAnalysis::analyze(&graph.graph);
+        let scc = SccAnalysis::analyze(graph.graph());
         let analysis = GraphAnalysis {
             graph,
             scc,

--- a/src/output/graph.rs
+++ b/src/output/graph.rs
@@ -167,15 +167,16 @@ impl GraphOutput {
         scc_analysis: Option<&SccAnalysis>,
         snapshot_id: u64,
     ) -> GraphMetadata {
-        let node_count = graph.graph.node_count();
-        let edge_count = graph.graph.edge_count();
+        let g = graph.graph();
+        let node_count = g.node_count();
+        let edge_count = g.edge_count();
         let scc_count = scc_analysis.map_or(0, |s| s.components.len());
 
         let mut file_count = 0;
         let mut symbol_count = 0;
         let mut data_node_count = 0;
 
-        for node_data in graph.graph.node_weights() {
+        for node_data in g.node_weights() {
             match node_data {
                 NodeData::File(_) => file_count += 1,
                 NodeData::Symbol(_) => symbol_count += 1,
@@ -196,11 +197,10 @@ impl GraphOutput {
     }
 
     fn serialize_nodes(graph: &CodeGraph) -> Vec<SerializedNode> {
-        graph
-            .graph
-            .node_indices()
+        let g = graph.graph();
+        g.node_indices()
             .map(|idx| {
-                let node_data = &graph.graph[idx];
+                let node_data = &g[idx];
                 Self::serialize_node(idx.index(), node_data)
             })
             .collect()
@@ -264,12 +264,11 @@ impl GraphOutput {
     }
 
     fn serialize_edges(graph: &CodeGraph) -> Vec<SerializedEdge> {
-        graph
-            .graph
-            .edge_indices()
+        let g = graph.graph();
+        g.edge_indices()
             .filter_map(|edge_idx| {
-                let (source, target) = graph.graph.edge_endpoints(edge_idx)?;
-                let edge_data = graph.graph.edge_weight(edge_idx)?;
+                let (source, target) = g.edge_endpoints(edge_idx)?;
+                let edge_data = g.edge_weight(edge_idx)?;
                 let confidence = if edge_data.confidence < 1.0 {
                     Some(edge_data.confidence)
                 } else {
@@ -465,7 +464,7 @@ mod tests {
             type_hint: Some("u32".into()),
             source_range: sample_source_range(),
         };
-        graph.graph.add_node(NodeData::Data(dnode));
+        graph.add_node(NodeData::Data(dnode));
         let scc = sample_scc_analysis();
 
         let output = GraphOutput::from_graph(&graph, Some(&scc), 1);
@@ -482,7 +481,7 @@ mod tests {
     fn flow_edge_serializes_with_flow_kind() {
         use crate::graph::node::DataGraphNode;
         let mut graph = CodeGraph::new(SnapshotId::new(1).unwrap());
-        let src = graph.graph.add_node(NodeData::Data(DataGraphNode {
+        let src = graph.add_node(NodeData::Data(DataGraphNode {
             id: DataNodeId::new(1).unwrap(),
             symbol_id: None,
             name: Some("x".into()),
@@ -490,7 +489,7 @@ mod tests {
             type_hint: None,
             source_range: sample_source_range(),
         }));
-        let dst = graph.graph.add_node(NodeData::Data(DataGraphNode {
+        let dst = graph.add_node(NodeData::Data(DataGraphNode {
             id: DataNodeId::new(2).unwrap(),
             symbol_id: None,
             name: Some("y".into()),
@@ -518,7 +517,7 @@ mod tests {
     fn flow_edge_without_flow_kind_omits_field() {
         use crate::graph::node::DataGraphNode;
         let mut graph = CodeGraph::new(SnapshotId::new(1).unwrap());
-        let src = graph.graph.add_node(NodeData::Data(DataGraphNode {
+        let src = graph.add_node(NodeData::Data(DataGraphNode {
             id: DataNodeId::new(1).unwrap(),
             symbol_id: None,
             name: Some("a".into()),
@@ -526,7 +525,7 @@ mod tests {
             type_hint: None,
             source_range: sample_source_range(),
         }));
-        let dst = graph.graph.add_node(NodeData::Data(DataGraphNode {
+        let dst = graph.add_node(NodeData::Data(DataGraphNode {
             id: DataNodeId::new(2).unwrap(),
             symbol_id: None,
             name: Some("b".into()),

--- a/src/output/graph.rs
+++ b/src/output/graph.rs
@@ -396,7 +396,30 @@ mod tests {
         assert_eq!(output.nodes.len(), 1);
         assert_eq!(output.nodes[0].kind, "file");
         assert_eq!(output.nodes[0].path.as_deref(), Some("src/main.py"));
-        assert!(output.nodes[0].language.is_some());
+        assert_eq!(output.nodes[0].language.as_deref(), Some("python"));
+    }
+
+    #[test]
+    fn graph_output_language_uses_canonical_names() {
+        let mut builder = GraphBuilder::new(SnapshotId::new(1).unwrap());
+        builder.add_file(PathBuf::from("src/main.js"), LangId::JavaScript);
+        builder.add_file(PathBuf::from("src/main.ts"), LangId::TypeScript);
+        builder.add_file(PathBuf::from("src/main.tsx"), LangId::Tsx);
+        let graph = builder.build();
+        let scc = sample_scc_analysis();
+
+        let output = GraphOutput::from_graph(&graph, Some(&scc), 1);
+
+        let language_of = |path: &str| {
+            output
+                .nodes
+                .iter()
+                .find(|n| n.path.as_deref() == Some(path))
+                .and_then(|n| n.language.as_deref())
+        };
+        assert_eq!(language_of("src/main.js"), Some("javascript"));
+        assert_eq!(language_of("src/main.ts"), Some("typescript"));
+        assert_eq!(language_of("src/main.tsx"), Some("tsx"));
     }
 
     #[test]

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use crate::error::Diagnostic;
 use crate::graph::{CodeGraph, GraphBuilder, SccAnalysis};
 use crate::input;
+use crate::language::LangId;
 use crate::model::SnapshotId;
 
 /// Metadata about a snapshot analysis run.
@@ -29,8 +30,9 @@ pub struct GraphAnalysis {
 pub fn analyze_graph(
     root: &Path,
     snapshot_id: SnapshotId,
+    languages: Option<&[LangId]>,
 ) -> anyhow::Result<(GraphAnalysis, Vec<Diagnostic>)> {
-    let files = input::discover_files(root, None)?;
+    let files = input::discover_files(root, languages)?;
     let extraction = crate::extractor::extract(&files);
     let mut diagnostics: Vec<Diagnostic> = extraction
         .files

--- a/src/watch/config.rs
+++ b/src/watch/config.rs
@@ -3,6 +3,7 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
+use crate::language::LangId;
 use crate::output::OutputFormat;
 
 /// Configuration parameters governing the debounced file-system watcher.
@@ -18,6 +19,8 @@ pub struct WatchConfig {
     pub html: bool,
     /// Automatically open the browser when generating an HTML dashboard.
     pub open_browser: bool,
+    /// Optional language filter applied to discovered files.
+    pub languages: Option<Vec<LangId>>,
 }
 
 impl WatchConfig {
@@ -29,6 +32,7 @@ impl WatchConfig {
             output: None,
             html: false,
             open_browser: true,
+            languages: None,
         }
     }
 }
@@ -51,5 +55,6 @@ mod tests {
         assert!(cfg.output.is_none());
         assert!(!cfg.html);
         assert!(cfg.open_browser);
+        assert!(cfg.languages.is_none());
     }
 }

--- a/src/watch/reanalyze.rs
+++ b/src/watch/reanalyze.rs
@@ -32,11 +32,12 @@ use crate::watch::state::{ChangeSet, WatchState};
 /// parse+extract cost for changed files.
 pub fn incremental_reanalyze(
     root: &Path,
+    languages: Option<&[LangId]>,
     state: &mut WatchState,
 ) -> Result<(GraphAnalysis, ChangeSet, Vec<Diagnostic>), crate::Error> {
     let started = Instant::now();
 
-    let files = input::discover_files(root, None)?;
+    let files = input::discover_files(root, languages)?;
 
     let (current_fingerprints, read_diagnostics): (HashMap<PathBuf, Fingerprint>, Vec<Diagnostic>) =
         files
@@ -207,7 +208,7 @@ mod tests {
         write_file(&root, "a.py", "def foo(): pass\n");
 
         let mut state = WatchState::new();
-        let (analysis, cs, diags) = incremental_reanalyze(&root, &mut state).unwrap();
+        let (analysis, cs, diags) = incremental_reanalyze(&root, None, &mut state).unwrap();
 
         assert!(diags.is_empty());
         assert_eq!(cs.files_added, 1);
@@ -224,11 +225,11 @@ mod tests {
         write_file(&root, "b.py", "def bar(): pass\n");
 
         let mut state = WatchState::new();
-        let (analysis, cs, _) = incremental_reanalyze(&root, &mut state).unwrap();
+        let (analysis, cs, _) = incremental_reanalyze(&root, None, &mut state).unwrap();
         assert_eq!(cs.files_added, 2);
         assert_eq!(analysis.graph.symbol_count(), 2);
 
-        let (analysis2, cs2, _) = incremental_reanalyze(&root, &mut state).unwrap();
+        let (analysis2, cs2, _) = incremental_reanalyze(&root, None, &mut state).unwrap();
         assert_eq!(cs2.files_unchanged, 2);
         assert_eq!(cs2.files_modified, 0);
         assert_eq!(cs2.files_added, 0);
@@ -243,7 +244,7 @@ mod tests {
         write_file(&root, "b.py", "def bar(): pass\n");
 
         let mut state = WatchState::new();
-        let (analysis, cs, _) = incremental_reanalyze(&root, &mut state).unwrap();
+        let (analysis, cs, _) = incremental_reanalyze(&root, None, &mut state).unwrap();
         assert_eq!(cs.files_added, 2);
         assert_eq!(analysis.graph.symbol_count(), 2);
 
@@ -256,7 +257,7 @@ mod tests {
 
         std::fs::write(&a, "def modified(): pass\ndef extra(): pass\n").unwrap();
 
-        let (analysis2, cs2, _) = incremental_reanalyze(&root, &mut state).unwrap();
+        let (analysis2, cs2, _) = incremental_reanalyze(&root, None, &mut state).unwrap();
         assert_eq!(cs2.files_unchanged, 1);
         assert_eq!(cs2.files_modified, 1);
         assert_eq!(analysis2.graph.symbol_count(), 3);
@@ -278,13 +279,13 @@ mod tests {
         write_file(&root, "b.py", "def bar(): pass\n");
 
         let mut state = WatchState::new();
-        let (analysis, cs, _) = incremental_reanalyze(&root, &mut state).unwrap();
+        let (analysis, cs, _) = incremental_reanalyze(&root, None, &mut state).unwrap();
         assert_eq!(cs.files_added, 2);
         assert_eq!(analysis.graph.file_count(), 2);
 
         std::fs::remove_file(&a).unwrap();
 
-        let (analysis2, cs2, _) = incremental_reanalyze(&root, &mut state).unwrap();
+        let (analysis2, cs2, _) = incremental_reanalyze(&root, None, &mut state).unwrap();
         assert_eq!(cs2.files_removed, 1);
         assert_eq!(analysis2.graph.file_count(), 1);
         assert_eq!(state.cache.extractions.len(), 1);
@@ -296,12 +297,12 @@ mod tests {
         write_file(&root, "a.py", "def foo(): pass\n");
 
         let mut state = WatchState::new();
-        let (_, cs, _) = incremental_reanalyze(&root, &mut state).unwrap();
+        let (_, cs, _) = incremental_reanalyze(&root, None, &mut state).unwrap();
         assert_eq!(cs.files_added, 1);
 
         write_file(&root, "b.py", "def bar(): pass\n");
 
-        let (analysis2, cs2, _) = incremental_reanalyze(&root, &mut state).unwrap();
+        let (analysis2, cs2, _) = incremental_reanalyze(&root, None, &mut state).unwrap();
         assert_eq!(cs2.files_added, 1);
         assert_eq!(analysis2.graph.file_count(), 2);
     }
@@ -313,11 +314,11 @@ mod tests {
         write_file(&root, "b.py", "def two(): pass\n");
 
         let mut state = WatchState::new();
-        let (_, _, _) = incremental_reanalyze(&root, &mut state).unwrap();
+        let (_, _, _) = incremental_reanalyze(&root, None, &mut state).unwrap();
 
         write_file(&root, "c.py", "def three(): pass\n");
 
-        let (analysis, _, _) = incremental_reanalyze(&root, &mut state).unwrap();
+        let (analysis, _, _) = incremental_reanalyze(&root, None, &mut state).unwrap();
 
         let mut ids: Vec<u32> = analysis
             .graph
@@ -337,11 +338,11 @@ mod tests {
         write_file(&root, "b.py", "z = 2\n");
 
         let mut state = WatchState::new();
-        let (_, _, _) = incremental_reanalyze(&root, &mut state).unwrap();
+        let (_, _, _) = incremental_reanalyze(&root, None, &mut state).unwrap();
 
         write_file(&root, "b.py", "z = 2\nw = z + 3\n");
 
-        let (_, _, _) = incremental_reanalyze(&root, &mut state).unwrap();
+        let (_, _, _) = incremental_reanalyze(&root, None, &mut state).unwrap();
 
         let mut ids: Vec<u32> = state
             .cache
@@ -366,13 +367,13 @@ mod tests {
         let _b = write_file(&root, "b.py", "def b(): pass\n");
 
         let mut state = WatchState::new();
-        let (_, cs1, _) = incremental_reanalyze(&root, &mut state).unwrap();
+        let (_, cs1, _) = incremental_reanalyze(&root, None, &mut state).unwrap();
         assert_eq!(cs1.files_added, 2);
         assert_eq!(cs1.files_removed, 0);
 
         std::fs::remove_file(&a).unwrap();
 
-        let (_, cs2, _) = incremental_reanalyze(&root, &mut state).unwrap();
+        let (_, cs2, _) = incremental_reanalyze(&root, None, &mut state).unwrap();
         assert_eq!(cs2.files_removed, 1);
         assert_eq!(cs2.files_added, 0);
         assert_eq!(cs2.files_modified, 0);
@@ -385,7 +386,7 @@ mod tests {
         let a = write_file(&root, "a.py", "def a(): pass\n");
 
         let mut state = WatchState::new();
-        let (_, _, diags1) = incremental_reanalyze(&root, &mut state).unwrap();
+        let (_, _, diags1) = incremental_reanalyze(&root, None, &mut state).unwrap();
         assert!(diags1.is_empty());
 
         #[cfg(unix)]
@@ -396,7 +397,7 @@ mod tests {
             let _ = std::fs::set_permissions(&a, perms);
         }
 
-        let (_, _, diags2) = incremental_reanalyze(&root, &mut state).unwrap();
+        let (_, _, diags2) = incremental_reanalyze(&root, None, &mut state).unwrap();
 
         #[cfg(unix)]
         {
@@ -414,7 +415,7 @@ mod tests {
     fn empty_project_handled() {
         let root = temp_dir("empty");
         let mut state = WatchState::new();
-        let (analysis, cs, diags) = incremental_reanalyze(&root, &mut state).unwrap();
+        let (analysis, cs, diags) = incremental_reanalyze(&root, None, &mut state).unwrap();
         assert!(diags.is_empty());
         assert_eq!(cs.files_added, 0);
         assert_eq!(analysis.graph.node_count(), 0);

--- a/src/watch/watcher.rs
+++ b/src/watch/watcher.rs
@@ -29,7 +29,8 @@ pub fn run_watch(
     let mut state = WatchState::new();
 
     tracing::info!(root = %root.display(), "Running initial analysis");
-    let (analysis, change_set, diags) = incremental_reanalyze(&root, &mut state)?;
+    let (analysis, change_set, diags) =
+        incremental_reanalyze(&root, config.languages.as_deref(), &mut state)?;
 
     for d in &diags {
         tracing::warn!(
@@ -69,7 +70,7 @@ pub fn run_watch(
                 }
 
                 tracing::debug!(count = events.len(), "Debounced change detected");
-                match incremental_reanalyze(&root, &mut state) {
+                match incremental_reanalyze(&root, config.languages.as_deref(), &mut state) {
                     Ok((analysis, change_set, diags)) => {
                         for d in &diags {
                             tracing::warn!(

--- a/src/watch/watcher.rs
+++ b/src/watch/watcher.rs
@@ -28,9 +28,10 @@ pub fn run_watch(
 
     let mut state = WatchState::new();
 
+    let languages = config.languages.as_deref();
+
     tracing::info!(root = %root.display(), "Running initial analysis");
-    let (analysis, change_set, diags) =
-        incremental_reanalyze(&root, config.languages.as_deref(), &mut state)?;
+    let (analysis, change_set, diags) = incremental_reanalyze(&root, languages, &mut state)?;
 
     for d in &diags {
         tracing::warn!(
@@ -62,15 +63,17 @@ pub fn run_watch(
     for res in rx {
         match res {
             Ok(events) => {
-                let relevant = events
-                    .iter()
-                    .any(|e| input::detect_language(&e.path).is_some() || e.path.is_dir());
+                let relevant = events.iter().any(|e| {
+                    e.path.is_dir()
+                        || input::detect_language(&e.path)
+                            .is_some_and(|lang| languages.is_none_or(|langs| langs.contains(&lang)))
+                });
                 if !relevant && !events.is_empty() {
                     continue;
                 }
 
                 tracing::debug!(count = events.len(), "Debounced change detected");
-                match incremental_reanalyze(&root, config.languages.as_deref(), &mut state) {
+                match incremental_reanalyze(&root, languages, &mut state) {
                     Ok((analysis, change_set, diags)) => {
                         for d in &diags {
                             tracing::warn!(

--- a/tests/integration/dashboard_test.rs
+++ b/tests/integration/dashboard_test.rs
@@ -39,7 +39,7 @@ fn build_sample_graph() -> (meta_ast::graph::CodeGraph, SccAnalysis) {
     builder.add_reference(sym1.id, sym2.id, 1.0);
 
     let graph = builder.build();
-    let scc = SccAnalysis::analyze(&graph.graph);
+    let scc = SccAnalysis::analyze(graph.graph());
     (graph, scc)
 }
 
@@ -106,7 +106,7 @@ fn to_graph_html_cdn_link() {
 fn to_graph_html_empty_graph() {
     let builder = GraphBuilder::new(SnapshotId::new(1).unwrap());
     let graph = builder.build();
-    let scc = SccAnalysis::analyze(&graph.graph);
+    let scc = SccAnalysis::analyze(graph.graph());
     let html = meta_ast::output::dashboard::to_graph_html(&graph, &scc, 1).unwrap();
     assert!(
         html.contains("\"node_count\":0"),

--- a/tests/integration/deploy_client_call_test.rs
+++ b/tests/integration/deploy_client_call_test.rs
@@ -20,6 +20,7 @@ mod deploy_client_call_tests {
             out: out_path.clone(),
             format: OutputFormat::Json,
             check: false,
+            max_pod_size: 20,
         };
         run_deploy(config).expect("Deploy failed");
 
@@ -202,6 +203,7 @@ mod deploy_client_call_tests {
                 out: out.to_path_buf(),
                 format: OutputFormat::Json,
                 check: false,
+                max_pod_size: 20,
             };
             run_deploy(config).expect("Deploy failed");
         };

--- a/tests/integration/deploy_edge_cases_test.rs
+++ b/tests/integration/deploy_edge_cases_test.rs
@@ -13,6 +13,7 @@ mod deploy_edge_cases_tests {
             out: out_path.clone(),
             format: OutputFormat::Json,
             check: false,
+            max_pod_size: 20,
         };
         (out_dir, config)
     }
@@ -49,6 +50,7 @@ metacall_load_from_file('py', ['other.py'])
             out: out_path.clone(),
             format: OutputFormat::Json,
             check: false,
+            max_pod_size: 20,
         };
 
         run_deploy(config).expect("Deploy failed");
@@ -82,6 +84,7 @@ metacall_load_from_file('py', ['other.py'])
             out: out_path.clone(),
             format: OutputFormat::Json,
             check: false,
+            max_pod_size: 20,
         };
 
         run_deploy(config).expect("Deploy failed");
@@ -134,6 +137,7 @@ metacall_load_from_file('py', ['other.py'])
             out: out_path.clone(),
             format: OutputFormat::Json,
             check: false,
+            max_pod_size: 20,
         };
 
         run_deploy(config).expect("Deploy failed");
@@ -184,6 +188,7 @@ metacall_load_from_file('py', ['other.py'])
             out: out_path.clone(),
             format: OutputFormat::Json,
             check: true,
+            max_pod_size: 20,
         };
 
         let result = run_deploy(config);

--- a/tests/integration/deploy_mixed_test.rs
+++ b/tests/integration/deploy_mixed_test.rs
@@ -16,6 +16,7 @@ mod deploy_mixed_tests {
             out: out_path.clone(),
             format: OutputFormat::Json,
             check: false,
+            max_pod_size: 20,
         };
         run_deploy(config).expect("Deploy failed");
 
@@ -110,6 +111,7 @@ mod deploy_mixed_tests {
             out: out_path,
             format: OutputFormat::Json,
             check: true,
+            max_pod_size: 20,
         };
 
         let result = run_deploy(config);
@@ -289,6 +291,7 @@ mod deploy_mixed_tests {
             out: out_dir.path().to_path_buf(),
             format: OutputFormat::Json,
             check: true,
+            max_pod_size: 20,
         };
 
         let result = run_deploy(config);
@@ -309,6 +312,7 @@ mod deploy_mixed_tests {
             out: out_path.clone(),
             format: OutputFormat::Json,
             check: false,
+            max_pod_size: 20,
         };
 
         run_deploy(config).expect("empty root should produce empty manifest");
@@ -457,6 +461,7 @@ mod deploy_mixed_tests {
             out: out_dir.path().to_path_buf(),
             format: OutputFormat::Json,
             check: false,
+            max_pod_size: 20,
         };
         run_deploy(config).expect("deploy failed");
 
@@ -532,6 +537,7 @@ mod deploy_mixed_tests {
             out: out_dir.path().to_path_buf(),
             format: OutputFormat::Json,
             check: true,
+            max_pod_size: 20,
         };
 
         let result = run_deploy(config);

--- a/tests/integration/deploy_test.rs
+++ b/tests/integration/deploy_test.rs
@@ -18,6 +18,7 @@ mod deploy_tests {
             out: out_path.clone(),
             format: OutputFormat::Json,
             check: false,
+            max_pod_size: 20,
         };
 
         run_deploy(config).expect("Deploy failed");
@@ -63,6 +64,7 @@ mod deploy_tests {
             out: out_path.clone(),
             format: OutputFormat::Json,
             check: true,
+            max_pod_size: 20,
         };
 
         // Without pre-existing cuts, the fairness check should pass
@@ -70,6 +72,60 @@ mod deploy_tests {
         assert!(
             result.is_ok(),
             "check mode should pass without pre-existing metadata"
+        );
+    }
+
+    #[test]
+    fn max_pod_size_forces_oversized_pod_cut() {
+        let fixture = tempdir().unwrap();
+        let root = fixture.path().join("proj");
+        fs::create_dir_all(&root).unwrap();
+        fs::write(root.join("a.py"), "import b\n").unwrap();
+        fs::write(root.join("b.py"), "import a\n").unwrap();
+
+        let run = |out_path: &std::path::Path, max_pod_size: usize| -> serde_json::Value {
+            let config = DeployConfig {
+                root: root.clone(),
+                out: out_path.to_path_buf(),
+                format: OutputFormat::Json,
+                check: false,
+                max_pod_size,
+            };
+            run_deploy(config).expect("Deploy failed");
+            let content = fs::read_to_string(out_path.join("metacall.pods.json")).unwrap();
+            serde_json::from_str(&content).unwrap()
+        };
+
+        let out_default = tempdir().unwrap();
+        let default_manifest = run(out_default.path(), 20);
+        let rpc_stubs: Vec<&serde_json::Value> = default_manifest["edges"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|e| e["kind"].as_str() == Some("rpc_stub"))
+            .collect();
+        assert!(
+            rpc_stubs.is_empty(),
+            "expected no rpc_stub edges at the default threshold, got {rpc_stubs:?}"
+        );
+
+        let out_small = tempdir().unwrap();
+        let small_manifest = run(out_small.path(), 1);
+        let oversized: Vec<&serde_json::Value> = small_manifest["edges"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|e| e["kind"].as_str() == Some("rpc_stub"))
+            .filter(|e| {
+                e["cut_annotation"]["cut_reason"]
+                    .get("OversizedPod")
+                    .is_some()
+            })
+            .collect();
+        assert!(
+            !oversized.is_empty(),
+            "expected an OversizedPod rpc_stub edge at max_pod_size 1, edges: {}",
+            small_manifest["edges"]
         );
     }
 

--- a/tests/integration/deploy_test.rs
+++ b/tests/integration/deploy_test.rs
@@ -97,16 +97,24 @@ mod deploy_tests {
         };
 
         let out_default = tempdir().unwrap();
-        let default_manifest = run(out_default.path(), 20);
-        let rpc_stubs: Vec<&serde_json::Value> = default_manifest["edges"]
+        let default_manifest = run(
+            out_default.path(),
+            meta_ast::deploy::cut::DEFAULT_MAX_POD_SIZE,
+        );
+        let oversized_stubs: Vec<&serde_json::Value> = default_manifest["edges"]
             .as_array()
             .unwrap()
             .iter()
             .filter(|e| e["kind"].as_str() == Some("rpc_stub"))
+            .filter(|e| {
+                e["cut_annotation"]["cut_reason"]
+                    .get("OversizedPod")
+                    .is_some()
+            })
             .collect();
         assert!(
-            rpc_stubs.is_empty(),
-            "expected no rpc_stub edges at the default threshold, got {rpc_stubs:?}"
+            oversized_stubs.is_empty(),
+            "expected no OversizedPod rpc_stub edge at the default threshold, got {oversized_stubs:?}"
         );
 
         let out_small = tempdir().unwrap();

--- a/tests/integration/deploy_test.rs
+++ b/tests/integration/deploy_test.rs
@@ -76,6 +76,19 @@ mod deploy_tests {
     }
 
     #[test]
+    fn max_pod_size_zero_returns_error() {
+        let root = tempdir().unwrap();
+        let config = DeployConfig {
+            root: root.path().to_path_buf(),
+            out: root.path().to_path_buf(),
+            format: OutputFormat::Json,
+            check: false,
+            max_pod_size: 0,
+        };
+        assert!(run_deploy(config).is_err());
+    }
+
+    #[test]
     fn max_pod_size_forces_oversized_pod_cut() {
         let fixture = tempdir().unwrap();
         let root = fixture.path().join("proj");

--- a/tests/integration/edge_cases_test.rs
+++ b/tests/integration/edge_cases_test.rs
@@ -13,7 +13,7 @@ use meta_ast::pipeline;
 /// Run the full pipeline and assert it does not panic on malformed input.
 fn analyze_recovers(root: &Path) {
     let (analysis, diags) =
-        pipeline::analyze_graph(root, meta_ast::model::SnapshotId::new(1).unwrap())
+        pipeline::analyze_graph(root, meta_ast::model::SnapshotId::new(1).unwrap(), None)
             .expect("pipeline must not fail on malformed input");
     // Every symbol node must belong to a discovered file; the graph must stay
     // internally consistent even after recovering from broken syntax.
@@ -74,7 +74,7 @@ fn malformed_file_emits_diagnostics_per_language() {
     for (name, _lang, src) in MALFORMED {
         std::fs::write(tmp.join(name), src).expect("write");
         let (analysis, diags) =
-            pipeline::analyze_graph(&tmp, meta_ast::model::SnapshotId::new(1).unwrap())
+            pipeline::analyze_graph(&tmp, meta_ast::model::SnapshotId::new(1).unwrap(), None)
                 .expect("no panic");
         // A single malformed file should at least be discovered and analyzed
         // without panicking, regardless of whether a diagnostic is emitted.
@@ -108,7 +108,7 @@ fn empty_files_produce_empty_symbols() {
         std::fs::write(tmp.join(name), "").expect("write");
     }
     let (analysis, diags) =
-        pipeline::analyze_graph(&tmp, meta_ast::model::SnapshotId::new(1).unwrap())
+        pipeline::analyze_graph(&tmp, meta_ast::model::SnapshotId::new(1).unwrap(), None)
             .expect("no panic on empty");
     assert!(
         analysis.graph.symbol_count() == 0,
@@ -149,7 +149,7 @@ fn unreadable_file_accumulates_diagnostic() {
         std::mem::forget(held);
     }
     let (analysis, diags) =
-        pipeline::analyze_graph(&tmp, meta_ast::model::SnapshotId::new(1).unwrap())
+        pipeline::analyze_graph(&tmp, meta_ast::model::SnapshotId::new(1).unwrap(), None)
             .expect("no panic");
     assert!(
         diags
@@ -173,7 +173,8 @@ fn unreadable_file_accumulates_diagnostic() {
 #[test]
 fn missing_root_errors_gracefully() {
     let missing = std::env::temp_dir().join("meta_ast_test_does_not_exist_xyz");
-    let result = pipeline::analyze_graph(&missing, meta_ast::model::SnapshotId::new(1).unwrap());
+    let result =
+        pipeline::analyze_graph(&missing, meta_ast::model::SnapshotId::new(1).unwrap(), None);
     assert!(result.is_err(), "missing root must return Err");
 }
 
@@ -186,7 +187,7 @@ fn empty_directory_is_valid() {
     }
     std::fs::create_dir_all(&tmp).expect("temp dir");
     let (analysis, diags) =
-        pipeline::analyze_graph(&tmp, meta_ast::model::SnapshotId::new(1).unwrap())
+        pipeline::analyze_graph(&tmp, meta_ast::model::SnapshotId::new(1).unwrap(), None)
             .expect("no panic");
     assert_eq!(analysis.graph.file_count(), 0);
     assert!(analysis.scc.components.is_empty());

--- a/tests/integration/output_format_test.rs
+++ b/tests/integration/output_format_test.rs
@@ -68,7 +68,7 @@ fn yaml_serialize_graph_output() {
     builder.add_symbol(&sym).unwrap();
 
     let graph = builder.build();
-    let scc = SccAnalysis::analyze(&graph.graph);
+    let scc = SccAnalysis::analyze(graph.graph());
 
     let yaml =
         meta_ast::output::graph::serialize_graph(&graph, &scc, 1, &OutputFormat::Yaml).unwrap();

--- a/tests/integration/pipeline_test.rs
+++ b/tests/integration/pipeline_test.rs
@@ -940,13 +940,13 @@ fn analyze_graph_external_imports_appear_in_graph() {
     assert_eq!(analysis.graph.file_count(), 1);
 
     // Should have at least one external node
-    let external_nodes: Vec<_> = analysis
-        .graph
-        .graph
-        .node_indices()
-        .filter_map(|idx| analysis.graph.graph.node_weight(idx))
-        .filter(|node| matches!(node, NodeData::External(_)))
-        .collect();
+    let external_nodes: Vec<_> = {
+        let g = analysis.graph.graph();
+        g.node_indices()
+            .filter_map(|idx| g.node_weight(idx))
+            .filter(|node| matches!(node, NodeData::External(_)))
+            .collect()
+    };
     assert!(
         !external_nodes.is_empty(),
         "should have external nodes for 'import os' and 'import json'"

--- a/tests/integration/pipeline_test.rs
+++ b/tests/integration/pipeline_test.rs
@@ -21,7 +21,7 @@ fn run_pipeline(
     Vec<meta_ast::error::Diagnostic>,
 ) {
     let (analysis, diags) =
-        meta_ast::pipeline::analyze_graph(root, meta_ast::model::SnapshotId::new(1).unwrap())
+        meta_ast::pipeline::analyze_graph(root, meta_ast::model::SnapshotId::new(1).unwrap(), None)
             .unwrap();
     (analysis.graph, analysis.scc, diags)
 }
@@ -753,6 +753,7 @@ fn analyze_graph_python_project() {
     let (analysis, _diags) = meta_ast::pipeline::analyze_graph(
         Path::new("tests/fixtures/python"),
         meta_ast::model::SnapshotId::new(1).unwrap(),
+        None,
     )
     .unwrap();
 
@@ -769,6 +770,7 @@ fn analyze_graph_multi_language() {
     let (analysis, _diags) = meta_ast::pipeline::analyze_graph(
         Path::new("tests/fixtures/multi"),
         meta_ast::model::SnapshotId::new(1).unwrap(),
+        None,
     )
     .unwrap();
 
@@ -782,7 +784,7 @@ fn analyze_graph_empty_dir() {
     std::fs::create_dir_all(&tmp).unwrap();
 
     let (analysis, _diags) =
-        meta_ast::pipeline::analyze_graph(&tmp, meta_ast::model::SnapshotId::new(1).unwrap())
+        meta_ast::pipeline::analyze_graph(&tmp, meta_ast::model::SnapshotId::new(1).unwrap(), None)
             .unwrap();
 
     assert_eq!(analysis.graph.node_count(), 0);
@@ -796,9 +798,12 @@ fn analyze_graph_empty_dir() {
 fn analyze_graph_diagnostics_propagated() {
     let path = Path::new("tests/fixtures/multi");
     if path.exists() {
-        let (_analysis, diags) =
-            meta_ast::pipeline::analyze_graph(path, meta_ast::model::SnapshotId::new(1).unwrap())
-                .unwrap();
+        let (_analysis, diags) = meta_ast::pipeline::analyze_graph(
+            path,
+            meta_ast::model::SnapshotId::new(1).unwrap(),
+            None,
+        )
+        .unwrap();
         let _ = diags;
     }
 }
@@ -808,6 +813,7 @@ fn analyze_graph_nonexistent_root() {
     let result = meta_ast::pipeline::analyze_graph(
         Path::new("/nonexistent/path/that/does/not/exist"),
         meta_ast::model::SnapshotId::new(1).unwrap(),
+        None,
     );
     assert!(result.is_err(), "nonexistent root should return Err");
 }
@@ -817,6 +823,7 @@ fn analyze_graph_snapshot_id_passthrough() {
     let (analysis, _diags) = meta_ast::pipeline::analyze_graph(
         Path::new("tests/fixtures/python"),
         meta_ast::model::SnapshotId::new(42).unwrap(),
+        None,
     )
     .unwrap();
 
@@ -833,7 +840,7 @@ fn analyze_graph_python_cross_file_import() {
     std::fs::write(tmp.join("main.py"), "from utils import helper\nhelper()\n").unwrap();
 
     let (analysis, _diags) =
-        meta_ast::pipeline::analyze_graph(&tmp, SnapshotId::new(1).unwrap()).unwrap();
+        meta_ast::pipeline::analyze_graph(&tmp, SnapshotId::new(1).unwrap(), None).unwrap();
 
     assert_eq!(analysis.graph.file_count(), 2);
 
@@ -879,7 +886,7 @@ fn analyze_graph_js_relative_import() {
     .unwrap();
 
     let (analysis, _diags) =
-        meta_ast::pipeline::analyze_graph(&tmp, SnapshotId::new(1).unwrap()).unwrap();
+        meta_ast::pipeline::analyze_graph(&tmp, SnapshotId::new(1).unwrap(), None).unwrap();
 
     assert_eq!(analysis.graph.file_count(), 2);
 
@@ -905,7 +912,7 @@ fn analyze_graph_external_imports_appear_in_graph() {
     .unwrap();
 
     let (analysis, _diags) =
-        meta_ast::pipeline::analyze_graph(&tmp, SnapshotId::new(1).unwrap()).unwrap();
+        meta_ast::pipeline::analyze_graph(&tmp, SnapshotId::new(1).unwrap(), None).unwrap();
 
     // Should have 1 file node
     assert_eq!(analysis.graph.file_count(), 1);
@@ -1013,7 +1020,7 @@ fn analyze_graph_python_multiline_import_edges() {
     .unwrap();
 
     let (analysis, _diags) =
-        meta_ast::pipeline::analyze_graph(&tmp, SnapshotId::new(1).unwrap()).unwrap();
+        meta_ast::pipeline::analyze_graph(&tmp, SnapshotId::new(1).unwrap(), None).unwrap();
     assert_eq!(analysis.graph.file_count(), 2);
 
     let import_edges: Vec<_> = analysis.graph.edges_of_kind(EdgeKind::Import).collect();
@@ -1042,7 +1049,7 @@ fn analyze_graph_js_multiline_import_edges() {
     .unwrap();
 
     let (analysis, _diags) =
-        meta_ast::pipeline::analyze_graph(&tmp, SnapshotId::new(1).unwrap()).unwrap();
+        meta_ast::pipeline::analyze_graph(&tmp, SnapshotId::new(1).unwrap(), None).unwrap();
     assert_eq!(analysis.graph.file_count(), 2);
 
     let import_edges: Vec<_> = analysis.graph.edges_of_kind(EdgeKind::Import).collect();
@@ -1071,7 +1078,7 @@ fn analyze_graph_rust_multiline_use_edges() {
     .unwrap();
 
     let (analysis, _diags) =
-        meta_ast::pipeline::analyze_graph(&tmp, SnapshotId::new(1).unwrap()).unwrap();
+        meta_ast::pipeline::analyze_graph(&tmp, SnapshotId::new(1).unwrap(), None).unwrap();
     assert_eq!(analysis.graph.file_count(), 2);
 
     let import_edges: Vec<_> = analysis.graph.edges_of_kind(EdgeKind::Import).collect();

--- a/tests/integration/pipeline_test.rs
+++ b/tests/integration/pipeline_test.rs
@@ -779,6 +779,28 @@ fn analyze_graph_multi_language() {
 }
 
 #[test]
+fn analyze_graph_language_filter_only_includes_requested_language() {
+    let (analysis, _diags) = meta_ast::pipeline::analyze_graph(
+        Path::new("tests/fixtures/mixed"),
+        meta_ast::model::SnapshotId::new(1).unwrap(),
+        Some(&[meta_ast::LangId::Python]),
+    )
+    .unwrap();
+
+    assert!(
+        analysis.graph.file_count() > 0,
+        "mixed fixture should contain Python files"
+    );
+    for (_, file_node) in analysis.graph.files() {
+        assert_eq!(
+            file_node.language,
+            meta_ast::LangId::Python,
+            "filtered graph should only contain Python files"
+        );
+    }
+}
+
+#[test]
 fn analyze_graph_empty_dir() {
     let tmp = std::env::temp_dir().join("meta_ast_test_empty_pipeline");
     std::fs::create_dir_all(&tmp).unwrap();

--- a/tests/integration/watch_test.rs
+++ b/tests/integration/watch_test.rs
@@ -43,7 +43,8 @@ fn cold_start_analyzes_all_files() {
     write_file(root, "b.py", "def beta(): pass\n");
 
     let mut state = meta_ast::watch::WatchState::new();
-    let (analysis, cs, diags) = meta_ast::watch::incremental_reanalyze(root, &mut state).unwrap();
+    let (analysis, cs, diags) =
+        meta_ast::watch::incremental_reanalyze(root, None, &mut state).unwrap();
 
     assert!(diags.is_empty());
     assert_eq!(cs.files_added, 2);
@@ -58,9 +59,9 @@ fn unchanged_files_produce_zero_changed() {
     write_file(root, "b.py", "class Bar: pass\n");
 
     let mut state = meta_ast::watch::WatchState::new();
-    meta_ast::watch::incremental_reanalyze(root, &mut state).unwrap();
+    meta_ast::watch::incremental_reanalyze(root, None, &mut state).unwrap();
 
-    let (_, cs, _) = meta_ast::watch::incremental_reanalyze(root, &mut state).unwrap();
+    let (_, cs, _) = meta_ast::watch::incremental_reanalyze(root, None, &mut state).unwrap();
     assert_eq!(cs.files_unchanged, 2);
     assert_eq!(cs.files_modified, 0);
     assert_eq!(cs.files_added, 0);
@@ -75,7 +76,7 @@ fn file_modification_detected_and_re_extracted() {
     write_file(root, "b.py", "class B: pass\n");
 
     let mut state = meta_ast::watch::WatchState::new();
-    let (initial, _, _) = meta_ast::watch::incremental_reanalyze(root, &mut state).unwrap();
+    let (initial, _, _) = meta_ast::watch::incremental_reanalyze(root, None, &mut state).unwrap();
 
     let initial_names: Vec<String> = initial
         .graph
@@ -86,7 +87,7 @@ fn file_modification_detected_and_re_extracted() {
 
     std::fs::write(&a, "def modified(): pass\ndef also_new(): pass\n").unwrap();
 
-    let (updated, cs, _) = meta_ast::watch::incremental_reanalyze(root, &mut state).unwrap();
+    let (updated, cs, _) = meta_ast::watch::incremental_reanalyze(root, None, &mut state).unwrap();
 
     assert_eq!(cs.files_modified, 1);
     assert_eq!(cs.files_unchanged, 1);
@@ -110,12 +111,12 @@ fn file_removal_cleans_up() {
     write_file(root, "b.py", "def bar(): pass\n");
 
     let mut state = meta_ast::watch::WatchState::new();
-    let (initial, _, _) = meta_ast::watch::incremental_reanalyze(root, &mut state).unwrap();
+    let (initial, _, _) = meta_ast::watch::incremental_reanalyze(root, None, &mut state).unwrap();
     assert_eq!(initial.graph.file_count(), 2);
 
     std::fs::remove_file(&a).unwrap();
 
-    let (updated, cs, _) = meta_ast::watch::incremental_reanalyze(root, &mut state).unwrap();
+    let (updated, cs, _) = meta_ast::watch::incremental_reanalyze(root, None, &mut state).unwrap();
 
     assert_eq!(cs.files_removed, 1);
     assert_eq!(updated.graph.file_count(), 1);
@@ -128,12 +129,12 @@ fn file_addition_picked_up() {
     write_file(root, "a.py", "def one(): pass\n");
 
     let mut state = meta_ast::watch::WatchState::new();
-    let (initial, _, _) = meta_ast::watch::incremental_reanalyze(root, &mut state).unwrap();
+    let (initial, _, _) = meta_ast::watch::incremental_reanalyze(root, None, &mut state).unwrap();
     assert_eq!(initial.graph.file_count(), 1);
 
     write_file(root, "b.py", "def two(): pass\n");
 
-    let (updated, cs, _) = meta_ast::watch::incremental_reanalyze(root, &mut state).unwrap();
+    let (updated, cs, _) = meta_ast::watch::incremental_reanalyze(root, None, &mut state).unwrap();
 
     assert_eq!(cs.files_added, 1);
     assert_eq!(updated.graph.file_count(), 2);
@@ -147,11 +148,11 @@ fn symbol_ids_unique_across_cold_and_warm_runs() {
     write_file(root, "b.py", "class B: pass\n");
 
     let mut state = meta_ast::watch::WatchState::new();
-    let (initial, _, _) = meta_ast::watch::incremental_reanalyze(root, &mut state).unwrap();
+    let (initial, _, _) = meta_ast::watch::incremental_reanalyze(root, None, &mut state).unwrap();
 
     write_file(root, "c.py", "def c(): pass\n");
 
-    let (updated, _, _) = meta_ast::watch::incremental_reanalyze(root, &mut state).unwrap();
+    let (updated, _, _) = meta_ast::watch::incremental_reanalyze(root, None, &mut state).unwrap();
 
     let ids_initial: std::collections::HashSet<u32> =
         initial.graph.symbols().map(|(id, _)| id.to_raw()).collect();
@@ -173,7 +174,8 @@ fn mixed_language_project_handled() {
     write_file(root, "index.js", "function handle() {}\n");
 
     let mut state = meta_ast::watch::WatchState::new();
-    let (analysis, cs, diags) = meta_ast::watch::incremental_reanalyze(root, &mut state).unwrap();
+    let (analysis, cs, diags) =
+        meta_ast::watch::incremental_reanalyze(root, None, &mut state).unwrap();
 
     assert!(diags.is_empty());
     assert_eq!(cs.files_added, 3);
@@ -197,7 +199,7 @@ fn scc_analysis_recomputed_on_each_tick() {
     write_file(root, "b.py", "import a\ndef b(): pass\n");
 
     let mut state = meta_ast::watch::WatchState::new();
-    let (initial, _, _) = meta_ast::watch::incremental_reanalyze(root, &mut state).unwrap();
+    let (initial, _, _) = meta_ast::watch::incremental_reanalyze(root, None, &mut state).unwrap();
 
     let has_cycle = initial
         .scc
@@ -211,7 +213,7 @@ fn scc_analysis_recomputed_on_each_tick() {
 
     let second_path = write_file(root, "c.py", "import b\ndef c(): pass\n");
 
-    let (updated, _, _) = meta_ast::watch::incremental_reanalyze(root, &mut state).unwrap();
+    let (updated, _, _) = meta_ast::watch::incremental_reanalyze(root, None, &mut state).unwrap();
     assert_eq!(updated.graph.file_count(), 3);
 
     let _ = second_path;
@@ -224,8 +226,8 @@ fn snapshot_id_increments_across_ticks() {
     write_file(root, "a.py", "def foo(): pass\n");
 
     let mut state = meta_ast::watch::WatchState::new();
-    let (a1, _, _) = meta_ast::watch::incremental_reanalyze(root, &mut state).unwrap();
-    let (a2, _, _) = meta_ast::watch::incremental_reanalyze(root, &mut state).unwrap();
+    let (a1, _, _) = meta_ast::watch::incremental_reanalyze(root, None, &mut state).unwrap();
+    let (a2, _, _) = meta_ast::watch::incremental_reanalyze(root, None, &mut state).unwrap();
 
     assert_ne!(a1.snapshot_id, a2.snapshot_id);
     assert!(a2.snapshot_id.to_raw() > a1.snapshot_id.to_raw());
@@ -247,6 +249,7 @@ fn debounced_watcher_smoke() {
         output: None,
         html: false,
         open_browser: false,
+        languages: None,
     };
 
     let (tx, rx) = std::sync::mpsc::channel();


### PR DESCRIPTION
Resolves #49, #42, #51, #52.

## What this branch does

Four issue fixes built incrementally on one branch, each reviewed separately:

### #49 - Wire the ignored `--language` CLI flag
- `--language` is now a working filter through file discovery (incl. single-file), the pipeline (`analyze_graph`), and watch mode (`WatchConfig.languages`).
- `LangId` gains `strum::EnumString` with canonical `javascript`/`typescript` names; `parse_language` clap value_parser lists all 9 valid names on error.

### #42 - Make `DEFAULT_MAX_POD_SIZE` configurable
- New `--max-pod-size` flag threads through `DeployConfig` (default stays `cut::DEFAULT_MAX_POD_SIZE`), with a zero-value guard in `run_deploy`.
- Integration test asserts an `OversizedPod` rpc_stub fires at size 1 and none at the default.

### #51 - Encapsulate petgraph DiGraph in CodeGraph
- `CodeGraph.graph` is now private; mutation flows only through `add_node` / `add_edge_normalized` / `add_edge_normalized_with_flow` / `get_or_create_external_node`. ~55 read sites migrated to the `graph()` accessor.

### #52 - O(1) edge normalization
- `(src, dst, kind) -> EdgeIndex` HashMap replaces the O(out-degree) linear scan, populated once in `GraphBuilder::build`.
- Benchmark: `postbuild_edge_normalization` ~9x faster at 100 out-degree, ~98x at 1000.

### Follow-ups
- Deleted dead `GraphBuilder::add_metacall_load` (never called; sole normalizer bypass).
- Locked and documented the canonical `LangId` vocabulary (`graph-model.md` §6).

## Verification
- `cargo test --all-features`: 338 unit + 109 integration + 1 doctest, 0 failures
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo +1.94.0 fmt --check`: clean
- `cargo bench --bench graph -- --quick postbuild_edge_normalization`: no regression
