### PR TITLE
feat(language): extract function expressions and module constants

### DIFF
--- a/src/language/javascript.rs
+++ b/src/language/javascript.rs
@@ -49,6 +49,20 @@ static JS_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
     ) @kind.class
   ]
 )
+
+(variable_declarator
+  name: (identifier) @name
+  value: (arrow_function
+    "async"? @async
+    parameters: (formal_parameters) @signature)
+) @kind.function
+
+(variable_declarator
+  name: (identifier) @name
+  value: (function_expression
+    "async"? @async
+    parameters: (formal_parameters) @signature)
+) @kind.function
 "#,
         "JavaScript",
     )

--- a/src/language/python.rs
+++ b/src/language/python.rs
@@ -61,6 +61,12 @@ static PYTHON_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
     ) @kind.class
   ]
 )
+
+(module
+  (expression_statement
+    (assignment
+      left: (identifier) @name) @kind.constant)
+)
 "#,
         "Python",
     )

--- a/src/language/snapshots/meta_ast__language__javascript__tests__js_insta_snapshot.snap
+++ b/src/language/snapshots/meta_ast__language__javascript__tests__js_insta_snapshot.snap
@@ -1,6 +1,5 @@
 ---
 source: src/language/javascript.rs
-assertion_line: 214
 expression: symbols
 ---
 [
@@ -43,5 +42,45 @@ expression: symbols
     "signature": "(url)",
     "docstring": null,
     "is_async": true
+  },
+  {
+    "name": "compute",
+    "kind": "Function",
+    "source_range": {
+      "byte_start": 150,
+      "byte_end": 196,
+      "start": {
+        "line": 9,
+        "column": 6
+      },
+      "end": {
+        "line": 11,
+        "column": 1
+      }
+    },
+    "visibility": null,
+    "signature": "(x, y)",
+    "docstring": null,
+    "is_async": false
+  },
+  {
+    "name": "greet",
+    "kind": "Function",
+    "source_range": {
+      "byte_start": 205,
+      "byte_end": 239,
+      "start": {
+        "line": 13,
+        "column": 6
+      },
+      "end": {
+        "line": 13,
+        "column": 40
+      }
+    },
+    "visibility": null,
+    "signature": "(name)",
+    "docstring": null,
+    "is_async": false
   }
 ]

--- a/src/language/snapshots/meta_ast__language__tsx__tests__tsx_insta_snapshot.snap
+++ b/src/language/snapshots/meta_ast__language__tsx__tests__tsx_insta_snapshot.snap
@@ -1,6 +1,5 @@
 ---
 source: src/language/tsx.rs
-assertion_line: 210
 expression: symbols
 ---
 [
@@ -41,6 +40,26 @@ expression: symbols
     },
     "visibility": null,
     "signature": "(props: Props)",
+    "docstring": null,
+    "is_async": false
+  },
+  {
+    "name": "Welcome",
+    "kind": "Function",
+    "source_range": {
+      "byte_start": 184,
+      "byte_end": 271,
+      "start": {
+        "line": 11,
+        "column": 6
+      },
+      "end": {
+        "line": 13,
+        "column": 1
+      }
+    },
+    "visibility": null,
+    "signature": "(props)",
     "docstring": null,
     "is_async": false
   },

--- a/src/language/typescript.rs
+++ b/src/language/typescript.rs
@@ -71,6 +71,20 @@ pub(crate) const TS_FAMILY_QUERY: &str = r#"
     ) @kind.type_alias
   ]
 )
+
+(variable_declarator
+  name: (identifier) @name
+  value: (arrow_function
+    "async"? @async
+    parameters: (formal_parameters) @signature)
+) @kind.function
+
+(variable_declarator
+  name: (identifier) @name
+  value: (function_expression
+    "async"? @async
+    parameters: (formal_parameters) @signature)
+) @kind.function
 "#;
 
 static TS_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {


### PR DESCRIPTION
## Summary

`export const handler = async () => {}` and `const fn = function () {}` produced no symbol, and Python module-level assignments were invisible.

- JS, TS and TSX capture `variable_declarator` values that are arrow functions or function expressions, sync and async.
- Python captures module-level assignments as constants; function locals stay out of scope.
- The JS and TSX snapshots gain `compute`, `greet` and `Welcome`. No other snapshot changes.

## Type of change

- [x] `feat` - new functionality

## Affected area

- [x] `language` (extraction)
- [x] `docs` / `tests`

## Public contract impact

- [x] No public contract change (the spec already promises these symbols)

## Verification

- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo nextest run --all-features` passes
- [x] `cargo +1.94.0 fmt --check` passes
- [x] Snapshot changes reviewed with `cargo insta` and `.snap` files committed
- [x] Any new language has fixtures under `tests/fixtures/<lang>/` and an insta test (no new language)

## Notes for reviewers

Stacked on #77. Next in the stack: C and C++ declarations plus header extensions.
