### PR TITLE
feat(shard): add a hardened .meta-ast index loader

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,9 +46,10 @@ pub use graph::{
 
 // Shard and index re-exports
 pub use output::shard::{
-    LoadedShard, SHARD_SCHEMA_VERSION, ShardEdge, ShardEdgeKind, ShardError, ShardFile,
-    ShardFlowKind, ShardHeader, ShardManifestRecord, ShardSymbol, read_header, read_manifest,
-    read_shard, restore_shard_edges, write_header, write_manifest, write_shard,
+    INDEX_DIR_NAME, IndexLoadOptions, IndexLoadStats, LoadedIndex, LoadedShard,
+    SHARD_SCHEMA_VERSION, ShardEdge, ShardEdgeKind, ShardError, ShardFile, ShardFlowKind,
+    ShardHeader, ShardManifestRecord, ShardSymbol, is_safe_shard_name, load_index, read_header,
+    read_manifest, read_shard, restore_shard_edges, write_header, write_manifest, write_shard,
 };
 pub use pipeline::{GraphAnalysis, SnapshotMeta, snapshot_meta};
 

--- a/src/output/shard/error.rs
+++ b/src/output/shard/error.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 
 /// Failures that can occur during shard reading, writing, or restoration.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum ShardError {
     #[error("shard IO failed: {0}")]
     Io(#[from] std::io::Error),
@@ -40,4 +41,13 @@ pub enum ShardError {
         edge_index: usize,
         message: String,
     },
+
+    #[error("index written by meta-ast {found}; this build is {expected}")]
+    ToolVersionMismatch { found: String, expected: String },
+
+    #[error("unsafe shard name: {name}")]
+    UnsafeShardName { name: String },
+
+    #[error("index path escapes the project root: {path:?}")]
+    PathOutsideRoot { path: PathBuf },
 }

--- a/src/output/shard/index.rs
+++ b/src/output/shard/index.rs
@@ -1,0 +1,189 @@
+//! Hardened `.meta-ast` index loader.
+//!
+//! Reads the header, manifest, and shard files under a project root and
+//! rebuilds the extraction set. Shard names, record paths, and BLAKE3 content
+//! hashes are verified. Stale records are skipped and counted; tampered names
+//! or paths are hard errors.
+
+use std::collections::BTreeMap;
+use std::fs::File;
+use std::io::BufReader;
+use std::path::{Component, Path, PathBuf};
+use std::sync::Arc;
+
+use crate::model::{FileExtraction, IdGenerator, SymbolId};
+
+use super::edge::ShardEdge;
+use super::error::ShardError;
+use super::file::{LoadedShard, ShardFile, read_shard};
+use super::header::{ShardHeader, read_header};
+use super::manifest::{ShardManifestRecord, read_manifest};
+
+/// Directory name of the generated index under the project root.
+pub const INDEX_DIR_NAME: &str = ".meta-ast";
+const HEADER_FILE: &str = "header.json";
+const MANIFEST_FILE: &str = "manifest.jsonl";
+
+/// Controls index verification during [`load_index`].
+#[derive(Debug)]
+pub struct IndexLoadOptions {
+    /// Verify the BLAKE3 content hash of every record.
+    pub verify_content_hash: bool,
+    /// Require the index tool version to match this build.
+    pub require_matching_tool_version: bool,
+}
+
+impl Default for IndexLoadOptions {
+    fn default() -> Self {
+        Self {
+            verify_content_hash: true,
+            require_matching_tool_version: true,
+        }
+    }
+}
+
+/// Counts of records that were loaded or skipped.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct IndexLoadStats {
+    pub loaded: usize,
+    pub skipped: usize,
+}
+
+/// Rebuilt index contents.
+#[derive(Debug)]
+pub struct LoadedIndex {
+    pub header: ShardHeader,
+    pub extractions: Vec<Arc<FileExtraction>>,
+    pub edges: Vec<ShardEdge>,
+    pub stats: IndexLoadStats,
+}
+
+/// Reports whether a manifest shard name stays inside `shards/`.
+pub fn is_safe_shard_name(name: &str) -> bool {
+    let path = Path::new(name);
+    !path.is_absolute()
+        && path.starts_with("shards")
+        && !path
+            .components()
+            .any(|component| matches!(component, Component::ParentDir | Component::RootDir))
+}
+
+/// Load and verify a `.meta-ast` index.
+///
+/// IDs are assigned in manifest order, so the caller must pass a generator
+/// whose start exceeds any cached ID.
+pub fn load_index(
+    root: &Path,
+    id_gen: &IdGenerator<SymbolId>,
+    options: &IndexLoadOptions,
+) -> Result<LoadedIndex, ShardError> {
+    let dir = root.join(INDEX_DIR_NAME);
+    let header = read_header(BufReader::new(File::open(dir.join(HEADER_FILE))?))?;
+    let expected_version = env!("CARGO_PKG_VERSION");
+    if options.require_matching_tool_version && header.tool_version != expected_version {
+        return Err(ShardError::ToolVersionMismatch {
+            found: header.tool_version,
+            expected: expected_version.to_string(),
+        });
+    }
+    let manifest = read_manifest(BufReader::new(File::open(dir.join(MANIFEST_FILE))?))?;
+
+    let mut shards: BTreeMap<String, Vec<ShardFile>> = BTreeMap::new();
+    for record in &manifest {
+        if !is_safe_shard_name(&record.shard) {
+            return Err(ShardError::UnsafeShardName {
+                name: record.shard.clone(),
+            });
+        }
+        if shards.contains_key(&record.shard) {
+            continue;
+        }
+        let path = dir.join(&record.shard);
+        let files = match File::open(&path) {
+            Ok(file) => read_shard(BufReader::new(file))?,
+            Err(_) => continue,
+        };
+        shards.insert(record.shard.clone(), files);
+    }
+
+    let root_canon = dunce::canonicalize(root)?;
+    let mut by_path: BTreeMap<PathBuf, ShardFile> = BTreeMap::new();
+    for files in shards.into_values() {
+        for file in files {
+            by_path.insert(file.path.clone(), file);
+        }
+    }
+
+    let mut extractions = Vec::new();
+    let mut edges = Vec::new();
+    let mut stats = IndexLoadStats::default();
+    for record in &manifest {
+        let Some(absolute) = resolve_record_path(&root_canon, &record.path)? else {
+            stats.skipped += 1;
+            continue;
+        };
+        let Some(shard) = by_path.remove(&record.path) else {
+            stats.skipped += 1;
+            continue;
+        };
+        let Ok(metadata) = std::fs::metadata(&absolute) else {
+            stats.skipped += 1;
+            continue;
+        };
+        if metadata.len() != record.size {
+            stats.skipped += 1;
+            continue;
+        }
+        let Ok(bytes) = std::fs::read(&absolute) else {
+            stats.skipped += 1;
+            continue;
+        };
+        if options.verify_content_hash
+            && ShardManifestRecord::compute_hash(&bytes) != record.content_hash
+        {
+            stats.skipped += 1;
+            continue;
+        }
+        let LoadedShard {
+            file,
+            edges: shard_edges,
+        } = match shard.load(id_gen) {
+            Ok(loaded) => loaded,
+            Err(_) => {
+                stats.skipped += 1;
+                continue;
+            }
+        };
+        extractions.push(Arc::new(file));
+        edges.extend(shard_edges);
+        stats.loaded += 1;
+    }
+
+    Ok(LoadedIndex {
+        header,
+        extractions,
+        edges,
+        stats,
+    })
+}
+
+/// Canonical record path when it exists under the root.
+///
+/// Returns `Ok(None)` for stale records whose file no longer exists. Returns
+/// an error when the resolved path escapes the root.
+fn resolve_record_path(root_canon: &Path, path: &Path) -> Result<Option<PathBuf>, ShardError> {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        root_canon.join(path)
+    };
+    let Ok(canonical) = dunce::canonicalize(&absolute) else {
+        return Ok(None);
+    };
+    if !canonical.starts_with(root_canon) {
+        return Err(ShardError::PathOutsideRoot {
+            path: path.to_path_buf(),
+        });
+    }
+    Ok(Some(canonical))
+}

