### PR TITLE
feat(lsp): implement RFC 0012 Phase 0 engine seams and .metast v2 shard persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,6 +861,7 @@ dependencies = [
  "tree-sitter-ruby",
  "tree-sitter-rust",
  "tree-sitter-typescript",
+ "url",
  "webbrowser",
  "yaml_serde",
 ]
@@ -1489,9 +1490,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.26.11"
+version = "0.26.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1c71c1c4cc0920b20d6b0f6572e7682cd07a6a2faec71067a31fa394c586df"
+checksum = "17ebdd3a5a7e28a1890b876fdbd0c3c0fe0a6336cffaa104f11b9f720c9daa29"
 dependencies = [
  "cc",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ name = "incremental"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 strum = { version = "0.28", features = ["derive"] }
+url = "2.5"
 yaml_serde = "0.10"
 
 # Browser
@@ -40,7 +41,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # Tree-Sitter Dependencies
-tree-sitter = "0.26.11"
+tree-sitter = "0.26.13"
 tree-sitter-c = "0.24.2"
 tree-sitter-cpp = "0.23.4"
 tree-sitter-go = "0.25.0"
@@ -63,8 +64,10 @@ rayon = "1.12"
 dunce = "1"
 ignore = "0.4"
 
+# Hashing
+blake3 = "1.8"
+
 # Watch mode (feature-gated)
-blake3 = { version = "1.8", optional = true }
 notify = { version = "8.2", optional = true }
 notify-debouncer-mini = { version = "0.7", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ tempfile = "3.27"
 default = []
 metacall-deploy = []
 dataflow = []
-watch = ["dep:notify", "dep:notify-debouncer-mini", "dep:blake3"]
+watch = ["dep:notify", "dep:notify-debouncer-mini"]
 
 [profile.bench]
 opt-level = 3

--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -50,6 +50,7 @@ back to requirements and forward to tests.
 - `rfcs/0009-cross-file-dependency-mapping.md` - Cross-file dependency mapping
 - `rfcs/0010-deploy-manifests.md` - MetaCall deploy manifests (superseded by the pod model)
 - `rfcs/0011-metacall-client-api-support.md` - MetaCall client call support: `metacall()` and the full invocation surface
+- `rfcs/0012-polyglot-lsp-server.md` - Polyglot LSP server and `.metast` v2 index contract
 
 ## Scope policy
 

--- a/docs/src/ROADMAP.md
+++ b/docs/src/ROADMAP.md
@@ -43,7 +43,7 @@ Goals:
 Exit gates:
 
 1. Export format validated via integration tests (JSON roundtrip, field checks).
-2. Snapshot/version semantics documented and tested (SCHEMA_VERSION = 1).
+2. Snapshot/version semantics documented and tested (SCHEMA_VERSION = 2).
 3. End-to-end pipeline extracts data nodes from real Rust fixtures.
 4. Flow edges created for def-use chains (param→usage, let→let shadowing).
 

--- a/docs/src/STRUCTURE.md
+++ b/docs/src/STRUCTURE.md
@@ -55,6 +55,14 @@ src/
 │   ├── emitter.rs            EmitConfig, emit_inspect(), emit_graph() - CLI output dispatch
 │   ├── inspect.rs            Inspect-compatible JSON/YAML emission
 │   ├── graph.rs              Unified GraphOutput (schema_version, metadata, nodes, edges, sccs, deployability)
+│   ├── shard/                `.metast` v2 stable-name JSONL shard and index persistence
+│   │   ├── mod.rs            Module root, re-exports, unit tests
+│   │   ├── error.rs          ShardError enum
+│   │   ├── file.rs           ShardFile, ShardSymbol, write_shard(), read_shard()
+│   │   ├── edge.rs           ShardEdge, ShardEdgeKind, restore_shard_edges()
+│   │   ├── manifest.rs       ShardManifestRecord, write_manifest(), read_manifest()
+│   │   ├── header.rs         ShardHeader, write_header(), read_header()
+│   │   └── name.rs           Stable naming, descriptors, and parent hierarchy resolution
 │   └── dashboard.rs          Interactive HTML dashboard (Cytoscape.js via CDN, --html)
 │
 └── sink/                     [feature: dataflow] GraphSink trait + JsonSink

--- a/docs/src/specs/graph-model.md
+++ b/docs/src/specs/graph-model.md
@@ -72,9 +72,9 @@ Deployability hint policy:
 
 Graph serialization for external consumers shall preserve:
 
-- stable IDs
+- snapshot-local node IDs
 - edge kinds
-- source ranges for symbol nodes
+- defining file paths and source ranges for symbol nodes
 
 Sink adapters (e.g., Dgraph) that must preserve semantic equivalence.
 

--- a/docs/src/specs/graph-model.md
+++ b/docs/src/specs/graph-model.md
@@ -86,6 +86,10 @@ lowercase language names, in enum declaration order:
 These values also parse back through the CLI `--language` flag. The same names
 apply to the strum `Display`/`AsRefStr` and serde representations of `LangId`.
 
+Graph output schema version 2 adds `file_path` and `source_range` to serialized
+symbol nodes. `.metast` v2 shards do not persist numeric IDs. They store stable
+language-scoped endpoint names and regenerate symbol IDs when loaded.
+
 ## 7. Known limitations
 
 - Cross-language resolution is initially best-effort string/scope matching.

--- a/src/error.rs
+++ b/src/error.rs
@@ -34,6 +34,9 @@ pub enum Error {
     #[error("config: {0}")]
     Config(String),
 
+    #[error("invalid source URI '{uri}': {message}")]
+    InvalidSourceUri { uri: String, message: String },
+
     #[error("graph error: {0}")]
     Graph(String),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,14 +2,14 @@ use std::path::PathBuf;
 
 use crate::model::SourceRange;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[non_exhaustive]
 pub enum Severity {
     Warning,
     Error,
 }
 
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Diagnostic {
     pub path: PathBuf,
     pub severity: Severity,

--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -60,6 +60,15 @@ impl ExtractionIdGenerators {
             data_nodes: IdGenerator::with_start(data_node_start),
         }
     }
+
+    pub fn symbols(&self) -> &IdGenerator<SymbolId> {
+        &self.symbols
+    }
+
+    #[cfg(feature = "dataflow")]
+    pub fn data_nodes(&self) -> &IdGenerator<crate::model::DataNodeId> {
+        &self.data_nodes
+    }
 }
 
 /// Source text supplied by an editor buffer.
@@ -141,6 +150,7 @@ pub fn extract_text_with_id_gen(
             uri: source.uri.to_string(),
             message: "URI must use the file scheme and contain an absolute path".to_string(),
         })?;
+    let path = dunce::simplified(&path).to_path_buf();
     let file = extract_source(
         &path,
         source.language,
@@ -400,6 +410,21 @@ mod tests {
         .unwrap_err();
 
         assert!(matches!(error, crate::Error::InvalidSourceUri { .. }));
+    }
+
+    #[test]
+    fn extraction_id_generators_accessors() {
+        let id_generators = ExtractionIdGenerators::with_symbol_start(100);
+        assert_eq!(id_generators.symbols().next(), SymbolId::new(100).unwrap());
+        #[cfg(feature = "dataflow")]
+        {
+            let dual = ExtractionIdGenerators::with_starts(200, 300);
+            assert_eq!(dual.symbols().next(), SymbolId::new(200).unwrap());
+            assert_eq!(
+                dual.data_nodes().next(),
+                crate::model::DataNodeId::new(300).unwrap()
+            );
+        }
     }
 
     #[test]

--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -125,65 +125,68 @@ pub(crate) fn extract_with_id_gen(
 }
 
 fn extract_single_file(
-    path: &std::path::Path,
+    path: &Path,
     lang: &LangId,
-    id_gen: &IdGenerator<SymbolId>,
-    #[cfg(feature = "dataflow")] data_id_gen: &IdGenerator<crate::model::DataNodeId>,
+    id_generators: &ExtractionIdGenerators,
     opts: &ExtractOptions,
 ) -> FileExtraction {
     let source = match std::fs::read(path) {
-        Ok(s) => s,
-        Err(e) => {
-            return FileExtraction {
-                path: path.to_path_buf(),
-                lang: *lang,
-                symbols: Vec::new(),
-                imports: Vec::new(),
-                references: Vec::new(),
-                diagnostics: vec![Diagnostic {
-                    path: path.to_path_buf(),
-                    severity: Severity::Error,
-                    message: format!("failed to read file: {e}"),
-                    source_range: None,
-                }],
-                ast_node_count: 0,
-                #[cfg(feature = "metacall-deploy")]
-                call_sites: Vec::new(),
-                #[cfg(feature = "dataflow")]
-                data_nodes: Vec::new(),
-                #[cfg(feature = "dataflow")]
-                flow_edges: Vec::new(),
-            };
+        Ok(source) => source,
+        Err(error) => {
+            return failed_extraction(path, *lang, format!("failed to read file: {error}"));
         }
     };
 
-    let tree = match crate::parser::parse_tree(*lang, &source) {
+    extract_source(path, *lang, &source, id_generators, opts)
+}
+
+/// Extract an open editor buffer without reading its backing file.
+pub fn extract_text_with_id_gen(
+    source: InMemorySource<'_>,
+    opts: &ExtractOptions,
+    id_generators: &ExtractionIdGenerators,
+) -> Result<VersionedExtraction, crate::Error> {
+    let parsed_uri =
+        url::Url::parse(source.uri).map_err(|error| crate::Error::InvalidSourceUri {
+            uri: source.uri.to_string(),
+            message: error.to_string(),
+        })?;
+    let path = parsed_uri
+        .to_file_path()
+        .map_err(|()| crate::Error::InvalidSourceUri {
+            uri: source.uri.to_string(),
+            message: "URI must use the file scheme and contain an absolute path".to_string(),
+        })?;
+    let file = extract_source(
+        &path,
+        source.language,
+        source.text.as_bytes(),
+        id_generators,
+        opts,
+    );
+
+    Ok(VersionedExtraction {
+        uri: source.uri.to_string(),
+        version: source.version,
+        file,
+    })
+}
+
+fn extract_source(
+    path: &Path,
+    lang: LangId,
+    source: &[u8],
+    id_generators: &ExtractionIdGenerators,
+    opts: &ExtractOptions,
+) -> FileExtraction {
+    let tree = match crate::parser::parse_tree(lang, source) {
         Ok(t) => t,
         Err(e) => {
-            return FileExtraction {
-                path: path.to_path_buf(),
-                lang: *lang,
-                symbols: Vec::new(),
-                imports: Vec::new(),
-                references: Vec::new(),
-                diagnostics: vec![Diagnostic {
-                    path: path.to_path_buf(),
-                    severity: Severity::Error,
-                    message: e.to_string(),
-                    source_range: None,
-                }],
-                ast_node_count: 0,
-                #[cfg(feature = "metacall-deploy")]
-                call_sites: Vec::new(),
-                #[cfg(feature = "dataflow")]
-                data_nodes: Vec::new(),
-                #[cfg(feature = "dataflow")]
-                flow_edges: Vec::new(),
-            };
+            return failed_extraction(path, lang, e.to_string());
         }
     };
 
-    let metrics = parser::tree_metrics(&tree, &source);
+    let metrics = parser::tree_metrics(&tree, source);
     let mut diags = Vec::new();
 
     if metrics.error_ratio > 0.5 {
@@ -242,6 +245,29 @@ fn extract_single_file(
         data_nodes,
         #[cfg(feature = "dataflow")]
         flow_edges,
+    }
+}
+
+fn failed_extraction(path: &Path, lang: LangId, message: String) -> FileExtraction {
+    FileExtraction {
+        path: path.to_path_buf(),
+        lang,
+        symbols: Vec::new(),
+        imports: Vec::new(),
+        references: Vec::new(),
+        diagnostics: vec![Diagnostic {
+            path: path.to_path_buf(),
+            severity: Severity::Error,
+            message,
+            source_range: None,
+        }],
+        ast_node_count: 0,
+        #[cfg(feature = "metacall-deploy")]
+        call_sites: Vec::new(),
+        #[cfg(feature = "dataflow")]
+        data_nodes: Vec::new(),
+        #[cfg(feature = "dataflow")]
+        flow_edges: Vec::new(),
     }
 }
 

--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -85,36 +85,18 @@ pub fn extract_with_options(
     files: &[(std::path::PathBuf, LangId)],
     opts: &ExtractOptions,
 ) -> ExtractionResult {
-    let id_gen = IdGenerator::<SymbolId>::new();
-    #[cfg(feature = "dataflow")]
-    let data_id_gen = IdGenerator::<crate::model::DataNodeId>::new();
-    extract_with_id_gen(
-        files,
-        opts,
-        id_gen,
-        #[cfg(feature = "dataflow")]
-        data_id_gen,
-    )
+    let id_generators = ExtractionIdGenerators::new();
+    extract_with_id_gen(files, opts, &id_generators)
 }
 
-pub(crate) fn extract_with_id_gen(
-    files: &[(std::path::PathBuf, LangId)],
+pub fn extract_with_id_gen(
+    files: &[(PathBuf, LangId)],
     opts: &ExtractOptions,
-    id_gen: IdGenerator<SymbolId>,
-    #[cfg(feature = "dataflow")] data_id_gen: IdGenerator<crate::model::DataNodeId>,
+    id_generators: &ExtractionIdGenerators,
 ) -> ExtractionResult {
     let mut file_extractions: Vec<_> = files
         .par_iter()
-        .map(|(path, lang)| {
-            extract_single_file(
-                path,
-                lang,
-                &id_gen,
-                #[cfg(feature = "dataflow")]
-                &data_id_gen,
-                opts,
-            )
-        })
+        .map(|(path, lang)| extract_single_file(path, lang, id_generators, opts))
         .collect();
 
     file_extractions.sort_by(|a, b| a.path.cmp(&b.path));

--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -359,6 +359,50 @@ mod tests {
     }
 
     #[test]
+    fn in_memory_extraction_uses_unsaved_text_and_preserves_version() {
+        let path = test_dir().join("buffer.py");
+        let _ = std::fs::remove_file(&path);
+        let uri = url::Url::from_file_path(&path).unwrap().to_string();
+        let id_generators = ExtractionIdGenerators::with_symbol_start(40);
+
+        let result = extract_text_with_id_gen(
+            InMemorySource {
+                uri: &uri,
+                text: "def unsaved(): pass\n",
+                version: 7,
+                language: LangId::Python,
+            },
+            &ExtractOptions::default(),
+            &id_generators,
+        )
+        .unwrap();
+
+        assert_eq!(result.version, 7);
+        assert_eq!(result.uri, uri);
+        assert_eq!(result.file.path, path);
+        assert_eq!(result.file.symbols[0].name, "unsaved");
+        assert_eq!(result.file.symbols[0].id, SymbolId::new(40).unwrap());
+    }
+
+    #[test]
+    fn in_memory_extraction_rejects_non_file_uri() {
+        let id_generators = ExtractionIdGenerators::new();
+        let error = extract_text_with_id_gen(
+            InMemorySource {
+                uri: "untitled:buffer.py",
+                text: "def value(): pass\n",
+                version: 1,
+                language: LangId::Python,
+            },
+            &ExtractOptions::default(),
+            &id_generators,
+        )
+        .unwrap_err();
+
+        assert!(matches!(error, crate::Error::InvalidSourceUri { .. }));
+    }
+
+    #[test]
     fn symbols_assigned_ids() {
         let path = write_temp("ids.py", b"def a(): pass\ndef b(): pass\ndef c(): pass\n");
         let result = extract(&[(path, LangId::Python)]);

--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -30,6 +30,53 @@ pub struct ExtractionResult {
     pub files: Vec<FileExtraction>,
 }
 
+/// ID allocation state shared by disk and in-memory extraction.
+#[derive(Debug, Default)]
+pub struct ExtractionIdGenerators {
+    symbols: IdGenerator<SymbolId>,
+    #[cfg(feature = "dataflow")]
+    data_nodes: IdGenerator<crate::model::DataNodeId>,
+}
+
+impl ExtractionIdGenerators {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_symbol_start(symbol_start: u32) -> Self {
+        Self {
+            symbols: IdGenerator::with_start(symbol_start),
+            #[cfg(feature = "dataflow")]
+            data_nodes: IdGenerator::new(),
+        }
+    }
+
+    #[cfg(feature = "dataflow")]
+    pub fn with_starts(symbol_start: u32, data_node_start: u32) -> Self {
+        Self {
+            symbols: IdGenerator::with_start(symbol_start),
+            data_nodes: IdGenerator::with_start(data_node_start),
+        }
+    }
+}
+
+/// Source text supplied by an editor buffer.
+#[derive(Debug, Clone, Copy)]
+pub struct InMemorySource<'a> {
+    pub uri: &'a str,
+    pub text: &'a str,
+    pub version: i32,
+    pub language: LangId,
+}
+
+/// Extraction result tied to the editor document version that produced it.
+#[derive(Debug, Clone)]
+pub struct VersionedExtraction {
+    pub uri: String,
+    pub version: i32,
+    pub file: FileExtraction,
+}
+
 pub fn extract(files: &[(std::path::PathBuf, LangId)]) -> ExtractionResult {
     extract_with_options(files, &ExtractOptions::default())
 }

--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -8,6 +8,8 @@
 //! symbol listing is needed (e.g. inspect mode); skips the import and
 //! reference query passes, roughly halving per-file extraction time.
 
+use std::path::{Path, PathBuf};
+
 use rayon::prelude::*;
 
 use crate::error::{Diagnostic, Severity};

--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -185,14 +185,14 @@ fn extract_source(
         });
     }
 
-    let raw_symbols = crate::language::extract_symbols_for(*lang, &tree, &source);
+    let raw_symbols = crate::language::extract_symbols_for(lang, &tree, source);
     let symbols = raw_symbols
         .into_iter()
         .map(|raw| Symbol {
-            id: id_gen.next(),
+            id: id_generators.symbols.next(),
             name: raw.name.into_owned(),
             kind: raw.kind,
-            language: *lang,
+            language: lang,
             file_path: path.to_path_buf(),
             source_range: raw.source_range,
             visibility: raw.visibility,
@@ -205,19 +205,19 @@ fn extract_source(
     let (imports, references) = if opts.skip_imports_and_refs {
         (Vec::new(), Vec::new())
     } else {
-        crate::language::extract_imports_and_references_for(*lang, &tree, &source, path)
+        crate::language::extract_imports_and_references_for(lang, &tree, source, path)
     };
 
     #[cfg(feature = "metacall-deploy")]
-    let call_sites = crate::deploy::scanner::scan_file(*lang, &tree, &source, path);
+    let call_sites = crate::deploy::scanner::scan_file(lang, &tree, source, path);
 
     #[cfg(feature = "dataflow")]
     let (data_nodes, flow_edges) =
-        crate::language::dataflow::extract_dataflow(*lang, &tree, &source, data_id_gen);
+        crate::language::dataflow::extract_dataflow(lang, &tree, source, &id_generators.data_nodes);
 
     FileExtraction {
         path: path.to_path_buf(),
-        lang: *lang,
+        lang,
         symbols,
         imports,
         references,

--- a/src/language/import_resolver.rs
+++ b/src/language/import_resolver.rs
@@ -15,6 +15,9 @@ use std::sync::{OnceLock, RwLock};
 /// config file reads (tsconfig.json, go.mod, sys.path) on first use.
 pub trait ImportResolver: Send + Sync {
     fn resolve(&self, raw: &str, source_dir: &Path, project_root: &Path) -> Option<PathBuf>;
+
+    /// Invalidate any memoized filesystem state or configuration caches.
+    fn clear_cache(&self) {}
 }
 
 /// Zero-cost adapter wrapping a stateless function pointer.

--- a/src/language/import_resolver.rs
+++ b/src/language/import_resolver.rs
@@ -177,6 +177,10 @@ impl ImportResolver for GoModResolver {
 
         (self.f)(raw, source_dir, project_root)
     }
+
+    fn clear_cache(&self) {
+        GoModResolver::clear_cache(self);
+    }
 }
 
 /// Stateful resolver for JavaScript import paths.
@@ -190,6 +194,12 @@ impl JsResolver {
         Self {
             f,
             is_file_cache: RwLock::new(HashMap::new()),
+        }
+    }
+
+    pub fn clear_cache(&self) {
+        if let Ok(mut cache) = self.is_file_cache.write() {
+            cache.clear();
         }
     }
 }

--- a/src/language/import_resolver.rs
+++ b/src/language/import_resolver.rs
@@ -329,6 +329,10 @@ impl ImportResolver for TsConfigResolver {
 
         (self.f)(raw, source_dir, project_root)
     }
+
+    fn clear_cache(&self) {
+        TsConfigResolver::clear_cache(self);
+    }
 }
 
 /// Construct a boxed `ImportResolver` for the given language.

--- a/src/language/import_resolver.rs
+++ b/src/language/import_resolver.rs
@@ -143,25 +143,42 @@ impl ImportResolver for GoModResolver {
             return Some(path.with_extension("go"));
         }
 
-        let module_info = self.cached_module.get_or_init(|| {
-            let mut current = Some(project_root);
-            while let Some(dir) = current {
-                let go_mod = dir.join("go.mod");
-                if go_mod.is_file() {
-                    if let Ok(content) = std::fs::read_to_string(&go_mod) {
-                        for line in content.lines() {
-                            let line = line.trim();
-                            if let Some(module) = line.strip_prefix("module ") {
-                                return Some((dir.to_path_buf(), module.trim().to_string()));
+        let cached = self
+            .cached_module
+            .read()
+            .ok()
+            .and_then(|guard| guard.clone());
+        let module_info = match cached {
+            Some(info) => info,
+            None => {
+                let computed = {
+                    let mut current = Some(project_root);
+                    let mut found = None;
+                    while let Some(dir) = current {
+                        let go_mod = dir.join("go.mod");
+                        if go_mod.is_file() {
+                            if let Ok(content) = std::fs::read_to_string(&go_mod) {
+                                for line in content.lines() {
+                                    let line = line.trim();
+                                    if let Some(module) = line.strip_prefix("module ") {
+                                        found =
+                                            Some((dir.to_path_buf(), module.trim().to_string()));
+                                        break;
+                                    }
+                                }
                             }
+                            break;
                         }
+                        current = dir.parent();
                     }
-                    break;
+                    found
+                };
+                if let Ok(mut guard) = self.cached_module.write() {
+                    *guard = Some(computed.clone());
                 }
-                current = dir.parent();
+                computed
             }
-            None
-        });
+        };
 
         let matched_module = module_info.as_ref().and_then(|(dir, name)| {
             if raw.starts_with(name) {

--- a/src/language/import_resolver.rs
+++ b/src/language/import_resolver.rs
@@ -53,6 +53,12 @@ impl PythonResolver {
             exists_cache: RwLock::new(HashMap::new()),
         }
     }
+
+    pub fn clear_cache(&self) {
+        if let Ok(mut cache) = self.exists_cache.write() {
+            cache.clear();
+        }
+    }
 }
 
 impl ImportResolver for PythonResolver {
@@ -98,19 +104,29 @@ impl ImportResolver for PythonResolver {
 
         (self.f)(raw, source_dir, project_root)
     }
+
+    fn clear_cache(&self) {
+        PythonResolver::clear_cache(self);
+    }
 }
 
 /// Stateful resolver for Go module import paths.
 pub struct GoModResolver {
     f: fn(&str, &Path, &Path) -> Option<PathBuf>,
-    cached_module: OnceLock<Option<(PathBuf, String)>>,
+    cached_module: RwLock<Option<Option<(PathBuf, String)>>>,
 }
 
 impl GoModResolver {
     pub fn new(f: fn(&str, &Path, &Path) -> Option<PathBuf>) -> Self {
         Self {
             f,
-            cached_module: OnceLock::new(),
+            cached_module: RwLock::new(None),
+        }
+    }
+
+    pub fn clear_cache(&self) {
+        if let Ok(mut guard) = self.cached_module.write() {
+            *guard = None;
         }
     }
 }

--- a/src/language/import_resolver.rs
+++ b/src/language/import_resolver.rs
@@ -55,9 +55,11 @@ impl PythonResolver {
     }
 
     pub fn clear_cache(&self) {
-        if let Ok(mut cache) = self.exists_cache.write() {
-            cache.clear();
-        }
+        let mut cache = self
+            .exists_cache
+            .write()
+            .unwrap_or_else(|poison| poison.into_inner());
+        cache.clear();
     }
 }
 
@@ -125,9 +127,11 @@ impl GoModResolver {
     }
 
     pub fn clear_cache(&self) {
-        if let Ok(mut guard) = self.cached_module.write() {
-            *guard = None;
-        }
+        let mut guard = self
+            .cached_module
+            .write()
+            .unwrap_or_else(|poison| poison.into_inner());
+        *guard = None;
     }
 }
 
@@ -215,9 +219,11 @@ impl JsResolver {
     }
 
     pub fn clear_cache(&self) {
-        if let Ok(mut cache) = self.is_file_cache.write() {
-            cache.clear();
-        }
+        let mut cache = self
+            .is_file_cache
+            .write()
+            .unwrap_or_else(|poison| poison.into_inner());
+        cache.clear();
     }
 }
 
@@ -291,9 +297,11 @@ impl TsConfigResolver {
     }
 
     pub fn clear_cache(&self) {
-        if let Ok(mut cache) = self.is_file_cache.write() {
-            cache.clear();
-        }
+        let mut cache = self
+            .is_file_cache
+            .write()
+            .unwrap_or_else(|poison| poison.into_inner());
+        cache.clear();
     }
 }
 

--- a/src/language/import_resolver.rs
+++ b/src/language/import_resolver.rs
@@ -527,4 +527,84 @@ mod tests {
 
         let _ = std::fs::remove_dir_all(&temp_dir);
     }
+
+    #[test]
+    fn resolver_clear_cache_invalidates_memoized_state() {
+        let temp_dir = std::env::temp_dir().join("resolver_clear_cache_invalidates_memoized_state");
+        if temp_dir.exists() {
+            let _ = std::fs::remove_dir_all(&temp_dir);
+        }
+        std::fs::create_dir_all(&temp_dir).unwrap();
+
+        // 1. Python resolver cache invalidation
+        let pkg_dir = temp_dir.join("py_pkg");
+        std::fs::create_dir_all(&pkg_dir).unwrap();
+        let init_py = pkg_dir.join("__init__.py");
+        std::fs::write(&init_py, "").unwrap();
+        let py_resolver = make_resolver(crate::language::LangId::Python);
+        assert_eq!(
+            py_resolver.resolve("py_pkg", &temp_dir, &temp_dir),
+            Some(init_py.clone())
+        );
+        std::fs::remove_file(&init_py).unwrap();
+        // Still cached:
+        assert_eq!(
+            py_resolver.resolve("py_pkg", &temp_dir, &temp_dir),
+            Some(init_py.clone())
+        );
+        // Invalidate:
+        py_resolver.clear_cache();
+        assert_eq!(
+            py_resolver.resolve("py_pkg", &temp_dir, &temp_dir),
+            Some(temp_dir.join("py_pkg.py"))
+        );
+
+        // 2. Go resolver cache invalidation
+        let go_mod_path = temp_dir.join("go.mod");
+        std::fs::write(&go_mod_path, "module oldmod\n").unwrap();
+        let go_resolver = make_resolver(crate::language::LangId::Go);
+        assert_eq!(
+            go_resolver.resolve("oldmod/sub", &temp_dir, &temp_dir),
+            Some(temp_dir.join("sub.go"))
+        );
+        std::fs::write(&go_mod_path, "module newmod\n").unwrap();
+        // Still cached to oldmod:
+        assert_eq!(
+            go_resolver.resolve("oldmod/sub", &temp_dir, &temp_dir),
+            Some(temp_dir.join("sub.go"))
+        );
+        // Invalidate:
+        go_resolver.clear_cache();
+        assert_eq!(
+            go_resolver.resolve("oldmod/sub", &temp_dir, &temp_dir),
+            None
+        );
+        assert_eq!(
+            go_resolver.resolve("newmod/sub", &temp_dir, &temp_dir),
+            Some(temp_dir.join("sub.go"))
+        );
+
+        // 3. TypeScript resolver cache invalidation
+        let ts_file = temp_dir.join("ts_file.ts");
+        std::fs::write(&ts_file, "").unwrap();
+        let ts_resolver = make_resolver(crate::language::LangId::TypeScript);
+        assert_eq!(
+            ts_resolver.resolve("./ts_file", &temp_dir, &temp_dir),
+            Some(ts_file.clone())
+        );
+        std::fs::remove_file(&ts_file).unwrap();
+        // Still cached:
+        assert_eq!(
+            ts_resolver.resolve("./ts_file", &temp_dir, &temp_dir),
+            Some(ts_file)
+        );
+        // Invalidate:
+        ts_resolver.clear_cache();
+        assert_eq!(
+            ts_resolver.resolve("./ts_file", &temp_dir, &temp_dir),
+            Some(temp_dir.join("./ts_file"))
+        );
+
+        let _ = std::fs::remove_dir_all(&temp_dir);
+    }
 }

--- a/src/language/import_resolver.rs
+++ b/src/language/import_resolver.rs
@@ -6,7 +6,7 @@
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::{OnceLock, RwLock};
+use std::sync::RwLock;
 
 /// Stateful import path resolution seam.
 ///

--- a/src/language/import_resolver.rs
+++ b/src/language/import_resolver.rs
@@ -253,6 +253,10 @@ impl ImportResolver for JsResolver {
 
         (self.f)(raw, source_dir, project_root)
     }
+
+    fn clear_cache(&self) {
+        JsResolver::clear_cache(self);
+    }
 }
 
 /// Stateful resolver for TypeScript import paths using `tsconfig.json`.
@@ -266,6 +270,12 @@ impl TsConfigResolver {
         Self {
             f,
             is_file_cache: RwLock::new(HashMap::new()),
+        }
+    }
+
+    pub fn clear_cache(&self) {
+        if let Ok(mut cache) = self.is_file_cache.write() {
+            cache.clear();
         }
     }
 }

--- a/src/language/mod.rs
+++ b/src/language/mod.rs
@@ -59,6 +59,7 @@ pub enum DefaultVisibility {
     Eq,
     Hash,
     Serialize,
+    Deserialize,
     strum::Display,
     strum::AsRefStr,
     strum::EnumString,

--- a/src/language/mod.rs
+++ b/src/language/mod.rs
@@ -19,7 +19,7 @@ pub(crate) mod rust;
 pub(crate) mod tsx;
 pub(crate) mod typescript;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use tree_sitter::Query;
 
 use crate::model::Visibility;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,12 @@ pub use graph::{
     scc::{DeployabilityHint, Scc, SccAnalysis},
 };
 
-// Pipeline re-exports
+// Shard and index re-exports
+pub use output::shard::{
+    LoadedShard, SHARD_SCHEMA_VERSION, ShardEdge, ShardEdgeKind, ShardError, ShardFile,
+    ShardFlowKind, ShardHeader, ShardManifestRecord, ShardSymbol, read_header, read_manifest,
+    read_shard, restore_shard_edges, write_header, write_manifest, write_shard,
+};
 pub use pipeline::{GraphAnalysis, SnapshotMeta, snapshot_meta};
 
 // Watch-mode re-exports

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,10 @@ pub mod deploy;
 pub mod sink;
 
 pub use error::{Diagnostic, Error, Severity};
+pub use extractor::{
+    ExtractOptions, ExtractionIdGenerators, ExtractionResult, InMemorySource, VersionedExtraction,
+    extract_text_with_id_gen, extract_with_id_gen,
+};
 pub use input::detect_language;
 pub use language::{LangId, LanguageSpec};
 pub use model::{

--- a/src/model/ids.rs
+++ b/src/model/ids.rs
@@ -17,7 +17,9 @@ use serde::{Deserialize, Serialize};
 
 macro_rules! define_id_type {
     ($name:ident) => {
-        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+        #[derive(
+            Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
+        )]
         #[serde(transparent)]
         pub struct $name(NonZeroU32);
 

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -14,9 +14,9 @@ pub use ids::{DataNodeId, FileId, IdGenerator, SnapshotId, SymbolId};
 pub use output::{ClassEntry, FuncEntry, InspectOutput, ObjectEntry};
 
 use crate::language::LangId;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UnresolvedImport {
     pub import_specifier: String,
     pub alias: Option<String>,

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -25,7 +25,7 @@ pub struct UnresolvedImport {
     pub range: SourceRange,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UnresolvedReference {
     pub name: String,
     pub range: SourceRange,
@@ -49,13 +49,13 @@ pub struct FileExtraction {
     pub flow_edges: Vec<FlowEdge>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LineColumn {
     pub line: usize,
     pub column: usize,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SourceRange {
     pub byte_start: usize,
     pub byte_end: usize,
@@ -63,7 +63,7 @@ pub struct SourceRange {
     pub end: LineColumn,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum SymbolKind {
     Function,

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -81,7 +81,7 @@ pub enum SymbolKind {
     TypeAlias,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum Visibility {
     Public,

--- a/src/output/graph.rs
+++ b/src/output/graph.rs
@@ -13,7 +13,7 @@ use crate::graph::scc::{DeployabilityHint, SccAnalysis};
 
 /// Version of the graph export schema.
 /// Incremented on breaking changes to the serialized structure.
-pub const SCHEMA_VERSION: u32 = 1;
+pub const SCHEMA_VERSION: u32 = 2;
 
 /// Complete graph analysis output for serialization.
 ///

--- a/src/output/graph.rs
+++ b/src/output/graph.rs
@@ -251,11 +251,20 @@ impl GraphOutput {
         }
     }
 
-    fn serialize_symbol_node(id: usize, symbol_node: &SymbolNode) -> SerializedNode {
+    fn serialize_symbol_node(
+        graph: &CodeGraph,
+        id: usize,
+        symbol_node: &SymbolNode,
+    ) -> SerializedNode {
+        let file_path = graph
+            .file_node(symbol_node.file_id)
+            .map(|file| file.path.to_string_lossy().to_string());
         SerializedNode {
             id,
             kind: "symbol".to_string(),
             path: None,
+            file_path,
+            source_range: Some(symbol_node.source_range.clone()),
             language: None,
             name: Some(symbol_node.name.clone()),
             symbol_kind: Some(format!("{:?}", symbol_node.kind)),

--- a/src/output/graph.rs
+++ b/src/output/graph.rs
@@ -201,19 +201,21 @@ impl GraphOutput {
         g.node_indices()
             .map(|idx| {
                 let node_data = &g[idx];
-                Self::serialize_node(idx.index(), node_data)
+                Self::serialize_node(graph, idx.index(), node_data)
             })
             .collect()
     }
 
-    fn serialize_node(id: usize, node_data: &NodeData) -> SerializedNode {
+    fn serialize_node(graph: &CodeGraph, id: usize, node_data: &NodeData) -> SerializedNode {
         match node_data {
             NodeData::File(f) => Self::serialize_file_node(id, f),
-            NodeData::Symbol(s) => Self::serialize_symbol_node(id, s),
+            NodeData::Symbol(s) => Self::serialize_symbol_node(graph, id, s),
             NodeData::External(e) => SerializedNode {
                 id,
                 kind: "external".to_string(),
                 path: Some(e.raw_path.clone()),
+                file_path: None,
+                source_range: None,
                 language: Some(e.language.as_ref().to_string()),
                 name: None,
                 symbol_kind: None,

--- a/src/output/graph.rs
+++ b/src/output/graph.rs
@@ -61,9 +61,15 @@ pub struct SerializedNode {
     pub id: usize,
     /// Node kind: "file", "symbol", "external", or "data"
     pub kind: String,
-    /// File path (for file/external nodes)
+    /// File or external path.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub path: Option<String>,
+    /// Defining file path for symbol nodes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub file_path: Option<String>,
+    /// Source range for symbol nodes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_range: Option<crate::model::SourceRange>,
     /// Language identifier (for file/external nodes)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub language: Option<String>,
@@ -227,6 +233,8 @@ impl GraphOutput {
                 id,
                 kind: "data".to_string(),
                 path: None,
+                file_path: None,
+                source_range: None,
                 language: None,
                 name: d.name.clone(),
                 symbol_kind: None,

--- a/src/output/graph.rs
+++ b/src/output/graph.rs
@@ -250,6 +250,8 @@ impl GraphOutput {
             id,
             kind: "file".to_string(),
             path: Some(file_node.path.to_string_lossy().to_string()),
+            file_path: None,
+            source_range: None,
             language: Some(file_node.language.as_ref().to_string()),
             name: None,
             symbol_kind: None,
@@ -472,7 +474,7 @@ mod tests {
 
         assert!(json.contains("\"node_count\":0"));
         assert!(json.contains("\"edge_count\":0"));
-        assert!(json.contains("\"schema_version\":1"));
+        assert!(json.contains("\"schema_version\":2"));
     }
 
     #[test]

--- a/src/output/graph.rs
+++ b/src/output/graph.rs
@@ -453,7 +453,7 @@ mod tests {
         let json = serialize_graph(&graph, &scc, 1, &OutputFormat::Json).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
 
-        assert_eq!(parsed["schema_version"], 1);
+        assert_eq!(parsed["schema_version"], 2);
         assert!(parsed["metadata"].is_object());
         assert!(parsed["nodes"].is_array());
         assert!(parsed["edges"].is_array());

--- a/src/output/graph.rs
+++ b/src/output/graph.rs
@@ -628,6 +628,8 @@ mod tests {
         assert_eq!(output.edges.len(), 1); // ownership
         let sym_node = output.nodes.iter().find(|n| n.kind == "symbol").unwrap();
         assert_eq!(sym_node.name.as_deref(), Some("main_fn"));
+        assert_eq!(sym_node.file_path.as_deref(), Some("main.rs"));
+        assert_eq!(sym_node.source_range.as_ref(), Some(&sample_source_range()));
     }
 
     #[test]

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -2,6 +2,7 @@ pub mod dashboard;
 pub mod emitter;
 pub mod graph;
 pub mod inspect;
+pub mod shard;
 
 use serde::Serialize;
 

--- a/src/output/shard/edge.rs
+++ b/src/output/shard/edge.rs
@@ -1,0 +1,145 @@
+//! Shard edge serialization, validation, and restoration.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::graph::{CodeGraph, EdgeKind, NodeData};
+use crate::output::shard::error::ShardError;
+use crate::output::shard::name::stable_node_name;
+
+/// Serialized cross-node edge in a shard file.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ShardEdge {
+    pub source_name: String,
+    pub target_name: String,
+    pub kind: ShardEdgeKind,
+    pub confidence: f32,
+    pub flow_kind: Option<ShardFlowKind>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ShardEdgeKind {
+    Ownership,
+    Import,
+    Reference,
+    Flow,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ShardFlowKind {
+    DefUse,
+    Argument,
+    Return,
+    FieldAccess,
+}
+
+impl From<EdgeKind> for ShardEdgeKind {
+    fn from(kind: EdgeKind) -> Self {
+        match kind {
+            EdgeKind::Ownership => Self::Ownership,
+            EdgeKind::Import => Self::Import,
+            EdgeKind::Reference => Self::Reference,
+            EdgeKind::Flow => Self::Flow,
+        }
+    }
+}
+
+impl From<ShardEdgeKind> for EdgeKind {
+    fn from(kind: ShardEdgeKind) -> Self {
+        match kind {
+            ShardEdgeKind::Ownership => Self::Ownership,
+            ShardEdgeKind::Import => Self::Import,
+            ShardEdgeKind::Reference => Self::Reference,
+            ShardEdgeKind::Flow => Self::Flow,
+        }
+    }
+}
+
+impl From<crate::model::FlowKind> for ShardFlowKind {
+    fn from(kind: crate::model::FlowKind) -> Self {
+        match kind {
+            crate::model::FlowKind::DefUse => Self::DefUse,
+            crate::model::FlowKind::Argument => Self::Argument,
+            crate::model::FlowKind::Return => Self::Return,
+            crate::model::FlowKind::FieldAccess => Self::FieldAccess,
+        }
+    }
+}
+
+impl From<ShardFlowKind> for crate::model::FlowKind {
+    fn from(kind: ShardFlowKind) -> Self {
+        match kind {
+            ShardFlowKind::DefUse => Self::DefUse,
+            ShardFlowKind::Argument => Self::Argument,
+            ShardFlowKind::Return => Self::Return,
+            ShardFlowKind::FieldAccess => Self::FieldAccess,
+        }
+    }
+}
+
+pub(crate) fn validate_edge(
+    edge: &ShardEdge,
+    line: usize,
+    edge_index: usize,
+) -> Result<(), ShardError> {
+    let valid_confidence = edge.confidence.is_finite() && (0.0..=1.0).contains(&edge.confidence);
+    if !valid_confidence {
+        return Err(ShardError::InvalidEdge {
+            line,
+            edge_index,
+            message: "confidence must be finite and in the range 0.0..=1.0".to_string(),
+        });
+    }
+    if edge.kind == ShardEdgeKind::Flow {
+        return Err(ShardError::InvalidEdge {
+            line,
+            edge_index,
+            message: "schema version 2 does not persist dataflow nodes".to_string(),
+        });
+    }
+    if edge.flow_kind.is_some() {
+        return Err(ShardError::InvalidEdge {
+            line,
+            edge_index,
+            message: "non-flow edges forbid flow_kind".to_string(),
+        });
+    }
+    Ok(())
+}
+
+/// Restore persisted edges after `GraphBuilder::from_extractions` regenerates graph nodes.
+pub fn restore_shard_edges(graph: &mut CodeGraph, edges: &[ShardEdge]) -> Result<(), ShardError> {
+    let endpoint_index = graph
+        .graph()
+        .node_indices()
+        .filter(|index| !matches!(graph.graph()[*index], NodeData::Data(_)))
+        .map(|index| stable_node_name(graph, index).map(|name| (name, index)))
+        .collect::<Result<HashMap<_, _>, ShardError>>()?;
+
+    for edge in edges {
+        validate_edge(edge, 0, 0)?;
+        let source = endpoint_index
+            .get(&edge.source_name)
+            .copied()
+            .ok_or_else(|| ShardError::MissingEndpoint {
+                name: edge.source_name.clone(),
+            })?;
+        let target = endpoint_index
+            .get(&edge.target_name)
+            .copied()
+            .ok_or_else(|| ShardError::MissingEndpoint {
+                name: edge.target_name.clone(),
+            })?;
+        graph.add_edge_normalized_with_flow(
+            source,
+            target,
+            edge.kind.into(),
+            edge.confidence,
+            edge.flow_kind.map(Into::into),
+        );
+    }
+    Ok(())
+}

--- a/src/output/shard/edge.rs
+++ b/src/output/shard/edge.rs
@@ -119,8 +119,8 @@ pub fn restore_shard_edges(graph: &mut CodeGraph, edges: &[ShardEdge]) -> Result
         .map(|index| stable_node_name(graph, index).map(|name| (name, index)))
         .collect::<Result<HashMap<_, _>, ShardError>>()?;
 
-    for edge in edges {
-        validate_edge(edge, 0, 0)?;
+    for (edge_index, edge) in edges.iter().enumerate() {
+        validate_edge(edge, 0, edge_index)?;
         let source = endpoint_index
             .get(&edge.source_name)
             .copied()

--- a/src/output/shard/error.rs
+++ b/src/output/shard/error.rs
@@ -1,0 +1,43 @@
+//! Error definitions for shard serialization and deserialization.
+
+use std::path::PathBuf;
+
+/// Failures that can occur during shard reading, writing, or restoration.
+#[derive(Debug, thiserror::Error)]
+pub enum ShardError {
+    #[error("shard IO failed: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("failed to encode shard record: {0}")]
+    Encode(serde_json::Error),
+
+    #[error("invalid shard JSON on line {line}: {source}")]
+    Decode {
+        line: usize,
+        #[source]
+        source: serde_json::Error,
+    },
+
+    #[error("unsupported shard schema version {found} on line {line}; expected {expected}")]
+    SchemaVersion {
+        line: usize,
+        found: u32,
+        expected: u32,
+    },
+
+    #[error("graph node {node_index} has no stable file owner")]
+    MissingNodeOwner { node_index: usize },
+
+    #[error("shard edge endpoint '{name}' does not exist in the rebuilt graph")]
+    MissingEndpoint { name: String },
+
+    #[error("path is not valid UTF-8: {path:?}")]
+    NonUtf8Path { path: PathBuf },
+
+    #[error("invalid edge {edge_index} on shard line {line}: {message}")]
+    InvalidEdge {
+        line: usize,
+        edge_index: usize,
+        message: String,
+    },
+}

--- a/src/output/shard/file.rs
+++ b/src/output/shard/file.rs
@@ -184,6 +184,9 @@ impl ShardSymbol {
     }
 }
 
+/// Write shard records to a writer in JSONL format.
+///
+/// Use `std::io::BufWriter` when writing to a file to prevent frequent write system calls.
 pub fn write_shard<W: Write>(mut writer: W, files: &[ShardFile]) -> Result<(), ShardError> {
     for (line_index, file) in files.iter().enumerate() {
         validate_file(file, line_index + 1)?;

--- a/src/output/shard/file.rs
+++ b/src/output/shard/file.rs
@@ -1,0 +1,231 @@
+//! Shard file record representation and JSONL read/write operations.
+
+use std::io::{BufRead, Write};
+use std::path::{Path, PathBuf};
+
+use petgraph::visit::EdgeRef;
+use serde::{Deserialize, Serialize};
+
+use crate::error::Diagnostic;
+use crate::graph::{CodeGraph, NodeData};
+use crate::language::LangId;
+use crate::model::{
+    FileExtraction, IdGenerator, SourceRange, Symbol, SymbolId, SymbolKind, UnresolvedImport,
+    UnresolvedReference, Visibility,
+};
+use crate::output::shard::edge::{ShardEdge, validate_edge};
+use crate::output::shard::error::ShardError;
+use crate::output::shard::name::{node_belongs_to_file, normalized_path, stable_node_name};
+
+pub const SHARD_SCHEMA_VERSION: u32 = 2;
+
+/// A per-file shard record stored in `.meta-ast/shards/<n>.jsonl`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ShardFile {
+    pub schema_version: u32,
+    pub path: PathBuf,
+    pub language: LangId,
+    pub symbols: Vec<ShardSymbol>,
+    pub imports: Vec<UnresolvedImport>,
+    pub references: Vec<UnresolvedReference>,
+    pub diagnostics: Vec<Diagnostic>,
+    pub ast_node_count: usize,
+    pub edges: Vec<ShardEdge>,
+}
+
+/// Symbol representation in a shard file without runtime-local identifiers.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ShardSymbol {
+    pub name: String,
+    pub kind: SymbolKind,
+    pub source_range: SourceRange,
+    pub visibility: Option<Visibility>,
+    pub signature: Option<String>,
+    pub docstring: Option<String>,
+    pub is_async: bool,
+}
+
+/// Extraction result reconstituted from a shard record.
+#[derive(Debug)]
+pub struct LoadedShard {
+    pub file: FileExtraction,
+    pub edges: Vec<ShardEdge>,
+}
+
+impl ShardFile {
+    /// Convert an in-memory `FileExtraction` and graph into a shard record.
+    pub fn from_extraction(
+        extraction: &FileExtraction,
+        graph: &CodeGraph,
+    ) -> Result<Self, ShardError> {
+        normalized_path(&extraction.path)?;
+        for diagnostic in &extraction.diagnostics {
+            normalized_path(&diagnostic.path)?;
+        }
+        let symbols = extraction.symbols.iter().map(ShardSymbol::from).collect();
+        let mut edges = graph
+            .graph()
+            .edge_references()
+            .filter(|edge| {
+                !matches!(graph.graph()[edge.source()], NodeData::Data(_))
+                    && !matches!(graph.graph()[edge.target()], NodeData::Data(_))
+                    && (node_belongs_to_file(graph, edge.source(), &extraction.path)
+                        || node_belongs_to_file(graph, edge.target(), &extraction.path))
+            })
+            .map(|edge| {
+                let source_name = stable_node_name(graph, edge.source())?;
+                let target_name = stable_node_name(graph, edge.target())?;
+                Ok(ShardEdge {
+                    source_name,
+                    target_name,
+                    kind: edge.weight().kind.into(),
+                    confidence: edge.weight().confidence,
+                    flow_kind: edge.weight().flow_kind.map(Into::into),
+                })
+            })
+            .collect::<Result<Vec<_>, ShardError>>()?;
+        edges.sort_by(|left, right| {
+            (
+                &left.source_name,
+                &left.target_name,
+                left.kind,
+                left.flow_kind,
+            )
+                .cmp(&(
+                    &right.source_name,
+                    &right.target_name,
+                    right.kind,
+                    right.flow_kind,
+                ))
+        });
+        for (edge_index, edge) in edges.iter().enumerate() {
+            validate_edge(edge, 1, edge_index)?;
+        }
+
+        Ok(Self {
+            schema_version: SHARD_SCHEMA_VERSION,
+            path: extraction.path.clone(),
+            language: extraction.lang,
+            symbols,
+            imports: extraction.imports.clone(),
+            references: extraction.references.clone(),
+            diagnostics: extraction.diagnostics.clone(),
+            ast_node_count: extraction.ast_node_count,
+            edges,
+        })
+    }
+
+    /// Reconstitute a `FileExtraction` and assign fresh IDs using the provided generator.
+    pub fn load(self, id_gen: &IdGenerator<SymbolId>) -> Result<LoadedShard, ShardError> {
+        if self.schema_version != SHARD_SCHEMA_VERSION {
+            return Err(ShardError::SchemaVersion {
+                line: 1,
+                found: self.schema_version,
+                expected: SHARD_SCHEMA_VERSION,
+            });
+        }
+
+        let symbols = self
+            .symbols
+            .into_iter()
+            .map(|symbol| symbol.into_symbol(&self.path, self.language, id_gen.next()))
+            .collect();
+        let file = FileExtraction {
+            path: self.path,
+            lang: self.language,
+            symbols,
+            imports: self.imports,
+            references: self.references,
+            diagnostics: self.diagnostics,
+            ast_node_count: self.ast_node_count,
+            #[cfg(feature = "metacall-deploy")]
+            call_sites: Vec::new(),
+            #[cfg(feature = "dataflow")]
+            data_nodes: Vec::new(),
+            #[cfg(feature = "dataflow")]
+            flow_edges: Vec::new(),
+        };
+
+        Ok(LoadedShard {
+            file,
+            edges: self.edges,
+        })
+    }
+}
+
+impl From<&Symbol> for ShardSymbol {
+    fn from(symbol: &Symbol) -> Self {
+        Self {
+            name: symbol.name.clone(),
+            kind: symbol.kind,
+            source_range: symbol.source_range.clone(),
+            visibility: symbol.visibility,
+            signature: symbol.signature.clone(),
+            docstring: symbol.docstring.clone(),
+            is_async: symbol.is_async,
+        }
+    }
+}
+
+impl ShardSymbol {
+    fn into_symbol(self, file_path: &Path, language: LangId, id: SymbolId) -> Symbol {
+        Symbol {
+            id,
+            name: self.name,
+            kind: self.kind,
+            language,
+            file_path: file_path.to_path_buf(),
+            source_range: self.source_range,
+            visibility: self.visibility,
+            signature: self.signature,
+            docstring: self.docstring,
+            is_async: self.is_async,
+        }
+    }
+}
+
+pub fn write_shard<W: Write>(mut writer: W, files: &[ShardFile]) -> Result<(), ShardError> {
+    for (line_index, file) in files.iter().enumerate() {
+        validate_file(file, line_index + 1)?;
+        serde_json::to_writer(&mut writer, file).map_err(ShardError::Encode)?;
+        writer.write_all(b"\n")?;
+    }
+    writer.flush()?;
+    Ok(())
+}
+
+pub fn read_shard<R: BufRead>(reader: R) -> Result<Vec<ShardFile>, ShardError> {
+    let mut files = Vec::new();
+    for (line_index, line) in reader.lines().enumerate() {
+        let line_number = line_index + 1;
+        let line = line?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let file: ShardFile = serde_json::from_str(&line).map_err(|source| ShardError::Decode {
+            line: line_number,
+            source,
+        })?;
+        validate_file(&file, line_number)?;
+        files.push(file);
+    }
+    Ok(files)
+}
+
+pub(crate) fn validate_file(file: &ShardFile, line: usize) -> Result<(), ShardError> {
+    if file.schema_version != SHARD_SCHEMA_VERSION {
+        return Err(ShardError::SchemaVersion {
+            line,
+            found: file.schema_version,
+            expected: SHARD_SCHEMA_VERSION,
+        });
+    }
+    normalized_path(&file.path)?;
+    for diagnostic in &file.diagnostics {
+        normalized_path(&diagnostic.path)?;
+    }
+    for (edge_index, edge) in file.edges.iter().enumerate() {
+        validate_edge(edge, line, edge_index)?;
+    }
+    Ok(())
+}

--- a/src/output/shard/header.rs
+++ b/src/output/shard/header.rs
@@ -1,0 +1,74 @@
+//! Shard header representation and JSON read/write operations.
+//!
+//! `.meta-ast/header.json` defines metadata for the index directory including
+//! the schema version, tool version, and index creation timestamp.
+
+use std::io::{Read, Write};
+
+use serde::{Deserialize, Serialize};
+
+use crate::output::shard::error::ShardError;
+use crate::output::shard::file::SHARD_SCHEMA_VERSION;
+
+/// Global index header stored in `.meta-ast/header.json`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ShardHeader {
+    /// Index schema version.
+    pub schema_version: u32,
+    /// Version of the creating tool (e.g., meta-ast version).
+    pub tool_version: String,
+    /// ISO 8601 creation timestamp.
+    pub created_at: String,
+}
+
+impl ShardHeader {
+    /// Create a new index header with the current crate version.
+    pub fn new(created_at: impl Into<String>) -> Self {
+        Self {
+            schema_version: SHARD_SCHEMA_VERSION,
+            tool_version: env!("CARGO_PKG_VERSION").to_string(),
+            created_at: created_at.into(),
+        }
+    }
+
+    /// Create an index header with a custom tool version.
+    pub fn with_tool_version(
+        tool_version: impl Into<String>,
+        created_at: impl Into<String>,
+    ) -> Self {
+        Self {
+            schema_version: SHARD_SCHEMA_VERSION,
+            tool_version: tool_version.into(),
+            created_at: created_at.into(),
+        }
+    }
+}
+
+/// Write the header to a writer as formatted JSON.
+pub fn write_header<W: Write>(mut writer: W, header: &ShardHeader) -> Result<(), ShardError> {
+    if header.schema_version != SHARD_SCHEMA_VERSION {
+        return Err(ShardError::SchemaVersion {
+            line: 1,
+            found: header.schema_version,
+            expected: SHARD_SCHEMA_VERSION,
+        });
+    }
+    serde_json::to_writer_pretty(&mut writer, header).map_err(ShardError::Encode)?;
+    writer.write_all(b"\n")?;
+    writer.flush()?;
+    Ok(())
+}
+
+/// Read the header from a reader.
+pub fn read_header<R: Read>(reader: R) -> Result<ShardHeader, ShardError> {
+    let header: ShardHeader =
+        serde_json::from_reader(reader).map_err(|source| ShardError::Decode { line: 1, source })?;
+    if header.schema_version != SHARD_SCHEMA_VERSION {
+        return Err(ShardError::SchemaVersion {
+            line: 1,
+            found: header.schema_version,
+            expected: SHARD_SCHEMA_VERSION,
+        });
+    }
+    Ok(header)
+}

--- a/src/output/shard/manifest.rs
+++ b/src/output/shard/manifest.rs
@@ -1,0 +1,103 @@
+//! Shard manifest representation and JSONL read/write operations.
+//!
+//! `.meta-ast/manifest.jsonl` tracks one record per indexed file with its
+//! BLAKE3 content hash, byte size, modification timestamp, shard location,
+//! and schema version.
+
+use std::io::{BufRead, Write};
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use crate::output::shard::error::ShardError;
+use crate::output::shard::file::SHARD_SCHEMA_VERSION;
+use crate::output::shard::name::normalized_path;
+
+/// One line in `.meta-ast/manifest.jsonl`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ShardManifestRecord {
+    /// Relative path of the indexed file.
+    pub path: PathBuf,
+    /// BLAKE3 hex hash of the file contents.
+    pub content_hash: String,
+    /// File size in bytes.
+    pub size: u64,
+    /// Modification timestamp in seconds since Unix epoch.
+    pub mtime: u64,
+    /// Shard filename (e.g., "0.jsonl" or "shards/0.jsonl").
+    pub shard: String,
+    /// Shard schema version.
+    pub schema_version: u32,
+}
+
+impl ShardManifestRecord {
+    /// Create a new manifest record.
+    pub fn new(path: PathBuf, content_hash: String, size: u64, mtime: u64, shard: String) -> Self {
+        Self {
+            path,
+            content_hash,
+            size,
+            mtime,
+            shard,
+            schema_version: SHARD_SCHEMA_VERSION,
+        }
+    }
+
+    /// Compute the BLAKE3 hex hash for source bytes.
+    pub fn compute_hash(bytes: &[u8]) -> String {
+        blake3::hash(bytes).to_hex().to_string()
+    }
+
+    /// Create a record by hashing in-memory bytes directly.
+    pub fn from_file_bytes(path: PathBuf, bytes: &[u8], mtime: u64, shard: String) -> Self {
+        let content_hash = Self::compute_hash(bytes);
+        let size = bytes.len() as u64;
+        Self::new(path, content_hash, size, mtime, shard)
+    }
+}
+
+/// Write manifest records to a writer in JSONL format.
+pub fn write_manifest<W: Write>(
+    mut writer: W,
+    records: &[ShardManifestRecord],
+) -> Result<(), ShardError> {
+    for (line_index, record) in records.iter().enumerate() {
+        validate_manifest_record(record, line_index + 1)?;
+        serde_json::to_writer(&mut writer, record).map_err(ShardError::Encode)?;
+        writer.write_all(b"\n")?;
+    }
+    writer.flush()?;
+    Ok(())
+}
+
+/// Read manifest records from a buffered JSONL reader.
+pub fn read_manifest<R: BufRead>(reader: R) -> Result<Vec<ShardManifestRecord>, ShardError> {
+    let mut records = Vec::new();
+    for (line_index, line) in reader.lines().enumerate() {
+        let line_number = line_index + 1;
+        let line = line?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let record: ShardManifestRecord =
+            serde_json::from_str(&line).map_err(|source| ShardError::Decode {
+                line: line_number,
+                source,
+            })?;
+        validate_manifest_record(&record, line_number)?;
+        records.push(record);
+    }
+    Ok(records)
+}
+
+fn validate_manifest_record(record: &ShardManifestRecord, line: usize) -> Result<(), ShardError> {
+    if record.schema_version != SHARD_SCHEMA_VERSION {
+        return Err(ShardError::SchemaVersion {
+            line,
+            found: record.schema_version,
+            expected: SHARD_SCHEMA_VERSION,
+        });
+    }
+    normalized_path(&record.path)?;
+    Ok(())
+}

--- a/src/output/shard/manifest.rs
+++ b/src/output/shard/manifest.rs
@@ -57,6 +57,8 @@ impl ShardManifestRecord {
 }
 
 /// Write manifest records to a writer in JSONL format.
+///
+/// Use `std::io::BufWriter` when writing to a file to prevent frequent write system calls.
 pub fn write_manifest<W: Write>(
     mut writer: W,
     records: &[ShardManifestRecord],

--- a/src/output/shard/mod.rs
+++ b/src/output/shard/mod.rs
@@ -296,4 +296,83 @@ mod tests {
         assert_eq!(decoded.len(), 1);
         assert_eq!(decoded[0], record);
     }
+
+    #[test]
+    fn duplicate_symbol_names_receive_deterministic_ordinals() {
+        let path = PathBuf::from("src/overload.py");
+        let sym1 = Symbol {
+            id: SymbolId::new(1).unwrap(),
+            name: "process".to_string(),
+            kind: SymbolKind::Function,
+            language: LangId::Python,
+            file_path: path.clone(),
+            source_range: SourceRange {
+                byte_start: 10,
+                byte_end: 30,
+                start: LineColumn { line: 1, column: 0 },
+                end: LineColumn {
+                    line: 2,
+                    column: 10,
+                },
+            },
+            visibility: Some(Visibility::Public),
+            signature: Some("def process(a: int)".to_string()),
+            docstring: None,
+            is_async: false,
+        };
+        let sym2 = Symbol {
+            id: SymbolId::new(2).unwrap(),
+            name: "process".to_string(),
+            kind: SymbolKind::Function,
+            language: LangId::Python,
+            file_path: path.clone(),
+            source_range: SourceRange {
+                byte_start: 40,
+                byte_end: 60,
+                start: LineColumn { line: 3, column: 0 },
+                end: LineColumn {
+                    line: 4,
+                    column: 10,
+                },
+            },
+            visibility: Some(Visibility::Public),
+            signature: Some("def process(a: str)".to_string()),
+            docstring: None,
+            is_async: false,
+        };
+        let extraction = FileExtraction {
+            path,
+            lang: LangId::Python,
+            symbols: vec![sym1, sym2],
+            imports: Vec::new(),
+            references: Vec::new(),
+            diagnostics: Vec::new(),
+            ast_node_count: 5,
+            #[cfg(feature = "metacall-deploy")]
+            call_sites: Vec::new(),
+            #[cfg(feature = "dataflow")]
+            data_nodes: Vec::new(),
+            #[cfg(feature = "dataflow")]
+            flow_edges: Vec::new(),
+        };
+        let mut diagnostics = Vec::new();
+        let (graph, _) = GraphBuilder::from_extractions(
+            std::slice::from_ref(&extraction),
+            Path::new("."),
+            SnapshotId::new(1).unwrap(),
+            &mut diagnostics,
+        );
+        let shard = ShardFile::from_extraction(&extraction, &graph).unwrap();
+        let edge_targets: Vec<_> = shard.edges.iter().map(|e| &e.target_name).collect();
+        assert!(
+            edge_targets
+                .iter()
+                .any(|name| name.contains("process#function!0"))
+        );
+        assert!(
+            edge_targets
+                .iter()
+                .any(|name| name.contains("process#function!1"))
+        );
+    }
 }

--- a/src/output/shard/mod.rs
+++ b/src/output/shard/mod.rs
@@ -1,0 +1,299 @@
+//! `.metast` v2 JSONL shard and index serialization.
+//!
+//! Provides the persistence model for `.meta-ast/` index directories:
+//! - `shards/<n>.jsonl`: Per-file AST symbols, unresolved items, and stable-name graph edges.
+//! - `manifest.jsonl`: File metadata with BLAKE3 content hashes.
+//! - `header.json`: Index schema and versioning metadata.
+//!
+//! Shards persist stable language-scoped qualified names instead of run-local graph identifiers.
+//! Loading regenerates symbol identifiers through the caller's `IdGenerator`.
+
+pub mod edge;
+pub mod error;
+pub mod file;
+pub mod header;
+pub mod manifest;
+pub(crate) mod name;
+
+pub use edge::{ShardEdge, ShardEdgeKind, ShardFlowKind, restore_shard_edges};
+pub use error::ShardError;
+pub use file::{
+    LoadedShard, SHARD_SCHEMA_VERSION, ShardFile, ShardSymbol, read_shard, write_shard,
+};
+pub use header::{ShardHeader, read_header, write_header};
+pub use manifest::{ShardManifestRecord, read_manifest, write_manifest};
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+    use std::path::{Path, PathBuf};
+
+    use super::*;
+    use crate::graph::{EdgeKind, GraphBuilder};
+    use crate::language::LangId;
+    use crate::model::{
+        FileExtraction, IdGenerator, LineColumn, SnapshotId, SourceRange, Symbol, SymbolId,
+        SymbolKind, Visibility,
+    };
+
+    fn range() -> SourceRange {
+        SourceRange {
+            byte_start: 0,
+            byte_end: 12,
+            start: LineColumn { line: 0, column: 0 },
+            end: LineColumn {
+                line: 0,
+                column: 12,
+            },
+        }
+    }
+
+    fn extraction() -> FileExtraction {
+        let path = PathBuf::from("src/example.py");
+        FileExtraction {
+            path: path.clone(),
+            lang: LangId::Python,
+            symbols: vec![Symbol {
+                id: SymbolId::new(91).unwrap(),
+                name: "encrypt".to_string(),
+                kind: SymbolKind::Function,
+                language: LangId::Python,
+                file_path: path,
+                source_range: range(),
+                visibility: Some(Visibility::Public),
+                signature: Some("def encrypt(value: str)".to_string()),
+                docstring: Some("Encrypt a value.".to_string()),
+                is_async: false,
+            }],
+            imports: Vec::new(),
+            references: Vec::new(),
+            diagnostics: Vec::new(),
+            ast_node_count: 7,
+            #[cfg(feature = "metacall-deploy")]
+            call_sites: Vec::new(),
+            #[cfg(feature = "dataflow")]
+            data_nodes: Vec::new(),
+            #[cfg(feature = "dataflow")]
+            flow_edges: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn shard_round_trip_regenerates_symbol_ids() {
+        let extraction = extraction();
+        let mut diagnostics = Vec::new();
+        let (graph, _) = GraphBuilder::from_extractions(
+            std::slice::from_ref(&extraction),
+            Path::new("."),
+            SnapshotId::new(1).unwrap(),
+            &mut diagnostics,
+        );
+        let shard = ShardFile::from_extraction(&extraction, &graph).unwrap();
+        let mut bytes = Vec::new();
+        write_shard(&mut bytes, &[shard]).unwrap();
+        let decoded = read_shard(Cursor::new(bytes)).unwrap();
+        let loaded = decoded
+            .into_iter()
+            .next()
+            .unwrap()
+            .load(&IdGenerator::with_start(500))
+            .unwrap();
+
+        assert_eq!(loaded.file.symbols[0].id, SymbolId::new(500).unwrap());
+        assert_eq!(loaded.file.symbols[0].name, "encrypt");
+        assert_eq!(loaded.file.symbols[0].source_range, range());
+        assert_eq!(loaded.edges.len(), 1);
+    }
+
+    #[test]
+    fn shard_json_omits_numeric_graph_ids() {
+        let extraction = extraction();
+        let mut diagnostics = Vec::new();
+        let (graph, _) = GraphBuilder::from_extractions(
+            std::slice::from_ref(&extraction),
+            Path::new("."),
+            SnapshotId::new(1).unwrap(),
+            &mut diagnostics,
+        );
+        let shard = ShardFile::from_extraction(&extraction, &graph).unwrap();
+        let json = serde_json::to_string(&shard).unwrap();
+
+        assert!(!json.contains("\"id\""));
+        assert!(json.contains("python src%2Fexample.py . encrypt#function!0 ."));
+        assert!(json.contains("\"kind\":\"ownership\""));
+    }
+
+    #[test]
+    fn stable_symbol_name_ignores_source_offset_changes() {
+        let first = extraction();
+        let mut shifted = first.clone();
+        shifted.symbols[0].source_range.byte_start = 100;
+        shifted.symbols[0].source_range.byte_end = 112;
+        let mut diagnostics = Vec::new();
+        let (first_graph, _) = GraphBuilder::from_extractions(
+            std::slice::from_ref(&first),
+            Path::new("."),
+            SnapshotId::new(1).unwrap(),
+            &mut diagnostics,
+        );
+        let (shifted_graph, _) = GraphBuilder::from_extractions(
+            std::slice::from_ref(&shifted),
+            Path::new("."),
+            SnapshotId::new(2).unwrap(),
+            &mut diagnostics,
+        );
+        let first_shard = ShardFile::from_extraction(&first, &first_graph).unwrap();
+        let shifted_shard = ShardFile::from_extraction(&shifted, &shifted_graph).unwrap();
+
+        assert_eq!(
+            first_shard.edges[0].target_name,
+            shifted_shard.edges[0].target_name
+        );
+    }
+
+    #[test]
+    fn restored_edges_use_graph_normalization() {
+        let extraction = extraction();
+        let mut diagnostics = Vec::new();
+        let (mut graph, _) = GraphBuilder::from_extractions(
+            std::slice::from_ref(&extraction),
+            Path::new("."),
+            SnapshotId::new(1).unwrap(),
+            &mut diagnostics,
+        );
+        let file_index = graph
+            .files()
+            .next()
+            .and_then(|(id, _)| graph.file_node_index(id))
+            .unwrap();
+        let symbol_index = graph
+            .symbols()
+            .next()
+            .and_then(|(id, _)| graph.symbol_node_index(id))
+            .unwrap();
+        graph.add_edge_normalized(file_index, symbol_index, EdgeKind::Reference, 0.4);
+        let shard = ShardFile::from_extraction(&extraction, &graph).unwrap();
+        let loaded = shard.load(&IdGenerator::with_start(500)).unwrap();
+        let (mut rebuilt, _) = GraphBuilder::from_extractions(
+            std::slice::from_ref(&loaded.file),
+            Path::new("."),
+            SnapshotId::new(2).unwrap(),
+            &mut diagnostics,
+        );
+
+        restore_shard_edges(&mut rebuilt, &loaded.edges).unwrap();
+
+        let references = rebuilt.edges_of_kind(EdgeKind::Reference).count();
+        assert_eq!(references, 1);
+    }
+
+    #[test]
+    fn reader_reports_line_for_invalid_json() {
+        let error = read_shard(Cursor::new("\n{invalid}\n")).unwrap_err();
+        assert!(matches!(error, ShardError::Decode { line: 2, .. }));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_backslash_and_separator_paths_stay_distinct() {
+        let backslash = name::normalized_path(Path::new("a\\b.py")).unwrap();
+        let separator = name::normalized_path(Path::new("a/b.py")).unwrap();
+        assert_ne!(backslash, separator);
+    }
+
+    #[test]
+    fn reader_rejects_invalid_edge_metadata() {
+        let file = ShardFile {
+            schema_version: SHARD_SCHEMA_VERSION,
+            path: PathBuf::from("a.py"),
+            language: LangId::Python,
+            symbols: Vec::new(),
+            imports: Vec::new(),
+            references: Vec::new(),
+            diagnostics: Vec::new(),
+            ast_node_count: 0,
+            edges: vec![ShardEdge {
+                source_name: "python file a.py".to_string(),
+                target_name: "python file b.py".to_string(),
+                kind: ShardEdgeKind::Import,
+                confidence: 1.5,
+                flow_kind: None,
+            }],
+        };
+        let mut output = Vec::new();
+        let write_error = write_shard(&mut output, std::slice::from_ref(&file)).unwrap_err();
+        assert!(matches!(
+            write_error,
+            ShardError::InvalidEdge { line: 1, .. }
+        ));
+
+        let input = format!("{}\n", serde_json::to_string(&file).unwrap());
+        let read_error = read_shard(Cursor::new(input)).unwrap_err();
+        assert!(matches!(
+            read_error,
+            ShardError::InvalidEdge { line: 1, .. }
+        ));
+    }
+
+    #[test]
+    fn reader_rejects_other_schema_versions() {
+        let mut value = serde_json::to_value(ShardFile {
+            schema_version: SHARD_SCHEMA_VERSION,
+            path: PathBuf::from("a.py"),
+            language: LangId::Python,
+            symbols: Vec::new(),
+            imports: Vec::new(),
+            references: Vec::new(),
+            diagnostics: Vec::new(),
+            ast_node_count: 0,
+            edges: Vec::new(),
+        })
+        .unwrap();
+        value["schema_version"] = serde_json::json!(99);
+        let input = format!("{}\n", serde_json::to_string(&value).unwrap());
+
+        let error = read_shard(Cursor::new(input)).unwrap_err();
+        assert!(matches!(
+            error,
+            ShardError::SchemaVersion {
+                line: 1,
+                found: 99,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn header_round_trip() {
+        let header = ShardHeader::new("2026-08-29T12:00:00Z");
+        assert_eq!(header.schema_version, SHARD_SCHEMA_VERSION);
+        assert_eq!(header.tool_version, env!("CARGO_PKG_VERSION"));
+
+        let mut bytes = Vec::new();
+        write_header(&mut bytes, &header).unwrap();
+        let loaded = read_header(Cursor::new(bytes)).unwrap();
+        assert_eq!(header, loaded);
+    }
+
+    #[test]
+    fn manifest_round_trip() {
+        let record = ShardManifestRecord::from_file_bytes(
+            PathBuf::from("src/main.py"),
+            b"def main(): pass\n",
+            1724932800,
+            "shards/0.jsonl".to_string(),
+        );
+        assert_eq!(record.schema_version, SHARD_SCHEMA_VERSION);
+        assert_eq!(record.size, 17);
+        assert_eq!(
+            record.content_hash,
+            blake3::hash(b"def main(): pass\n").to_hex().to_string()
+        );
+
+        let mut bytes = Vec::new();
+        write_manifest(&mut bytes, std::slice::from_ref(&record)).unwrap();
+        let decoded = read_manifest(Cursor::new(bytes)).unwrap();
+        assert_eq!(decoded.len(), 1);
+        assert_eq!(decoded[0], record);
+    }
+}

--- a/src/output/shard/name.rs
+++ b/src/output/shard/name.rs
@@ -90,18 +90,26 @@ pub(crate) fn symbol_descriptor(graph: &CodeGraph, node_index: NodeIndex) -> Str
         .graph()
         .node_indices()
         .filter(|candidate_index| {
-            if *candidate_index == node_index || parent_symbol(graph, *candidate_index) != parent {
+            if *candidate_index == node_index {
                 return false;
             }
             let NodeData::Symbol(candidate) = &graph.graph()[*candidate_index] else {
                 return false;
             };
-            candidate.file_id == symbol.file_id
-                && candidate.name == symbol.name
-                && candidate.kind == symbol.kind
-                && (candidate.source_range.byte_start < symbol.source_range.byte_start
-                    || (candidate.source_range.byte_start == symbol.source_range.byte_start
-                        && candidate_index.index() < node_index.index()))
+            if candidate.file_id != symbol.file_id
+                || candidate.name != symbol.name
+                || candidate.kind != symbol.kind
+            {
+                return false;
+            }
+            if parent_symbol(graph, *candidate_index) != parent {
+                return false;
+            }
+            candidate.source_range.byte_start < symbol.source_range.byte_start
+                || (candidate.source_range.byte_start == symbol.source_range.byte_start
+                    && (candidate.source_range.byte_end < symbol.source_range.byte_end
+                        || (candidate.source_range.byte_end == symbol.source_range.byte_end
+                            && candidate.id < symbol.id)))
         })
         .count();
     format!(
@@ -130,11 +138,13 @@ pub(crate) fn parent_symbol(graph: &CodeGraph, node_index: NodeIndex) -> Option<
                     || candidate.source_range.byte_end > symbol.source_range.byte_end);
             contains.then_some((
                 candidate.source_range.byte_end - candidate.source_range.byte_start,
+                candidate.source_range.byte_start,
+                candidate.source_range.byte_end,
                 candidate_index,
             ))
         })
-        .min_by_key(|(span, index)| (*span, index.index()))
-        .map(|(_, index)| index)
+        .min_by_key(|(span, start, end, _)| (*span, *start, *end))
+        .map(|(_, _, _, index)| index)
 }
 
 pub(crate) fn normalized_path(path: &Path) -> Result<String, ShardError> {

--- a/src/output/shard/name.rs
+++ b/src/output/shard/name.rs
@@ -1,0 +1,180 @@
+//! Stable naming and descriptor generation for shard endpoints.
+
+use std::path::Path;
+
+use petgraph::graph::NodeIndex;
+
+use crate::graph::{CodeGraph, NodeData};
+use crate::model::SymbolKind;
+use crate::output::shard::error::ShardError;
+
+pub(crate) fn node_belongs_to_file(graph: &CodeGraph, node_index: NodeIndex, path: &Path) -> bool {
+    match graph.graph().node_weight(node_index) {
+        Some(NodeData::File(file)) => file.path == path,
+        Some(NodeData::Symbol(symbol)) => graph
+            .file_node(symbol.file_id)
+            .is_some_and(|file| file.path == path),
+        Some(NodeData::External(_) | NodeData::Data(_)) | None => false,
+    }
+}
+
+pub(crate) fn stable_node_name(
+    graph: &CodeGraph,
+    node_index: NodeIndex,
+) -> Result<String, ShardError> {
+    let node = graph
+        .graph()
+        .node_weight(node_index)
+        .ok_or(ShardError::MissingNodeOwner {
+            node_index: node_index.index(),
+        })?;
+    match node {
+        NodeData::File(file) => Ok(format!(
+            "{} file {}",
+            file.language.as_ref(),
+            escape_component(&normalized_path(&file.path)?)
+        )),
+        NodeData::Symbol(_) => stable_symbol_name(graph, node_index),
+        NodeData::External(external) => Ok(format!(
+            "{} external {}",
+            external.language.as_ref(),
+            escape_component(&external.raw_path)
+        )),
+        NodeData::Data(_) => Err(ShardError::MissingNodeOwner {
+            node_index: node_index.index(),
+        }),
+    }
+}
+
+pub(crate) fn stable_symbol_name(
+    graph: &CodeGraph,
+    node_index: NodeIndex,
+) -> Result<String, ShardError> {
+    let NodeData::Symbol(symbol) = &graph.graph()[node_index] else {
+        return Err(ShardError::MissingNodeOwner {
+            node_index: node_index.index(),
+        });
+    };
+    let file = graph
+        .file_node(symbol.file_id)
+        .ok_or(ShardError::MissingNodeOwner {
+            node_index: node_index.index(),
+        })?;
+    let mut hierarchy = Vec::new();
+    let mut current = Some(node_index);
+    while let Some(index) = current {
+        hierarchy.push(index);
+        current = parent_symbol(graph, index);
+    }
+    hierarchy.reverse();
+
+    let descriptors = hierarchy
+        .into_iter()
+        .map(|index| symbol_descriptor(graph, index))
+        .collect::<Vec<_>>()
+        .join(" . ");
+    Ok(format!(
+        "{} {} . {} .",
+        file.language.as_ref(),
+        escape_component(&normalized_path(&file.path)?),
+        descriptors
+    ))
+}
+
+pub(crate) fn symbol_descriptor(graph: &CodeGraph, node_index: NodeIndex) -> String {
+    let NodeData::Symbol(symbol) = &graph.graph()[node_index] else {
+        return String::new();
+    };
+    let parent = parent_symbol(graph, node_index);
+    let ordinal = graph
+        .graph()
+        .node_indices()
+        .filter(|candidate_index| {
+            if *candidate_index == node_index || parent_symbol(graph, *candidate_index) != parent {
+                return false;
+            }
+            let NodeData::Symbol(candidate) = &graph.graph()[*candidate_index] else {
+                return false;
+            };
+            candidate.file_id == symbol.file_id
+                && candidate.name == symbol.name
+                && candidate.kind == symbol.kind
+                && (candidate.source_range.byte_start < symbol.source_range.byte_start
+                    || (candidate.source_range.byte_start == symbol.source_range.byte_start
+                        && candidate_index.index() < node_index.index()))
+        })
+        .count();
+    format!(
+        "{}#{}!{ordinal}",
+        escape_component(&symbol.name),
+        symbol_kind_name(symbol.kind)
+    )
+}
+
+pub(crate) fn parent_symbol(graph: &CodeGraph, node_index: NodeIndex) -> Option<NodeIndex> {
+    let NodeData::Symbol(symbol) = &graph.graph()[node_index] else {
+        return None;
+    };
+    graph
+        .graph()
+        .node_indices()
+        .filter(|candidate_index| *candidate_index != node_index)
+        .filter_map(|candidate_index| {
+            let NodeData::Symbol(candidate) = &graph.graph()[candidate_index] else {
+                return None;
+            };
+            let contains = candidate.file_id == symbol.file_id
+                && candidate.source_range.byte_start <= symbol.source_range.byte_start
+                && candidate.source_range.byte_end >= symbol.source_range.byte_end
+                && (candidate.source_range.byte_start < symbol.source_range.byte_start
+                    || candidate.source_range.byte_end > symbol.source_range.byte_end);
+            contains.then_some((
+                candidate.source_range.byte_end - candidate.source_range.byte_start,
+                candidate_index,
+            ))
+        })
+        .min_by_key(|(span, index)| (*span, index.index()))
+        .map(|(_, index)| index)
+}
+
+pub(crate) fn normalized_path(path: &Path) -> Result<String, ShardError> {
+    let value = path.to_str().ok_or_else(|| ShardError::NonUtf8Path {
+        path: path.to_path_buf(),
+    })?;
+    #[cfg(windows)]
+    let value = value.replace('\\', "/");
+    #[cfg(not(windows))]
+    let value = value.to_string();
+    Ok(value)
+}
+
+pub(crate) fn escape_component(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.') {
+            escaped.push(char::from(byte));
+        } else {
+            use std::fmt::Write as _;
+            let _ = write!(escaped, "%{byte:02X}");
+        }
+    }
+    escaped
+}
+
+pub(crate) fn symbol_kind_name(kind: SymbolKind) -> &'static str {
+    match kind {
+        SymbolKind::Function => "function",
+        SymbolKind::Method => "method",
+        SymbolKind::Class => "class",
+        SymbolKind::Struct => "struct",
+        SymbolKind::Interface => "interface",
+        SymbolKind::Trait => "trait",
+        SymbolKind::Enum => "enum",
+        SymbolKind::Object => "object",
+        SymbolKind::Constant => "constant",
+        SymbolKind::Static => "static",
+        SymbolKind::Module => "module",
+        SymbolKind::Namespace => "namespace",
+        SymbolKind::TypeAlias => "type_alias",
+    }
+}

--- a/src/watch/reanalyze.rs
+++ b/src/watch/reanalyze.rs
@@ -109,12 +109,12 @@ pub fn incremental_reanalyze(
     }
 
     let max_id = state.cache.max_symbol_id();
-    let id_gen = IdGenerator::<SymbolId>::with_start(max_id + 1);
-
     #[cfg(feature = "dataflow")]
     let max_data_id = state.cache.max_data_node_id();
     #[cfg(feature = "dataflow")]
-    let data_id_gen = IdGenerator::<crate::model::DataNodeId>::with_start(max_data_id + 1);
+    let id_generators = extractor::ExtractionIdGenerators::with_starts(max_id + 1, max_data_id + 1);
+    #[cfg(not(feature = "dataflow"))]
+    let id_generators = extractor::ExtractionIdGenerators::with_symbol_start(max_id + 1);
 
     let new_extractions = if changed.is_empty() {
         Vec::new()
@@ -124,9 +124,7 @@ pub fn incremental_reanalyze(
             &extractor::ExtractOptions {
                 skip_imports_and_refs: false,
             },
-            id_gen,
-            #[cfg(feature = "dataflow")]
-            data_id_gen,
+            &id_generators,
         )
         .files
     };

--- a/src/watch/reanalyze.rs
+++ b/src/watch/reanalyze.rs
@@ -15,7 +15,7 @@ use crate::extractor;
 use crate::graph::GraphBuilder;
 use crate::input;
 use crate::language::LangId;
-use crate::model::{FileExtraction, IdGenerator, SymbolId};
+use crate::model::FileExtraction;
 use crate::pipeline::GraphAnalysis;
 use crate::watch::cache::{Fingerprint, compute_fingerprint};
 use crate::watch::state::{ChangeSet, WatchState};

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -13,6 +13,7 @@ mod integration {
     mod inspect_output_test;
     mod output_format_test;
     mod pipeline_test;
+    mod shard_test;
     #[cfg(feature = "watch")]
     mod watch_test;
 }

--- a/tests/integration/datagraph_test.rs
+++ b/tests/integration/datagraph_test.rs
@@ -87,6 +87,11 @@ fn datagraph_export_symbol_node_fields() {
             node.symbol_kind.is_some(),
             "symbol node must have symbol_kind"
         );
+        assert!(node.file_path.is_some(), "symbol node must have file_path");
+        assert!(
+            node.source_range.is_some(),
+            "symbol node must have source_range"
+        );
         assert!(
             node.data_scope.is_none(),
             "symbol node should not have data_scope"
@@ -142,7 +147,7 @@ fn datagraph_export_json_roundtrip() {
     let json = serde_json::to_string_pretty(&export).unwrap();
     let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
 
-    assert_eq!(parsed["schema_version"], 1);
+    assert_eq!(parsed["schema_version"], 2);
     assert_eq!(parsed["metadata"]["snapshot_id"], 1);
     assert!(parsed["nodes"].is_array());
     assert!(parsed["edges"].is_array());
@@ -203,7 +208,7 @@ fn sink_json_writes_datagraph_to_file() {
 
     let content = std::fs::read_to_string(&temp).unwrap();
     let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
-    assert_eq!(parsed["schema_version"], 1);
+    assert_eq!(parsed["schema_version"], 2);
     assert!(parsed["nodes"].is_array());
     assert!(parsed["edges"].is_array());
 

--- a/tests/integration/shard_test.rs
+++ b/tests/integration/shard_test.rs
@@ -1,0 +1,140 @@
+//! Integration tests for .metast v2 shard and index persistence.
+
+use std::fs;
+use std::path::Path;
+
+use meta_ast::graph::GraphBuilder;
+use meta_ast::model::{IdGenerator, SnapshotId, SymbolId};
+use meta_ast::output::shard::{
+    SHARD_SCHEMA_VERSION, ShardFile, ShardHeader, ShardManifestRecord, read_header, read_manifest,
+    read_shard, restore_shard_edges, write_header, write_manifest, write_shard,
+};
+
+#[test]
+fn shard_full_pipeline_roundtrip_and_graph_restoration() {
+    let root = Path::new("tests/fixtures/python");
+    let files = meta_ast::input::discover_files(root, None).unwrap();
+    assert!(!files.is_empty(), "fixture files must be discovered");
+
+    let initial_extraction = meta_ast::extractor::extract(&files);
+    let mut initial_diags = Vec::new();
+    let (initial_graph, _) = GraphBuilder::from_extractions(
+        &initial_extraction.files,
+        root,
+        SnapshotId::new(1).unwrap(),
+        &mut initial_diags,
+    );
+
+    let temp_dir = std::env::temp_dir().join("meta_ast_shard_integration_test");
+    if temp_dir.exists() {
+        let _ = fs::remove_dir_all(&temp_dir);
+    }
+    fs::create_dir_all(&temp_dir).unwrap();
+
+    let shards_dir = temp_dir.join("shards");
+    fs::create_dir_all(&shards_dir).unwrap();
+
+    // 1. Convert extractions to ShardFiles and collect edges
+    let shard_files: Vec<ShardFile> = initial_extraction
+        .files
+        .iter()
+        .map(|file| ShardFile::from_extraction(file, &initial_graph).unwrap())
+        .collect();
+
+    // 2. Write header.json
+    let header = ShardHeader::new("2026-08-29T12:00:00Z");
+    let header_path = temp_dir.join("header.json");
+    let header_file = fs::File::create(&header_path).unwrap();
+    write_header(header_file, &header).unwrap();
+
+    // 3. Write shards/0.jsonl
+    let shard_path = shards_dir.join("0.jsonl");
+    let shard_out = fs::File::create(&shard_path).unwrap();
+    write_shard(shard_out, &shard_files).unwrap();
+
+    // 4. Write manifest.jsonl
+    let mut manifest_records = Vec::new();
+    for (idx, (path, _lang)) in files.iter().enumerate() {
+        let content = fs::read(path).unwrap();
+        manifest_records.push(ShardManifestRecord::from_file_bytes(
+            path.clone(),
+            &content,
+            1724932800 + idx as u64,
+            "shards/0.jsonl".to_string(),
+        ));
+    }
+    let manifest_path = temp_dir.join("manifest.jsonl");
+    let manifest_out = fs::File::create(&manifest_path).unwrap();
+    write_manifest(manifest_out, &manifest_records).unwrap();
+
+    // 5. Read back header and manifest
+    let header_in = fs::File::open(&header_path).unwrap();
+    let loaded_header = read_header(header_in).unwrap();
+    assert_eq!(loaded_header.schema_version, SHARD_SCHEMA_VERSION);
+    assert_eq!(loaded_header.created_at, "2026-08-29T12:00:00Z");
+
+    let manifest_in = std::io::BufReader::new(fs::File::open(&manifest_path).unwrap());
+    let loaded_manifest = read_manifest(manifest_in).unwrap();
+    assert_eq!(loaded_manifest.len(), manifest_records.len());
+    for (orig, loaded) in manifest_records.iter().zip(&loaded_manifest) {
+        assert_eq!(orig.path, loaded.path);
+        assert_eq!(orig.content_hash, loaded.content_hash);
+        assert_eq!(orig.size, loaded.size);
+    }
+
+    // 6. Read back shards and regenerate IDs with new generator
+    let shard_in = std::io::BufReader::new(fs::File::open(&shard_path).unwrap());
+    let loaded_shard_files = read_shard(shard_in).unwrap();
+    assert_eq!(loaded_shard_files.len(), shard_files.len());
+
+    let id_gen = IdGenerator::<SymbolId>::with_start(10_000);
+    let mut loaded_extractions = Vec::new();
+    let mut all_shard_edges = Vec::new();
+
+    for shard in loaded_shard_files {
+        let loaded = shard.load(&id_gen).unwrap();
+        all_shard_edges.extend(loaded.edges);
+        loaded_extractions.push(loaded.file);
+    }
+
+    // Symbol IDs must be >= 10000
+    for file in &loaded_extractions {
+        for sym in &file.symbols {
+            assert!(sym.id.to_raw() >= 10_000);
+        }
+    }
+
+    // 7. Rebuild graph from loaded extractions and restore edges
+    let mut rebuild_diags = Vec::new();
+    let (mut rebuilt_graph, _) = GraphBuilder::from_extractions(
+        &loaded_extractions,
+        root,
+        SnapshotId::new(2).unwrap(),
+        &mut rebuild_diags,
+    );
+
+    restore_shard_edges(&mut rebuilt_graph, &all_shard_edges).unwrap();
+
+    use meta_ast::graph::edge::EdgeKind;
+
+    // Verify rebuilt graph topology matches initial graph for AST nodes and edges
+    assert_eq!(rebuilt_graph.files().count(), initial_graph.files().count());
+    assert_eq!(
+        rebuilt_graph.symbols().count(),
+        initial_graph.symbols().count()
+    );
+    assert_eq!(
+        rebuilt_graph.edges_of_kind(EdgeKind::Ownership).count(),
+        initial_graph.edges_of_kind(EdgeKind::Ownership).count()
+    );
+    assert_eq!(
+        rebuilt_graph.edges_of_kind(EdgeKind::Import).count(),
+        initial_graph.edges_of_kind(EdgeKind::Import).count()
+    );
+    assert_eq!(
+        rebuilt_graph.edges_of_kind(EdgeKind::Reference).count(),
+        initial_graph.edges_of_kind(EdgeKind::Reference).count()
+    );
+
+    let _ = fs::remove_dir_all(&temp_dir);
+}


### PR DESCRIPTION
## Summary

Implements Phase 0 prerequisites for [RFC 0012: Polyglot LSP Server](docs/src/rfcs/0012-polyglot-lsp-server.md) to support downstream integration
  with `metacall/lsp`.

### Key Changes

 1. **Symbol Location Export (`SCHEMA_VERSION = 2`)**:
       - Updated `SerializedNode` and `serialize_symbol_node` in `src/output/graph.rs` to emit `source_range` and `file_path`.
       - Bumped graph export schema version from 1 to 2.

   2. **In-Memory Document Extraction Seam**:
       - Added `InMemorySource`, `VersionedExtraction`, and `extract_text_with_id_gen` to `src/extractor/mod.rs` to analyze editor buffers from `(uri,
  text, version)`.
       - Added `ExtractionIdGenerators` to share ID allocation safely across disk and in-memory passes.
       - Added `crate::Error::InvalidSourceUri` for non-file URI validation.

3. **Modular `.metast` v2 Shard & Index Persistence (`src/output/shard/`)**:
       - `file.rs`: `ShardFile` and `ShardSymbol` with JSONL `write_shard` and `read_shard`.
       - `edge.rs`: `ShardEdge`, `ShardEdgeKind`, and `restore_shard_edges` using canonical graph edge normalization.
       - `manifest.rs`: `ShardManifestRecord` with BLAKE3 content hashing for `manifest.jsonl`.
       - `header.rs`: `ShardHeader` for `header.json`.
       - `name.rs`: Language-scoped hierarchical stable names and descriptors.

4. **Resolver Cache Invalidation**:
       - Added `clear_cache` to `ImportResolver` trait.
       - Implemented dynamic cache clearing across `PythonResolver`, `JsResolver`, `TsConfigResolver`, and `GoModResolver` for long-lived language server
  processes.

5. **Test Coverage**:
       - Added `tests/integration/shard_test.rs` validating multi-file shard persistence, ID regeneration, and graph restoration.
       - Added symbol node coordinate assertions in `tests/integration/datagraph_test.rs`.
       - Added unit tests for in-memory extraction, URI parsing, and resolver cache clearing.