### PR TITLE
ci(release): generate notes with git-cliff and verify tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,52 @@
+name: publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Tag to publish, for example v0.6.1
+        required: true
+        type: string
+      dry_run:
+        description: Validate the package without uploading to crates.io
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: publish ${{ inputs.tag }}
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.94.0
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Check tag against Cargo.toml
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          version=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -n 1)
+          tag="${INPUT_TAG#v}"
+          if [ "$tag" != "$version" ]; then
+            echo "::error::tag $INPUT_TAG does not match Cargo.toml version $version"
+            exit 1
+          fi
+
+      - name: Publish dry run
+        if: inputs.dry_run
+        run: cargo publish --locked --dry-run
+
+      - name: Publish
+        if: ${{ !inputs.dry_run }}
+        run: cargo publish --locked --token ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,43 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  verify:
+    name: verify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.94.0
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Check tag against Cargo.toml
+        run: |
+          version=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -n 1)
+          tag="${GITHUB_REF_NAME#v}"
+          if [ "$tag" != "$version" ]; then
+            echo "::error::tag $GITHUB_REF_NAME does not match Cargo.toml version $version"
+            exit 1
+          fi
+
+      - name: Test
+        run: cargo test --all-features --locked
+
+      - name: Clippy
+        run: cargo clippy --all-targets --all-features --locked -- -D warnings
+
+      - name: Format
+        run: cargo fmt --check
+
   build:
     name: build (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
+    needs: verify
     strategy:
       fail-fast: false
       matrix:
@@ -41,6 +75,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: 1.94.0
           targets: ${{ matrix.target }}
 
       - uses: Swatinem/rust-cache@v2
@@ -56,7 +91,7 @@ jobs:
 
       # Core binary (no features).
       - name: Build release (core)
-        run: cargo build --release --target ${{ matrix.target }}
+        run: cargo build --release --locked --target ${{ matrix.target }}
 
       - name: Strip binary (core)
         if: runner.os != 'Windows'
@@ -66,7 +101,7 @@ jobs:
       - name: Build release (deploy)
         env:
           CARGO_TARGET_DIR: target-deploy
-        run: cargo build --release --target ${{ matrix.target }} --features metacall-deploy
+        run: cargo build --release --locked --target ${{ matrix.target }} --features metacall-deploy
 
       - name: Strip binary (deploy)
         if: runner.os != 'Windows'
@@ -84,19 +119,19 @@ jobs:
         with:
           name: meta-ast-${{ matrix.target }}
           path: release/meta-ast-${{ matrix.target }}${{ matrix.ext }}
-          if-no-files-match-files: error
+          if-no-files-found: error
 
       - name: Upload deploy artifact
         uses: actions/upload-artifact@v4
         with:
           name: meta-ast-${{ matrix.target }}-deploy
           path: release/meta-ast-${{ matrix.target }}-deploy${{ matrix.ext }}
-          if-no-files-match-files: error
+          if-no-files-found: error
 
   release:
     name: release
     runs-on: ubuntu-latest
-    needs: build
+    needs: [verify, build]
     permissions:
       contents: write
     steps:
@@ -110,34 +145,21 @@ jobs:
           path: artifacts
           merge-multiple: false
 
-      - name: Generate changelog
+      - name: Generate release notes
         id: changelog
-        run: |
-          PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
-          if [ -n "$PREV_TAG" ]; then
-            LOG=$(git log "${PREV_TAG}..HEAD" --pretty=format:"- %s (%h)" --no-merges)
-          else
-            LOG=$(git log --pretty=format:"- %s (%h)" --no-merges -20)
-          fi
-          echo "log<<EOF" >> "$GITHUB_OUTPUT"
-          echo "$LOG" >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
+        uses: orhun/git-cliff-action@v4
+        with:
+          version: v2.14.1
+          config: cliff.toml
+          args: --current --strip header --offline
+        env:
+          OUTPUT: release-notes.md
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: false
-          body: |
-            ## meta-ast ${{ github.ref_name }}
-
-            Polyglot static analysis engine - GSoC 2026 final release.
-
-            This release includes core and `metacall-deploy` binaries for
-            Linux (glibc + musl), macOS (x86_64 + aarch64), and Windows
-            (x86_64 + aarch64), plus the crates.io package.
-
-            ## Changes
-            ${{ steps.changelog.outputs.log }}
+          body_path: ${{ steps.changelog.outputs.changelog }}
           files: |
             artifacts/meta-ast-x86_64-unknown-linux-gnu/*
             artifacts/meta-ast-x86_64-unknown-linux-musl/*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -240,7 +240,17 @@ Architectural decisions go in `docs/adr/` as a numbered ADR with context, decisi
 
 ## Releases
 
-Releases are driven by tags. Pushing a `v*` tag runs `release.yml`, which builds the binary for 7 target triples (Linux gnu and musl, aarch64 Linux, macOS x64 and arm64, Windows x64 and arm64) in both core and `metacall-deploy` variants, then creates a GitHub release with a changelog generated from `git log` since the previous tag. Versioning is semver. Maintainers cut releases; if you think one is due, say so in the issues.
+Releases are driven by tags. Pushing a `v*` tag runs `release.yml`:
+
+1. `verify` checks that the tag matches the `Cargo.toml` version, then runs tests, clippy, and formatting.
+2. `build` compiles the core and `metacall-deploy` binaries for 7 target triples (Linux gnu and musl, aarch64 Linux, macOS x64 and arm64, Windows x64 and arm64).
+3. `release` generates categorized notes from Conventional Commits with `cliff.toml` (git-cliff) and creates the GitHub release with every artifact.
+
+Versioning is semver. Write commit subjects in Conventional Commits form so the notes group correctly. Merge commits and version bump chores stay out. Preview notes for a tag locally with `git cliff --config cliff.toml --current --strip header --offline`.
+
+Crates.io publishing is manual: run the `publish` workflow with the release tag. Keep `dry_run` enabled for the first pass. The workflow reads `CARGO_REGISTRY_TOKEN` from the repository secrets and uses the `release` environment.
+
+Maintainers cut releases; if you think one is due, say so in the issues.
 
 ## License
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,66 @@
+# git-cliff configuration. See https://git-cliff.org/docs/configuration
+#
+# Release notes group Conventional Commits by type. Merge commits and version
+# bump chores stay out. Unconventional subjects land under Other Changes.
+# Run offline so notes never depend on the GitHub API:
+#
+#   git cliff --config cliff.toml --current --strip header --offline
+
+[changelog]
+body = """
+{% if version %}## meta-ast {{ version }}{% else %}## Unreleased{% endif %}
+
+Polyglot static analysis engine for Python, JavaScript, TypeScript, TSX, C, C++, Rust, Go, and Ruby.
+See the [README](https://github.com/metacall/meta-ast#readme) for usage.
+
+{% for entry in commits | commit_groups(groups=commit_parsers_groups) -%}
+### {{ entry.group | striptags | trim }}
+
+{% for commit in entry.commits -%}
+- {% if commit.scope %}**{{ commit.scope }}**: {% endif %}{% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message | upper_first }} ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/metacall/meta-ast/commit/{{ commit.id }}))
+{% endfor %}
+{% endfor %}
+### Install
+
+- CLI: `cargo install meta-ast{% if version %} --version {{ version | trim_start_matches(pat="v") }}{% endif %}`
+- Library: `cargo add meta-ast{% if version %}@{{ version | trim_start_matches(pat="v") }}{% endif %}`
+- Prebuilt binaries are attached for Linux (glibc and musl), macOS (x86_64 and aarch64), and Windows (x86_64 and aarch64), in core and `metacall-deploy` variants.
+{% if previous.version %}
+**Full Changelog**: https://github.com/metacall/meta-ast/compare/{{ previous.version }}...{{ version }}
+{% endif %}
+"""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = false
+require_conventional = false
+split_commits = false
+protect_breaking_commits = true
+commit_parsers = [
+    { message = "^feat", group = "<!-- 0 -->Features" },
+    { message = "^fix", group = "<!-- 1 -->Bug Fixes" },
+    { message = "^perf", group = "<!-- 2 -->Performance" },
+    { message = "^refactor", group = "<!-- 3 -->Refactoring" },
+    { message = "^docs?", group = "<!-- 4 -->Documentation" },
+    { message = "^test", group = "<!-- 5 -->Testing" },
+    { message = "^build", group = "<!-- 6 -->Build" },
+    { message = "^ci", group = "<!-- 7 -->CI" },
+    { message = "^style", group = "<!-- 8 -->Style" },
+    { message = "^revert", group = "<!-- 9 -->Reverts" },
+    { message = "^chore\\(release\\)", skip = true },
+    { message = "^chore.*version", skip = true },
+    { message = "^chore", group = "<!-- 10 -->Maintenance" },
+    { message = "^Merge", skip = true },
+    { message = ".*", group = "<!-- 11 -->Other Changes" },
+]
+filter_commits = false
+fail_on_unmatched_commit = false
+tag_pattern = "v[0-9].*"
+use_branch_tags = false
+topo_order = false
+topo_order_commits = true
+sort_commits = "oldest"
+commit_preprocessors = [
+    { pattern = '\(#(\d+)\)', replace = "([#${1}](https://github.com/metacall/meta-ast/pull/${1}))" },
+]


### PR DESCRIPTION
## Summary
Generate release notes with git-cliff from Conventional Commits, verify the tag against `Cargo.toml`, and add a manual crates.io publish workflow.

## Motivation & Context
Every release body repeated a "GSoC 2026 final release" line, including releases after the GSoC one. Notes were a raw `git log` dump with merge commits, version bumps, and uncategorized entries. The artifact upload guard used an invalid input name, so missing artifacts did not fail the run.

## Technical Architecture & Changes
- `cliff.toml`: grouped sections, commit links, compare link, install section, no emoji, offline.
- `.github/workflows/release.yml`: `verify` job for tag, tests, clippy, and fmt; git-cliff-action for notes; pinned toolchain; fixed upload guard.
- `.github/workflows/publish.yml`: manual `workflow_dispatch` publish with a dry-run default.
- `CONTRIBUTING.md`: release process.
