### PR TITLE
fix(imports): stop fabricating project paths

### DIFF
--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -183,7 +183,7 @@ fn extract_source(
     let metrics = parser::tree_metrics(&tree, source);
     let mut diags = Vec::new();
 
-    if metrics.error_ratio > 0.5 {
+    if tree.root_node().has_error() {
         diags.push(Diagnostic {
             path: path.to_path_buf(),
             severity: Severity::Warning,

--- a/src/graph/builder.rs
+++ b/src/graph/builder.rs
@@ -469,13 +469,25 @@ impl GraphBuilder {
                 continue;
             };
             let source_dir = file.path.parent().unwrap_or(std::path::Path::new("."));
-            if let Some(resolver) = resolvers.get(&file.lang) {
-                for import in &file.imports {
-                    if let Some(target) =
-                        resolver.resolve(&import.import_specifier, source_dir, root)
-                    {
-                        builder.add_import(source_fid, target);
+            let Some(resolver) = resolvers.get(&file.lang) else {
+                continue;
+            };
+            for import in &file.imports {
+                let specifier = import_specifier_for(file.lang, import);
+                match resolver.resolve(&specifier, source_dir, root) {
+                    Some(target) => builder.add_import(source_fid, target),
+                    None if is_relative_specifier(&specifier) => {
+                        diagnostics.push(crate::error::Diagnostic {
+                            path: file.path.clone(),
+                            severity: crate::error::Severity::Warning,
+                            message: format!("unresolved relative import: {specifier}"),
+                            source_range: Some(import.range.clone()),
+                        });
                     }
+                    None => builder.add_import(
+                        source_fid,
+                        std::path::PathBuf::from(external_name(file.lang, &specifier)),
+                    ),
                 }
             }
         }
@@ -540,6 +552,41 @@ impl GraphBuilder {
 
         (graph, scc, scope_cache)
     }
+}
+
+/// The specifier the resolver sees.
+///
+/// Python spells a bare relative import (`from . import x`) as a package plus
+/// a name, so the name joins the module path before resolution.
+fn import_specifier_for<'a>(
+    lang: crate::language::LangId,
+    import: &'a crate::model::UnresolvedImport,
+) -> std::borrow::Cow<'a, str> {
+    if lang == crate::language::LangId::Python {
+        crate::language::python::normalize_relative_specifier(
+            &import.import_specifier,
+            import.symbol.as_deref(),
+            import.star,
+        )
+    } else {
+        std::borrow::Cow::Borrowed(import.import_specifier.as_str())
+    }
+}
+
+/// A relative specifier addresses the project, so a miss is a config error.
+fn is_relative_specifier(specifier: &str) -> bool {
+    let stripped = specifier.trim_matches(|c| c == '\'' || c == '"');
+    stripped.starts_with('.') || stripped.starts_with('/')
+}
+
+/// Node name for an unresolved non-relative import (ADR 0003).
+fn external_name(lang: crate::language::LangId, specifier: &str) -> String {
+    use crate::language::{LangId, import_resolver};
+    let name = match lang {
+        LangId::C | LangId::Cpp => import_resolver::strip_c_family_quotes(specifier),
+        _ => import_resolver::strip_import_quotes(specifier),
+    };
+    name.to_string()
 }
 
 #[cfg(test)]

--- a/src/language/go.rs
+++ b/src/language/go.rs
@@ -3,24 +3,24 @@ use crate::model::Visibility;
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
 
-fn resolve_go_import(raw: &str, source_dir: &Path, project_root: &Path) -> Option<PathBuf> {
-    use crate::language::import_resolver::{find_go_module, go_relative_path, strip_import_quotes};
+fn resolve_go_import(raw: &str, _source_dir: &Path, project_root: &Path) -> Option<PathBuf> {
+    use crate::language::import_resolver::{find_go_module, strip_import_quotes};
     let raw = strip_import_quotes(raw);
-    if raw.is_empty() {
+    if raw.is_empty() || raw.starts_with('.') {
+        // Go modules reject relative imports, so there is no path to build.
         return None;
     }
 
-    if let Some(path) = go_relative_path(raw, source_dir) {
-        return Some(path);
-    }
-
     let (dir, module_name) = find_go_module(project_root)?;
-    if raw.starts_with(&module_name) {
-        let relative = raw[module_name.len()..].trim_start_matches('/');
-        return Some(dir.join(relative).with_extension("go"));
+    let relative = raw
+        .strip_prefix(module_name.as_str())
+        .filter(|rest| rest.starts_with('/'))?
+        .trim_start_matches('/');
+    if relative.is_empty() {
+        // A package is a directory. One file cannot represent it.
+        return None;
     }
-
-    None
+    Some(dir.join(relative).with_extension("go"))
 }
 
 static GO_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {

--- a/src/language/import_resolver.rs
+++ b/src/language/import_resolver.rs
@@ -77,21 +77,33 @@ pub(crate) fn resolve_js_family_import(
     probe_relative(raw, source_dir, extensions, is_file, true)
 }
 
-/// Shared stateless core for C-family imports.
+/// Resolve a C or C++ include specifier to a project file.
+///
+/// A system include (`<...>`) never resolves. There is no include path
+/// model, so a quoted include resolves only when the file sits next to the
+/// source file. Everything else stays external (ADR 0003).
 pub(crate) fn resolve_c_family_import(raw: &str, source_dir: &Path) -> Option<PathBuf> {
-    let raw = strip_c_family_quotes(raw);
-    if raw.is_empty() {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() || trimmed.starts_with('<') {
         return None;
     }
-    let path = source_dir.join(raw);
-    if path.extension().is_none() {
-        Some(path.with_extension("h"))
-    } else {
-        Some(path)
+    let relative = strip_c_family_quotes(trimmed);
+    if relative.is_empty() {
+        return None;
     }
+    let candidate = source_dir.join(relative);
+    let candidate = if candidate.extension().is_none() {
+        candidate.with_extension("h")
+    } else {
+        candidate
+    };
+    candidate.is_file().then_some(candidate)
 }
 
-/// Candidate paths for a Python import.
+/// Candidate `__init__.py` and module file for a Python import.
+///
+/// One leading dot is the current package, two dots the parent package, and
+/// so on (PEP 328).
 pub(crate) fn python_candidate_paths(
     raw: &str,
     source_dir: &Path,
@@ -101,28 +113,24 @@ pub(crate) fn python_candidate_paths(
     if raw.is_empty() {
         return None;
     }
-    if raw.starts_with('.') {
-        let relative = raw.trim_start_matches('.');
-        if relative.is_empty() {
-            let init = source_dir.join("__init__.py");
-            return Some((init.clone(), init));
-        }
-        let path = source_dir.join(relative.replace('.', std::path::MAIN_SEPARATOR_STR));
-        let init = path.join("__init__.py");
-        let module = path.with_extension("py");
-        Some((init, module))
-    } else {
+    if !raw.starts_with('.') {
         let path = project_root.join(raw.replace('.', std::path::MAIN_SEPARATOR_STR));
         let init = path.join("__init__.py");
         let module = path.with_extension("py");
-        Some((init, module))
+        return Some((init, module));
     }
-}
 
-/// Relative Go import fast path: `.` prefix strips one dot.
-pub(crate) fn go_relative_path(raw: &str, source_dir: &Path) -> Option<PathBuf> {
-    raw.strip_prefix('.')
-        .map(|relative| source_dir.join(relative).with_extension("go"))
+    let dots = raw.chars().take_while(|c| *c == '.').count();
+    let base = source_dir.ancestors().nth(dots - 1)?;
+    let rest = &raw[dots..];
+    if rest.is_empty() {
+        let init = base.join("__init__.py");
+        return Some((init.clone(), init));
+    }
+    let path = base.join(rest.replace('.', std::path::MAIN_SEPARATOR_STR));
+    let init = path.join("__init__.py");
+    let module = path.with_extension("py");
+    Some((init, module))
 }
 
 /// Walk `project_root` parents for `go.mod` and parse the module name.
@@ -253,12 +261,9 @@ impl GoModResolver {
 impl ImportResolver for GoModResolver {
     fn resolve(&self, raw: &str, source_dir: &Path, project_root: &Path) -> Option<PathBuf> {
         let raw = strip_import_quotes(raw);
-        if raw.is_empty() {
+        if raw.is_empty() || raw.starts_with('.') {
+            // Go modules reject relative imports, so there is no path to build.
             return None;
-        }
-
-        if let Some(path) = go_relative_path(raw, source_dir) {
-            return Some(path);
         }
 
         let cached = self
@@ -278,14 +283,16 @@ impl ImportResolver for GoModResolver {
         };
 
         let matched_module = module_info.as_ref().and_then(|(dir, name)| {
-            if raw.starts_with(name) {
-                Some((dir, name))
-            } else {
-                None
-            }
+            raw.strip_prefix(name.as_str())
+                .filter(|rest| rest.is_empty() || rest.starts_with('/'))
+                .map(|_| (dir, name))
         });
         if let Some((dir, module_name)) = matched_module {
             let relative = raw[module_name.len()..].trim_start_matches('/');
+            if relative.is_empty() {
+                // A package is a directory. One file cannot represent it.
+                return None;
+            }
             return Some(dir.join(relative).with_extension("go"));
         }
 
@@ -769,10 +776,7 @@ mod tests {
         );
         // Invalidate:
         py_resolver.clear_cache();
-        assert_eq!(
-            py_resolver.resolve("py_pkg", &temp_dir, &temp_dir),
-            Some(temp_dir.join("py_pkg.py"))
-        );
+        assert_eq!(py_resolver.resolve("py_pkg", &temp_dir, &temp_dir), None);
 
         // 2. Go resolver cache invalidation
         let go_mod_path = temp_dir.join("go.mod");

--- a/src/language/python.rs
+++ b/src/language/python.rs
@@ -5,10 +5,30 @@ use std::sync::LazyLock;
 fn resolve_python_import(raw: &str, source_dir: &Path, project_root: &Path) -> Option<PathBuf> {
     use crate::language::import_resolver::python_candidate_paths;
     let (init_path, module_path) = python_candidate_paths(raw, source_dir, project_root)?;
-    if init_path.exists() {
+    if init_path.is_file() {
         return Some(init_path);
     }
-    Some(module_path)
+    module_path.is_file().then_some(module_path)
+}
+
+/// Join the imported name onto a dots-only relative specifier.
+///
+/// `from . import util` imports the submodule `util` of the current package.
+/// Tree-sitter captures the specifier and the name separately, so the module
+/// path is `.util`.
+pub(crate) fn normalize_relative_specifier<'a>(
+    specifier: &'a str,
+    symbol: Option<&str>,
+    star: bool,
+) -> std::borrow::Cow<'a, str> {
+    let specifier = specifier.trim();
+    if star || specifier.is_empty() || !specifier.bytes().all(|byte| byte == b'.') {
+        return std::borrow::Cow::Borrowed(specifier);
+    }
+    match symbol {
+        Some(name) if !name.is_empty() => std::borrow::Cow::Owned(format!("{specifier}{name}")),
+        _ => std::borrow::Cow::Borrowed(specifier),
+    }
 }
 
 static PYTHON_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
@@ -58,13 +78,22 @@ const PYTHON_IMPORT_QUERY_STR: &str = r#"
     name: (dotted_name) @import.path
     alias: (identifier) @import.alias))
 (import_from_statement
-  module_name: (dotted_name) @import.path
-  name: (_) @import.symbol)
+  module_name: [
+    (dotted_name)
+    (relative_import)
+  ] @import.path
+  name: (dotted_name) @import.symbol)
 (import_from_statement
-  module_name: (dotted_name) @import.path
+  module_name: [
+    (dotted_name)
+    (relative_import)
+  ] @import.path
   (aliased_import name: (_) @import.symbol alias: (identifier) @import.alias))
 (import_from_statement
-  module_name: (dotted_name) @import.path
+  module_name: [
+    (dotted_name)
+    (relative_import)
+  ] @import.path
   (wildcard_import) @import.star)
 "#;
 

--- a/src/language/rust.rs
+++ b/src/language/rust.rs
@@ -2,23 +2,35 @@ use crate::language::{DefaultVisibility, DocCommentConfig, LanguageSpec};
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
 
+/// Resolve a module path against a base directory.
+///
+/// The trailing segments may name items rather than modules, so the longest
+/// path that yields a file wins: `crate::lib::compute` resolves to `lib.rs`.
 fn resolve_rust_module_path(rest: &str, base: &Path) -> Option<PathBuf> {
-    let segments: Vec<&str> = rest.split("::").collect();
-    let module = segments.first()?;
+    let segments: Vec<&str> = rest.split("::").filter(|s| !s.is_empty()).collect();
+    (1..=segments.len())
+        .rev()
+        .find_map(|end| module_file(&segments[..end], base))
+}
 
-    // Try direct file: base/module.rs
-    let direct_file = base.join(format!("{module}.rs"));
-    if direct_file.exists() {
+fn module_file(segments: &[&str], base: &Path) -> Option<PathBuf> {
+    let (last, parents) = segments.split_last()?;
+
+    let mut current = base.to_path_buf();
+    for segment in parents {
+        current = current.join(segment);
+        if !current.is_dir() {
+            return None;
+        }
+    }
+
+    let direct_file = current.join(format!("{last}.rs"));
+    if direct_file.is_file() {
         return Some(direct_file);
     }
 
-    // Try directory module: base/module/mod.rs
-    let dir_mod = base.join(module).join("mod.rs");
-    if dir_mod.exists() {
-        return Some(dir_mod);
-    }
-
-    None
+    let dir_mod = current.join(last).join("mod.rs");
+    dir_mod.is_file().then_some(dir_mod)
 }
 
 fn resolve_rust_import(raw: &str, source_dir: &Path, project_root: &Path) -> Option<PathBuf> {
@@ -35,7 +47,13 @@ fn resolve_rust_import(raw: &str, source_dir: &Path, project_root: &Path) -> Opt
         return resolve_rust_module_path(rest, parent);
     }
     if let Some(rest) = raw.strip_prefix("crate::") {
-        return resolve_rust_module_path(rest, project_root);
+        let src_dir = project_root.join("src");
+        let base = if src_dir.is_dir() {
+            src_dir
+        } else {
+            project_root.to_path_buf()
+        };
+        return resolve_rust_module_path(rest, &base);
     }
     None
 }


### PR DESCRIPTION
## Summary

Unresolved imports fabricated project paths: `import requests` became `<root>/requests.py`, `#include <stdio.h>` became `<src>/stdio.h`, and `from . import util` was dropped with no diagnostic.

- Python resolves level-aware (PEP 328) and only returns paths that exist.
- Rust walks all segments and falls back to the deepest module file, with `src/` as the `crate::` base.
- Go rejects relative imports and requires a path boundary on the module prefix.
- A C include resolves only when the file exists next to the source; system includes never resolve.
- The builder applies ADR 0003: a relative miss warns, a non-relative miss becomes an external node.
- A tree with parse errors always reports a diagnostic, not only a mostly broken one.

## Type of change

- [x] `fix` - bug fix

## Affected area

- [x] `graph` / SCC
- [x] `language` (extraction)
- [x] `docs` / `tests`

## Public contract impact

- [x] No public contract change (implements ADR 0003 and the external-node rule in ARCHITECTURE.md)

## Verification

- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo nextest run --all-features` passes
- [x] `cargo +1.94.0 fmt --check` passes
- [x] Snapshot changes reviewed with `cargo insta` and `.snap` files committed (none changed)
- [x] Any new language has fixtures under `tests/fixtures/<lang>/` and an insta test (no new language)

## Notes for reviewers

`resolver_clear_cache_invalidates_memoized_state` asserted the fabricated Python fallback. It now asserts `None` after the cache is cleared.

Next in the stack: JS/TS arrow function and function expression symbols.