--- a/src/output/shard/mod.rs
+++ b/src/output/shard/mod.rs
@@ -12,6 +12,7 @@ pub mod edge;
 pub mod error;
 pub mod file;
 pub mod header;
+pub mod index;
 pub mod manifest;
 pub(crate) mod name;
 
@@ -21,6 +22,9 @@ pub use file::{
     LoadedShard, SHARD_SCHEMA_VERSION, ShardFile, ShardSymbol, read_shard, write_shard,
 };
 pub use header::{ShardHeader, read_header, write_header};
+pub use index::{
+    INDEX_DIR_NAME, IndexLoadOptions, IndexLoadStats, LoadedIndex, is_safe_shard_name, load_index,
+};
 pub use manifest::{ShardManifestRecord, read_manifest, write_manifest};
 
 #[cfg(test)]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -14,6 +14,7 @@ mod integration {
     mod output_format_test;
     mod pipeline_test;
     mod reanalyze_api_test;
+    mod shard_index_test;
     mod shard_test;
     #[cfg(feature = "watch")]
     mod watch_test;

--- a/tests/integration/shard_index_test.rs
+++ b/tests/integration/shard_index_test.rs
@@ -1,0 +1,189 @@
+//! Hardened `.meta-ast` index loading.
+
+use std::fs;
+use std::fs::File;
+use std::io::BufReader;
+use std::path::Path;
+
+use meta_ast::model::{IdGenerator, SnapshotId, SymbolId};
+use meta_ast::output::shard::{
+    INDEX_DIR_NAME, IndexLoadOptions, ShardError, ShardFile, ShardHeader, ShardManifestRecord,
+    is_safe_shard_name, load_index, read_manifest, write_header, write_manifest, write_shard,
+};
+use tempfile::tempdir;
+
+fn project() -> tempfile::TempDir {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("a.py"), "import b\ndef alpha(): pass\n").unwrap();
+    fs::write(dir.path().join("b.py"), "def beta(): pass\n").unwrap();
+    dir
+}
+
+fn write_index(root: &Path) -> usize {
+    let snapshot = SnapshotId::new(1).unwrap();
+    let (analysis, _diagnostics) = meta_ast::pipeline::analyze_graph(root, snapshot, None).unwrap();
+    let dir = root.join(INDEX_DIR_NAME);
+    fs::create_dir_all(dir.join("shards")).unwrap();
+
+    let mut header = Vec::new();
+    write_header(&mut header, &ShardHeader::new("2026-01-01T00:00:00Z")).unwrap();
+    fs::write(dir.join("header.json"), header).unwrap();
+
+    let mut records = Vec::new();
+    let mut shards = Vec::new();
+    for file in &analysis.extractions {
+        let bytes = fs::read(&file.path).unwrap();
+        records.push(ShardManifestRecord::from_file_bytes(
+            file.path.clone(),
+            &bytes,
+            0,
+            "shards/000.jsonl".to_string(),
+        ));
+        shards.push(ShardFile::from_extraction(file, &analysis.graph).unwrap());
+    }
+
+    let mut manifest = Vec::new();
+    write_manifest(&mut manifest, &records).unwrap();
+    fs::write(dir.join("manifest.jsonl"), manifest).unwrap();
+
+    let mut shard_bytes = Vec::new();
+    write_shard(&mut shard_bytes, &shards).unwrap();
+    fs::write(dir.join("shards/000.jsonl"), shard_bytes).unwrap();
+
+    records.len()
+}
+
+#[test]
+fn load_index_round_trips_extractions_and_edges() {
+    let dir = project();
+    let expected = write_index(dir.path());
+
+    let id_gen = IdGenerator::<SymbolId>::new();
+    let loaded = load_index(dir.path(), &id_gen, &IndexLoadOptions::default()).unwrap();
+
+    assert_eq!(loaded.stats.loaded, expected);
+    assert_eq!(loaded.stats.skipped, 0);
+    assert_eq!(loaded.extractions.len(), expected);
+
+    let names: Vec<&str> = loaded
+        .extractions
+        .iter()
+        .flat_map(|file| file.symbols.iter().map(|symbol| symbol.name.as_str()))
+        .collect();
+    assert!(names.contains(&"alpha"), "names: {names:?}");
+    assert!(names.contains(&"beta"), "names: {names:?}");
+    assert!(!loaded.edges.is_empty());
+}
+
+#[test]
+fn tampered_content_is_skipped() {
+    let dir = project();
+    write_index(dir.path());
+    fs::write(dir.path().join("a.py"), "def replaced(): pass\n").unwrap();
+
+    let id_gen = IdGenerator::<SymbolId>::new();
+    let loaded = load_index(dir.path(), &id_gen, &IndexLoadOptions::default()).unwrap();
+
+    assert_eq!(loaded.stats.loaded, 1);
+    assert_eq!(loaded.stats.skipped, 1);
+    assert!(
+        loaded
+            .extractions
+            .iter()
+            .flat_map(|file| file.symbols.iter())
+            .all(|symbol| symbol.name != "alpha")
+    );
+}
+
+#[test]
+fn unsafe_shard_name_is_rejected() {
+    let dir = project();
+    write_index(dir.path());
+    let manifest_path = dir.path().join(INDEX_DIR_NAME).join("manifest.jsonl");
+    let mut records = read_manifest(BufReader::new(File::open(&manifest_path).unwrap())).unwrap();
+    for record in &mut records {
+        record.shard = "shards/../secret.jsonl".to_string();
+    }
+    let mut manifest = Vec::new();
+    write_manifest(&mut manifest, &records).unwrap();
+    fs::write(&manifest_path, manifest).unwrap();
+
+    let id_gen = IdGenerator::<SymbolId>::new();
+    let error = load_index(dir.path(), &id_gen, &IndexLoadOptions::default()).unwrap_err();
+    assert!(matches!(error, ShardError::UnsafeShardName { .. }));
+}
+
+#[test]
+fn tool_version_mismatch_is_rejected() {
+    let dir = project();
+    write_index(dir.path());
+    let header_path = dir.path().join(INDEX_DIR_NAME).join("header.json");
+    let mut header = Vec::new();
+    write_header(
+        &mut header,
+        &ShardHeader::with_tool_version("0.0.0", "2026-01-01T00:00:00Z"),
+    )
+    .unwrap();
+    fs::write(&header_path, header).unwrap();
+
+    let id_gen = IdGenerator::<SymbolId>::new();
+    let error = load_index(dir.path(), &id_gen, &IndexLoadOptions::default()).unwrap_err();
+    assert!(matches!(error, ShardError::ToolVersionMismatch { .. }));
+}
+
+#[test]
+fn path_outside_root_is_rejected() {
+    let dir = project();
+    write_index(dir.path());
+    let outside = dir.path().parent().unwrap().join("outside.py");
+    fs::write(&outside, "def outside(): pass\n").unwrap();
+
+    let manifest_path = dir.path().join(INDEX_DIR_NAME).join("manifest.jsonl");
+    let mut records = read_manifest(BufReader::new(File::open(&manifest_path).unwrap())).unwrap();
+    let original = dir.path().join("a.py");
+    for record in &mut records {
+        if record.path == original {
+            record.path = outside.clone();
+        }
+    }
+    let mut manifest = Vec::new();
+    write_manifest(&mut manifest, &records).unwrap();
+    fs::write(&manifest_path, manifest).unwrap();
+
+    let id_gen = IdGenerator::<SymbolId>::new();
+    let error = load_index(dir.path(), &id_gen, &IndexLoadOptions::default()).unwrap_err();
+    assert!(matches!(error, ShardError::PathOutsideRoot { .. }));
+}
+
+#[test]
+fn ids_are_assigned_in_manifest_order() {
+    let dir = project();
+    write_index(dir.path());
+
+    let collect = |loaded: &meta_ast::LoadedIndex| -> Vec<(String, u32)> {
+        loaded
+            .extractions
+            .iter()
+            .flat_map(|file| {
+                file.symbols
+                    .iter()
+                    .map(|symbol| (symbol.name.clone(), symbol.id.to_raw()))
+            })
+            .collect()
+    };
+
+    let first_gen = IdGenerator::<SymbolId>::new();
+    let first = load_index(dir.path(), &first_gen, &IndexLoadOptions::default()).unwrap();
+    let second_gen = IdGenerator::<SymbolId>::new();
+    let second = load_index(dir.path(), &second_gen, &IndexLoadOptions::default()).unwrap();
+
+    assert_eq!(collect(&first), collect(&second));
+}
+
+#[test]
+fn shard_name_safety() {
+    assert!(is_safe_shard_name("shards/000.jsonl"));
+    assert!(!is_safe_shard_name("shards/../secret"));
+    assert!(!is_safe_shard_name("/etc/passwd"));
+    assert!(!is_safe_shard_name("000.jsonl"));
+}


