### PR TITLE
feat(output): emit structured JSON error envelope under --format json (closes #62)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,36 @@ fn main() -> anyhow::Result<()> {
 
     let cli = Cli::parse();
 
+    // Extract the output format *before* dispatching so we can intercept
+    // errors with structured JSON output when `--format json` is active.
+    let format = extract_format(&cli);
+
+    let result = run(cli);
+
+    if let Err(ref err) = result
+        && format == meta_ast::output::OutputFormat::Json
+    {
+        let json = meta_ast::output::format_json_error(err);
+        eprintln!("{json}");
+        std::process::exit(1);
+    }
+
+    result
+}
+
+/// Extract the [`OutputFormat`] from the parsed CLI arguments.
+fn extract_format(cli: &Cli) -> meta_ast::output::OutputFormat {
+    match cli {
+        Cli::Inspect(args) => args.format,
+        Cli::Graph(args) => args.format,
+        #[cfg(feature = "metacall-deploy")]
+        Cli::Deploy(args) => args.format,
+    }
+}
+
+/// Run the dispatched subcommand, returning any errors for the caller
+/// to handle (potentially as structured JSON).
+fn run(cli: Cli) -> anyhow::Result<()> {
     match cli {
         Cli::Inspect(args) => {
             let languages = args.language.map(|l| [l]);

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -23,3 +23,121 @@ impl OutputFormat {
         }
     }
 }
+
+// ---------------------------------------------------------------------------
+// Structured JSON error output (issue #62)
+// ---------------------------------------------------------------------------
+
+/// Classifies errors into machine-readable kinds for the JSON error envelope.
+///
+/// Variants are derived from [`crate::error::Error`].  `UnknownError` is the
+/// fallback for errors that cannot be downcast to a known variant.
+#[derive(Debug, Clone, Serialize)]
+pub enum ErrorKind {
+    IoError,
+    ParseError,
+    QueryError,
+    ConfigError,
+    InvalidSourceUri,
+    GraphError,
+    UnknownError,
+}
+
+/// The `error` object inside the JSON error envelope.
+#[derive(Debug, Clone, Serialize)]
+pub struct JsonErrorDetail {
+    pub kind: ErrorKind,
+    pub message: String,
+}
+
+/// Top-level JSON error envelope emitted when `--format json` is active
+/// and a fatal error occurs.
+///
+/// ```json
+/// {
+///   "status": "error",
+///   "error": { "kind": "IoError", "message": "..." },
+///   "diagnostics": [ ... ]
+/// }
+/// ```
+#[derive(Debug, Clone, Serialize)]
+pub struct JsonErrorOutput {
+    pub status: String,
+    pub error: JsonErrorDetail,
+    pub diagnostics: Vec<crate::error::Diagnostic>,
+}
+
+/// Build a structured JSON error string from an [`anyhow::Error`].
+///
+/// Attempts to downcast to [`crate::error::Error`] to determine the
+/// [`ErrorKind`] and extract diagnostics.  Falls back to `UnknownError`
+/// for errors that do not originate from the crate's error type.
+pub fn format_json_error(err: &anyhow::Error) -> String {
+    use crate::error::{Diagnostic, Error, Severity};
+    use std::path::PathBuf;
+
+    let (kind, message, diagnostics) = match err.downcast_ref::<Error>() {
+        Some(Error::Io(io_err)) => {
+            let msg = format!("{io_err}");
+            let diag = Diagnostic {
+                path: PathBuf::from("<unknown>"),
+                severity: Severity::Error,
+                message: msg.clone(),
+                source_range: None,
+            };
+            (ErrorKind::IoError, msg, vec![diag])
+        }
+        Some(Error::Parse { path, message }) => {
+            let diag = Diagnostic {
+                path: path.clone(),
+                severity: Severity::Error,
+                message: message.clone(),
+                source_range: None,
+            };
+            (ErrorKind::ParseError, err.to_string(), vec![diag])
+        }
+        Some(Error::Query { language, message }) => {
+            let msg = format!("query error ({language}): {message}");
+            (ErrorKind::QueryError, msg, vec![])
+        }
+        Some(Error::Config(msg)) => (ErrorKind::ConfigError, msg.clone(), vec![]),
+        Some(Error::InvalidSourceUri { uri, message }) => {
+            let msg = format!("invalid source URI '{uri}': {message}");
+            (ErrorKind::InvalidSourceUri, msg, vec![])
+        }
+        Some(Error::Graph(msg)) => (ErrorKind::GraphError, msg.clone(), vec![]),
+        None => {
+            if let Some(io_err) = err.downcast_ref::<std::io::Error>() {
+                let msg = format!("{io_err}");
+                let path = if let Some(stripped) = msg.strip_prefix("path does not exist: ") {
+                    PathBuf::from(stripped.trim())
+                } else {
+                    PathBuf::from("<unknown>")
+                };
+                let diag = Diagnostic {
+                    path,
+                    severity: Severity::Error,
+                    message: msg.clone(),
+                    source_range: None,
+                };
+                (ErrorKind::IoError, msg, vec![diag])
+            } else {
+                (ErrorKind::UnknownError, err.to_string(), vec![])
+            }
+        }
+    };
+
+    let output = JsonErrorOutput {
+        status: "error".to_string(),
+        error: JsonErrorDetail { kind, message },
+        diagnostics,
+    };
+
+    // Serialization of our own simple structs should never fail, but if it
+    // does, fall back to a hand-written JSON string.
+    serde_json::to_string_pretty(&output).unwrap_or_else(|e| {
+        format!(
+            r#"{{"status":"error","error":{{"kind":"UnknownError","message":"failed to serialize error: {e}"}},"diagnostics":[]}}"#
+        )
+    })
+}

--- a/tests/integration/output_format_test.rs
+++ b/tests/integration/output_format_test.rs
@@ -108,3 +108,94 @@ fn yaml_json_semantic_equivalence() {
     assert_eq!(json_parsed["funcs"][0]["name"], "func_a");
     assert_eq!(yaml_parsed["funcs"][0]["name"], "func_a");
 }
+
+// ---------------------------------------------------------------------------
+// Structured JSON error output tests (issue #62)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn json_error_output_nonexistent_path() {
+    let io_err = std::io::Error::new(
+        std::io::ErrorKind::NotFound,
+        "path does not exist: /invalid/path",
+    );
+    let err: anyhow::Error = meta_ast::error::Error::Io(io_err).into();
+    let json_str = meta_ast::output::format_json_error(&err);
+
+    let parsed: serde_json::Value =
+        serde_json::from_str(&json_str).expect("format_json_error should produce valid JSON");
+
+    assert_eq!(parsed["status"], "error");
+    assert_eq!(parsed["error"]["kind"], "IoError");
+    assert!(
+        parsed["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("path does not exist"),
+        "message should contain the IO error text"
+    );
+    assert!(
+        parsed["diagnostics"].is_array(),
+        "diagnostics must be an array"
+    );
+    let diags = parsed["diagnostics"].as_array().unwrap();
+    assert_eq!(diags.len(), 1);
+    assert_eq!(diags[0]["severity"], "Error");
+}
+
+#[test]
+fn json_error_output_parse_error() {
+    let err: anyhow::Error = meta_ast::error::Error::Parse {
+        path: PathBuf::from("broken.py"),
+        message: "unexpected token at line 42".into(),
+    }
+    .into();
+    let json_str = meta_ast::output::format_json_error(&err);
+
+    let parsed: serde_json::Value =
+        serde_json::from_str(&json_str).expect("format_json_error should produce valid JSON");
+
+    assert_eq!(parsed["status"], "error");
+    assert_eq!(parsed["error"]["kind"], "ParseError");
+    assert!(
+        parsed["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("broken.py"),
+        "message should reference the file path"
+    );
+    let diags = parsed["diagnostics"].as_array().unwrap();
+    assert_eq!(diags.len(), 1);
+    assert_eq!(diags[0]["path"], "broken.py");
+    assert_eq!(diags[0]["severity"], "Error");
+    assert!(
+        diags[0]["message"]
+            .as_str()
+            .unwrap()
+            .contains("unexpected token"),
+        "diagnostic message should contain parse error detail"
+    );
+}
+
+#[test]
+fn json_error_output_unknown_error() {
+    let err = anyhow::anyhow!("something completely unexpected");
+    let json_str = meta_ast::output::format_json_error(&err);
+
+    let parsed: serde_json::Value =
+        serde_json::from_str(&json_str).expect("format_json_error should produce valid JSON");
+
+    assert_eq!(parsed["status"], "error");
+    assert_eq!(parsed["error"]["kind"], "UnknownError");
+    assert!(
+        parsed["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("something completely unexpected"),
+        "message should contain the original error text"
+    );
+    assert!(
+        parsed["diagnostics"].as_array().unwrap().is_empty(),
+        "unknown errors should have no diagnostics"
+    );
+}


### PR DESCRIPTION
## Why

`meta-ast inspect` and `meta-ast graph` currently print plain-text error 
messages to stderr regardless of the requested output format. When 
`--format json` is passed, a failure still breaks that contract — errors 
come back as unparseable text instead of JSON, which makes the CLI 
unreliable for automated pipelines, CI, and IDE tooling consuming its 
output programmatically.

Closes #62.

## What Changed

- Errors are now emitted as a structured JSON envelope when `--format json` 
  is active, instead of falling through to anyhow's default plain-text output.
- Error classification (`ErrorKind`) is derived from the existing 
  `crate::error::Error` variants, with a fallback for raw `std::io::Error` 
  cases (e.g. a nonexistent root path) so common failures are classified 
  correctly instead of falling into `UnknownError`.
- Output continues to go to stderr, consistent with existing convention 
  (the startup banner also writes to stderr), keeping stdout clean for 
  piped data.

## How

- `src/output/mod.rs` — added `ErrorKind`, `JsonErrorDetail`, and 
  `JsonErrorOutput` types, plus `format_json_error()`, which downcasts the 
  incoming `anyhow::Error` to determine kind and build the diagnostics array.
- `src/main.rs` — split `main()` into `extract_format()` + `run()` so the 
  parsed `--format` value is available when errors are handled. On failure 
  with `--format json`, the error is routed through `format_json_error()` 
  instead of the default path.
- `tests/integration/output_format_test.rs` — added coverage for the 
  `IoError`, `ParseError`, and `UnknownError` envelope shapes.

## Scope Notes

- Errors from clap's own argument parsing remain plain text, since the 
  format can't be known until parsing succeeds.
- The startup banner prints before argument parsing completes, so it 
  currently appears above the JSON envelope on stderr. Flagging as a known 
  limitation rather than addressing here, since it's outside what the issue 
  asked for — happy to follow up if maintainers want it changed.

## Testing

- `cargo fmt --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean 
  (one pre-existing warning in `src/watch/reanalyze.rs`, unrelated to this change)
- `cargo test` — 360 passed, 0 failed
- `cargo rustdoc --all-features -- --deny warnings` — clean
- Manual smoke test confirming stderr/stdout separation and JSON shape