### PR TITLE
feat: add PowerShell distribution script for Windows install

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,71 @@
+<#
+.SYNOPSIS
+    meta-ast installer for Windows.
+.DESCRIPTION
+    Downloads and installs the latest (or specified) pre-built meta-ast
+    binary from GitHub Releases.
+.EXAMPLE
+    irm https://raw.githubusercontent.com/metacall/meta-ast/main/scripts/install.ps1 | iex
+.EXAMPLE
+    & ([scriptblock]::Create((irm https://.../install.ps1))) -Version v0.5.0
+#>
+
+param(
+    [string]$Version = "latest",
+    [switch]$Deploy,
+    [string]$InstallDir = "$env:USERPROFILE\.local\bin"
+)
+
+$ErrorActionPreference = "Stop"
+
+$Repo = "metacall/meta-ast"
+$BinaryName = "meta-ast.exe"
+
+function Write-Info($msg) { Write-Host $msg }
+function Fail($msg) { Write-Error $msg; exit 1 }
+
+# ---- Detect architecture ----
+$arch = $env:PROCESSOR_ARCHITECTURE
+switch ($arch) {
+    "AMD64" { $Arch = "x86_64" }
+    "ARM64" { $Arch = "aarch64" }
+    default { Fail "Unsupported architecture: $arch" }
+}
+
+$Platform = "pc-windows-msvc"
+$Variant = if ($Deploy) { "-deploy" } else { "" }
+$Asset = "meta-ast-$Arch-$Platform$Variant.exe"
+
+# ---- Resolve download URL ----
+if ($Version -eq "latest") {
+    $DownloadUrl = "https://github.com/$Repo/releases/latest/download/$Asset"
+} else {
+    $DownloadUrl = "https://github.com/$Repo/releases/download/$Version/$Asset"
+}
+
+Write-Info "Detected platform: $Arch-$Platform$Variant"
+Write-Info "Downloading: $DownloadUrl"
+
+# ---- Download ----
+New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+$OutFile = Join-Path $InstallDir $BinaryName
+
+try {
+    Invoke-WebRequest -Uri $DownloadUrl -OutFile $OutFile -UseBasicParsing
+} catch {
+    Fail "Download failed. Check that the version/platform combination exists."
+}
+
+Write-Info "Installed $BinaryName to $OutFile"
+
+# ---- PATH check ----
+$userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+if ($userPath -notlike "*$InstallDir*") {
+    Write-Info ""
+    Write-Info "NOTE: $InstallDir is not on your PATH."
+    Write-Info "Add it by running:"
+    Write-Info "  [Environment]::SetEnvironmentVariable('Path', `$env:Path + ';$InstallDir', 'User')"
+}
+
+Write-Info ""
+Write-Info "Run '$BinaryName --help' to get started."


### PR DESCRIPTION
## What
Added scripts/install.ps1, a PowerShell installer that downloads and installs the correct pre-built meta-ast Windows binary from GitHub Releases.

## Why
Follow-up to #46 — the bash installer explicitly pointed Windows users to this script (tracked as #59), since sh/curl aren't native there.

## Changes

* Added scripts/install.ps1
  * Detects architecture (AMD64/ARM64) via $env:PROCESSOR_ARCHITECTURE
  * Resolves the release asset name (meta-ast-{arch}-pc-windows-msvc[-deploy].exe)
  * Downloads via Invoke-WebRequest
  * Installs to $env:USERPROFILE\.local\bin by default
  * Supports -Version, -Deploy, and -InstallDir parameters
  * Adds a PATH reminder if the install dir isn't already on PATH

## Notes

* Tested on macOS using PowerShell Core (pwsh 7.6.5) by simulating Windows env vars — verified: AST parse check, ARM64 + AMD64 asset detection/download, -Deploy variant, invalid version → clean error (no crash), paths with spaces, and file integrity of the downloaded binary (confirmed real PE32+ Windows executable)
* No SHA256 checksum verification yet — consistent with scripts/install.sh (#46); could be a follow-up for both scripts
* Closes #59