### PR DESCRIPTION
<!--
  Title format: Conventional Commits, lowercase type and scope.
  Examples:
    feat(language): implement Rust intra-procedural dataflow extraction
    fix(graph): deduplicate client-call edges by file-to-symbol triple
    docs: update README installation and usage sections
  Branch: type/description, e.g. feat/fm-export-data-augmentation.
-->

## Summary

<!-- What this PR does and why it exists. Link the issue: Closes #NNN. -->

## Type of change

<!-- Mark with an x. -->

- [ ] `feat` - new functionality
- [x] `fix` - bug fix
- [ ] `refactor` - no behavior change
- [ ] `perf` - performance improvement
- [ ] `docs` - documentation only
- [ ] `test` - tests only
- [ ] `ci` / `chore` - tooling or build

## Affected area

<!-- Which module(s) this touches. -->

- [ ] `model` / ids
- [ ] `graph` / SCC
- [ ] `language` (extraction)
- [ ] `parser`
- [ ] `interface` (CLI)
- [ ] `output`
- [ ] `watch` (feature)
- [ ] `deploy` (feature)
- [ ] `dataflow` (feature)
- [ ] `docs` / `tests`

## Public contract impact

<!-- If this changes CLI, output schema, graph semantics, or manifest format,
     update docs/ and add an ADR or RFC when warranted (see CONTRIBUTING.md). -->

- [ ] No public contract change
- [ ] Public contract changed; `docs/` updated (ADR/RFC where needed)

## Verification

<!-- Run before opening the PR. CI runs the same gates on stable + nightly. -->

- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] `cargo nextest run --all-features` passes
- [ ] `cargo +1.94.0 fmt --check` passes
- [ ] Snapshot changes reviewed with `cargo insta` and `.snap` files committed
- [ ] Any new language has fixtures under `tests/fixtures/<lang>/` and an insta test

## Notes for reviewers

<!-- Anything non-obvious: resolved trade-offs, known limitations, follow-ups. -->