### PR TITLE
feat(shard): persist call sites in shard records

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -826,7 +826,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "meta-ast"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "meta-ast"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 description = "Polyglot static-analysis engine: extract symbols and cross-language dependency graphs from 9 supported source languages, with optional MetaCall deployment manifest generation."
 readme = "README.md"

--- a/src/deploy/scanner.rs
+++ b/src/deploy/scanner.rs
@@ -8,10 +8,10 @@ use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
 use tree_sitter::{Node, Query, QueryCursor, StreamingIterator, Tree};
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 /// Variant of a MetaCall call site: a load API or a client invocation.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum CallSiteVariant {
     LoadFromFile,
@@ -22,7 +22,7 @@ pub enum CallSiteVariant {
                 // metacall_function, metacall::metacall, Go Call/Await
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CallSite {
     pub source_file: PathBuf,
     pub caller_lang: LangId,

--- a/src/output/shard/file.rs
+++ b/src/output/shard/file.rs
@@ -17,7 +17,7 @@ use crate::output::shard::edge::{ShardEdge, validate_edge};
 use crate::output::shard::error::ShardError;
 use crate::output::shard::name::{node_belongs_to_file, normalized_path, stable_node_name};
 
-pub const SHARD_SCHEMA_VERSION: u32 = 2;
+pub const SHARD_SCHEMA_VERSION: u32 = 3;
 
 /// A per-file shard record stored in `.meta-ast/shards/<n>.jsonl`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -30,6 +30,10 @@ pub struct ShardFile {
     pub references: Vec<UnresolvedReference>,
     pub diagnostics: Vec<Diagnostic>,
     pub ast_node_count: usize,
+    /// MetaCall load and client-call sites, persisted for cold-start fidelity.
+    #[cfg(feature = "metacall-deploy")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub call_sites: Vec<crate::deploy::scanner::CallSite>,
     pub edges: Vec<ShardEdge>,
 }
 
@@ -111,6 +115,8 @@ impl ShardFile {
             references: extraction.references.clone(),
             diagnostics: extraction.diagnostics.clone(),
             ast_node_count: extraction.ast_node_count,
+            #[cfg(feature = "metacall-deploy")]
+            call_sites: extraction.call_sites.clone(),
             edges,
         })
     }
@@ -136,6 +142,10 @@ impl ShardFile {
         file.references = self.references;
         file.diagnostics = self.diagnostics;
         file.ast_node_count = self.ast_node_count;
+        #[cfg(feature = "metacall-deploy")]
+        {
+            file.call_sites = self.call_sites;
+        }
 
         Ok(LoadedShard {
             file,

--- a/src/output/shard/mod.rs
+++ b/src/output/shard/mod.rs
@@ -201,6 +201,8 @@ mod tests {
             references: Vec::new(),
             diagnostics: Vec::new(),
             ast_node_count: 0,
+            #[cfg(feature = "metacall-deploy")]
+            call_sites: Vec::new(),
             edges: vec![ShardEdge {
                 source_name: "python file a.py".to_string(),
                 target_name: "python file b.py".to_string(),
@@ -235,6 +237,8 @@ mod tests {
             references: Vec::new(),
             diagnostics: Vec::new(),
             ast_node_count: 0,
+            #[cfg(feature = "metacall-deploy")]
+            call_sites: Vec::new(),
             edges: Vec::new(),
         })
         .unwrap();
@@ -350,6 +354,52 @@ mod tests {
             edge_targets
                 .iter()
                 .any(|name| name.contains("process#function!1"))
+        );
+    }
+
+    #[cfg(feature = "metacall-deploy")]
+    #[test]
+    fn shard_round_trip_preserves_call_sites() {
+        use crate::deploy::scanner::{CallSite, CallSiteVariant};
+
+        let mut extraction = extraction();
+        extraction.call_sites = vec![CallSite {
+            source_file: extraction.path.clone(),
+            caller_lang: LangId::Python,
+            variant: CallSiteVariant::ClientCall,
+            target_lang: None,
+            scripts: Vec::new(),
+            function_name: Some("multiply".to_string()),
+            is_async: false,
+            source_range: Some(range()),
+            confidence: 0.4,
+        }];
+        let mut diagnostics = Vec::new();
+        let (graph, _) = GraphBuilder::from_extractions(
+            std::slice::from_ref(&extraction),
+            Path::new("."),
+            SnapshotId::new(1).unwrap(),
+            &mut diagnostics,
+        );
+        let shard = ShardFile::from_extraction(&extraction, &graph).unwrap();
+        let mut bytes = Vec::new();
+        write_shard(&mut bytes, &[shard]).unwrap();
+        let decoded = read_shard(Cursor::new(bytes)).unwrap();
+        let loaded = decoded
+            .into_iter()
+            .next()
+            .unwrap()
+            .load(&IdGenerator::with_start(500))
+            .unwrap();
+
+        assert_eq!(loaded.file.call_sites.len(), 1);
+        assert_eq!(
+            loaded.file.call_sites[0].variant,
+            CallSiteVariant::ClientCall
+        );
+        assert_eq!(
+            loaded.file.call_sites[0].function_name.as_deref(),
+            Some("multiply")
         );
     }
 }


### PR DESCRIPTION
## Summary
Persist MetaCall load and client call sites in shard records and bump the shard schema to 3.

## Motivation & Context
Cold load rebuilt `FileExtraction` without `call_sites`, so client-call edges disappeared. The LSP cold-start path needs them to keep cross-language navigation lossless.

## Technical Architecture & Changes
- `src/output/shard/file.rs`: gated `call_sites` field, write and load paths, schema 3.
- `src/deploy/scanner.rs`: `Deserialize` plus `PartialEq` on `CallSite` and `CallSiteVariant`.
- `Cargo.toml`: version 0.6.1.
