### PR TITLE
feat(language): capture C and C++ declarations and headers

### DIFF
--- a/docs/src/specs/symbol-extraction.md
+++ b/docs/src/specs/symbol-extraction.md
@@ -31,11 +31,13 @@ languages grows over time; see `ROADMAP.md` Phase 6 for the expansion plan.
 ### C
 
 - Extract: function definitions/declarations, structs, enums, typedefs, includes.
+- Extensions: `.c` and `.h`.
 - Distinguish declaration vs definition 'where possible'.
 
 ### C++
 
 - Extract C symbols plus classes, namespaces, templates, aliases, method definitions.
+- Extensions: `.cc`, `.cpp`, `.cxx` and `.hpp`.
 
 ### Rust
 

--- a/src/language/c.rs
+++ b/src/language/c.rs
@@ -33,6 +33,17 @@ static C_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
 
         (type_definition
             declarator: (type_identifier) @name) @kind.type_alias
+
+        (declaration
+            declarator: [
+                (function_declarator
+                    declarator: (identifier) @name
+                    parameters: (parameter_list) @signature)
+                (pointer_declarator
+                    declarator: (function_declarator
+                        declarator: (identifier) @name
+                        parameters: (parameter_list) @signature))
+            ]) @kind.declaration
         "#,
         "C",
     )
@@ -76,7 +87,7 @@ fn c_import_ref_query() -> &'static tree_sitter::Query {
 }
 
 pub(crate) const C_SPEC: LanguageSpec = LanguageSpec {
-    extensions: &["c"],
+    extensions: &["c", "h"],
     grammar_fn: || tree_sitter_c::LANGUAGE.into(),
     query_fn: c_query,
     import_path_resolver: resolve_c_import,

--- a/src/language/common.rs
+++ b/src/language/common.rs
@@ -132,6 +132,7 @@ pub(crate) fn extract_with_spec<'a>(
                         "module" => SymbolKind::Module,
                         "namespace" => SymbolKind::Namespace,
                         "type_alias" => SymbolKind::TypeAlias,
+                        "declaration" => SymbolKind::Declaration,
                         "object" => SymbolKind::Object,
                         _ => continue,
                     };

--- a/src/language/cpp.rs
+++ b/src/language/cpp.rs
@@ -13,10 +13,74 @@ static CPP_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
         r#"
         (function_definition
           declarator: (function_declarator
-            declarator: (_) @name
+            declarator: [
+              (identifier)
+              (field_identifier)
+              (operator_name)
+              (destructor_name)
+            ] @name
             parameters: (parameter_list) @signature
           )
         ) @kind.function
+
+        (function_definition
+          declarator: (function_declarator
+            declarator: (qualified_identifier name: (identifier) @name)
+            parameters: (parameter_list) @signature
+          )
+        ) @kind.function
+
+        (function_definition
+          declarator: (pointer_declarator
+            declarator: (function_declarator
+              declarator: (identifier) @name
+              parameters: (parameter_list) @signature
+            )
+          )
+        ) @kind.function
+
+        (function_definition
+          declarator: (reference_declarator
+            (function_declarator
+              declarator: (identifier) @name
+              parameters: (parameter_list) @signature
+            )
+          )
+        ) @kind.function
+
+        (declaration
+          declarator: (function_declarator
+            declarator: (identifier) @name
+            parameters: (parameter_list) @signature
+          )
+        ) @kind.declaration
+
+        (declaration
+          declarator: (function_declarator
+            declarator: (qualified_identifier name: (identifier) @name)
+            parameters: (parameter_list) @signature
+          )
+        ) @kind.declaration
+
+        (declaration
+          declarator: (pointer_declarator
+            declarator: (function_declarator
+              declarator: (identifier) @name
+              parameters: (parameter_list) @signature
+            )
+          )
+        ) @kind.declaration
+
+        (field_declaration
+          declarator: (function_declarator
+            declarator: [
+              (field_identifier)
+              (operator_name)
+              (destructor_name)
+            ] @name
+            parameters: (parameter_list) @signature
+          )
+        ) @kind.declaration
 
         (class_specifier
             name: (type_identifier) @name) @kind.class
@@ -57,7 +121,7 @@ fn cpp_import_ref_query() -> &'static tree_sitter::Query {
 }
 
 pub(crate) const CPP_SPEC: LanguageSpec = LanguageSpec {
-    extensions: &["cc", "cpp", "cxx"],
+    extensions: &["cc", "cpp", "cxx", "hpp"],
     grammar_fn: || tree_sitter_cpp::LANGUAGE.into(),
     query_fn: cpp_query,
     import_path_resolver: resolve_cpp_import,

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -115,6 +115,8 @@ pub enum SymbolKind {
     Module,
     Namespace,
     TypeAlias,
+    /// Function or method declaration without a body (C and C++ prototypes).
+    Declaration,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -314,6 +316,7 @@ mod tests {
             SymbolKind::Module,
             SymbolKind::Namespace,
             SymbolKind::TypeAlias,
+            SymbolKind::Declaration,
         ];
         for v in &variants {
             let json = serde_json::to_string(v).unwrap();

--- a/src/output/inspect.rs
+++ b/src/output/inspect.rs
@@ -12,7 +12,7 @@ pub fn symbols_to_inspect_output(symbols: Vec<Symbol>) -> InspectOutput {
 
     for symbol in symbols {
         match symbol.kind {
-            SymbolKind::Function | SymbolKind::Method => {
+            SymbolKind::Function | SymbolKind::Method | SymbolKind::Declaration => {
                 output.funcs.push(crate::model::output::FuncEntry {
                     name: symbol.name,
                     source_range: symbol.source_range,

--- a/src/output/shard/name.rs
+++ b/src/output/shard/name.rs
@@ -187,5 +187,6 @@ pub(crate) fn symbol_kind_name(kind: SymbolKind) -> &'static str {
         SymbolKind::Module => "module",
         SymbolKind::Namespace => "namespace",
         SymbolKind::TypeAlias => "type_alias",
+        SymbolKind::Declaration => "declaration",
     }
 }


### PR DESCRIPTION
## Summary

C and C++ headers never entered the pipeline, so header-only APIs produced nothing, and `#include "utils.h"` pointed at a fabricated project path. C++ declarators were captured by wildcard, which named `void C::m()` as `C::m` and dropped `void *alloc()` entirely.

- `.h` joins the C pack and `.hpp` joins the C++ pack, one owner per extension.
- C captures function declarations as `SymbolKind::Declaration`; definitions stay `Function`.
- C++ enumerates declarator shapes: plain, member, qualified, operator, destructor, pointer-returning and reference-returning.
- The new kind maps to `declaration` in stable shard names and to the function bucket in inspect output.

## Type of change

- [x] `feat` - new functionality

## Affected area

- [x] `language` (extraction)
- [x] `model` / ids
- [x] `output`
- [x] `docs` / `tests`

## Public contract impact

- [x] Public contract changed; `docs/` updated (catalog extensions recorded in the symbol extraction spec)

## Verification

- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo nextest run --all-features` passes
- [x] `cargo +1.94.0 fmt --check` passes
- [x] Snapshot changes reviewed with `cargo insta` and `.snap` files committed (none changed)
- [x] Any new language has fixtures under `tests/fixtures/<lang>/` and an insta test (no new language)

## Notes for reviewers

Stacked on #78. Follow-up, not included here: the resolver still emits every name candidate, so a header declaration and a source definition of the same name both take an edge until shadowing is enforced.
