### PR TITLE
test: pin extraction and import defects

### DIFF
--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -433,4 +433,32 @@ mod tests {
             "all IDs must be unique"
         );
     }
+
+    #[test]
+    fn parse_errors_are_reported_for_any_broken_tree() {
+        let clean = write_temp("parse_clean.py", b"def ok(): pass\n");
+        let slightly_broken = write_temp("parse_broken.py", b"def broken(\n   # no close paren\n");
+        let heavily_broken = write_temp("parse_heavily_broken.py", b"@@@ ??? (((\n");
+        let result = extract(&[
+            (clean.clone(), LangId::Python),
+            (slightly_broken.clone(), LangId::Python),
+            (heavily_broken.clone(), LangId::Python),
+        ]);
+
+        let parse_diagnostics = |path: &PathBuf| -> usize {
+            result
+                .files
+                .iter()
+                .find(|f| &f.path == path)
+                .unwrap()
+                .diagnostics
+                .iter()
+                .filter(|d| d.message.contains("parse errors"))
+                .count()
+        };
+
+        assert_eq!(parse_diagnostics(&clean), 0);
+        assert!(parse_diagnostics(&slightly_broken) > 0);
+        assert!(parse_diagnostics(&heavily_broken) > 0);
+    }
 }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -301,4 +301,13 @@ mod tests {
         let out = simplified_path(Path::new("a/b.py"));
         assert_eq!(out, PathBuf::from("a/b.py"));
     }
+
+    #[test]
+    fn header_extensions_are_detected() {
+        assert_eq!(detect_language(&PathBuf::from("foo.h")), Some(LangId::C));
+        assert_eq!(
+            detect_language(&PathBuf::from("foo.hpp")),
+            Some(LangId::Cpp)
+        );
+    }
 }

--- a/src/language/c.rs
+++ b/src/language/c.rs
@@ -145,6 +145,54 @@ mod tests {
     }
 
     #[test]
+    fn extract_function_declaration() {
+        let src = b"int add(int a, int b);";
+        let tree = parse(src);
+        let symbols = extract_symbols_for(LangId::C, &tree, src);
+        let found = symbols.iter().find(|s| s.name == "add");
+        assert!(found.is_some(), "missing add: {symbols:?}");
+        let found = found.unwrap();
+        assert_eq!(format!("{:?}", found.kind), "Declaration");
+        assert_eq!(found.signature.as_deref(), Some("(int a, int b)"));
+    }
+
+    #[test]
+    fn extract_pointer_returning_function_declaration() {
+        let src = b"int *f(void);";
+        let tree = parse(src);
+        let symbols = extract_symbols_for(LangId::C, &tree, src);
+        let found = symbols.iter().find(|s| s.name == "f");
+        assert!(found.is_some(), "missing f: {symbols:?}");
+        assert_eq!(format!("{:?}", found.unwrap().kind), "Declaration");
+    }
+
+    #[test]
+    fn extern_variable_declaration_is_not_a_symbol() {
+        let src = b"extern int counter;";
+        let tree = parse(src);
+        let symbols = extract_symbols_for(LangId::C, &tree, src);
+        assert!(!symbols.iter().any(|s| s.name == "counter"));
+    }
+
+    #[test]
+    fn typedef_function_pointer_is_not_a_declaration() {
+        let src = b"typedef int (*cb)(int);";
+        let tree = parse(src);
+        let symbols = extract_symbols_for(LangId::C, &tree, src);
+        assert!(!symbols.iter().any(|s| s.name == "cb"));
+    }
+
+    #[test]
+    fn definition_is_not_marked_as_a_declaration() {
+        let src = b"int add(int a, int b) { return a + b; }";
+        let tree = parse(src);
+        let symbols = extract_symbols_for(LangId::C, &tree, src);
+        assert_eq!(symbols.len(), 1, "{symbols:?}");
+        assert_eq!(symbols[0].name, "add");
+        assert_eq!(format!("{:?}", symbols[0].kind), "Function");
+    }
+
+    #[test]
     fn c_insta_snapshot() {
         let src = std::fs::read_to_string(
             std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))

--- a/src/language/cpp.rs
+++ b/src/language/cpp.rs
@@ -119,6 +119,50 @@ mod tests {
     }
 
     #[test]
+    fn extract_class_member_function_declaration() {
+        let src = b"class C { void m(); };";
+        let tree = parse(src);
+        let symbols = extract_symbols_for(LangId::Cpp, &tree, src);
+        let found = symbols.iter().find(|s| s.name == "m");
+        assert!(found.is_some(), "missing m: {symbols:?}");
+        assert_eq!(format!("{:?}", found.unwrap().kind), "Declaration");
+    }
+
+    #[test]
+    fn qualified_definition_uses_the_plain_name() {
+        let src = b"void C::m() {}";
+        let tree = parse(src);
+        let symbols = extract_symbols_for(LangId::Cpp, &tree, src);
+        let names: Vec<&str> = symbols.iter().map(|s| s.name.as_ref()).collect();
+        assert!(names.contains(&"m"), "names: {names:?}");
+        assert!(!names.contains(&"C::m"), "names: {names:?}");
+    }
+
+    #[test]
+    fn pointer_returning_definition_is_captured() {
+        let src = b"void *alloc(int n) { return 0; }";
+        let tree = parse(src);
+        let symbols = extract_symbols_for(LangId::Cpp, &tree, src);
+        assert!(symbols.iter().any(|s| s.name == "alloc"), "{symbols:?}");
+    }
+
+    #[test]
+    fn reference_returning_definition_is_captured() {
+        let src = b"int &ref(int n) { return n; }";
+        let tree = parse(src);
+        let symbols = extract_symbols_for(LangId::Cpp, &tree, src);
+        assert!(symbols.iter().any(|s| s.name == "ref"), "{symbols:?}");
+    }
+
+    #[test]
+    fn data_member_is_not_a_symbol() {
+        let src = b"class C { int x; };";
+        let tree = parse(src);
+        let symbols = extract_symbols_for(LangId::Cpp, &tree, src);
+        assert!(!symbols.iter().any(|s| s.name == "x"));
+    }
+
+    #[test]
     fn cpp_insta_snapshot() {
         let src = std::fs::read_to_string(
             std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))

--- a/src/language/import_resolver.rs
+++ b/src/language/import_resolver.rs
@@ -500,10 +500,157 @@ mod tests {
     fn shared_quote_strip_helpers() {
         assert_eq!(strip_import_quotes("\"react\""), "react");
         assert_eq!(strip_c_family_quotes("<stdio.h>"), "stdio.h");
-        assert_eq!(
-            resolve_c_family_import("<stdio.h>", Path::new("/src")),
-            Some(PathBuf::from("/src/stdio.h"))
+    }
+
+    fn scratch(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("meta_ast_resolver_{name}"));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn touch(path: &Path) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, "").unwrap();
+    }
+
+    fn resolved(
+        lang: crate::language::LangId,
+        raw: &str,
+        source_dir: &Path,
+        root: &Path,
+    ) -> Option<PathBuf> {
+        make_resolver(lang).resolve(raw, source_dir, root)
+    }
+
+    #[test]
+    fn python_level_two_relative_import_uses_the_parent_package() {
+        let root = scratch("py_level_two");
+        let pkg = root.join("pkg");
+        touch(&root.join("util.py"));
+        touch(&pkg.join("util.py"));
+
+        let out = resolved(crate::language::LangId::Python, "..util", &pkg, &root);
+        assert_eq!(out, Some(root.join("util.py")));
+    }
+
+    #[test]
+    fn python_third_party_import_is_not_a_project_path() {
+        let root = scratch("py_third_party");
+        let pkg = root.join("pkg");
+        touch(&pkg.join("__init__.py"));
+
+        let out = resolved(crate::language::LangId::Python, "requests", &pkg, &root);
+        assert_eq!(out, None);
+    }
+
+    #[test]
+    fn python_first_party_relative_import_still_resolves() {
+        let root = scratch("py_first_party");
+        let pkg = root.join("pkg");
+        touch(&pkg.join("util.py"));
+
+        let out = resolved(crate::language::LangId::Python, ".util", &pkg, &root);
+        assert_eq!(out, Some(pkg.join("util.py")));
+    }
+
+    #[test]
+    fn python_dotted_import_resolves_when_the_file_exists() {
+        let root = scratch("py_dotted");
+        touch(&root.join("svc/api.py"));
+
+        let out = resolved(crate::language::LangId::Python, "svc.api", &root, &root);
+        assert_eq!(out, Some(root.join("svc/api.py")));
+    }
+
+    #[test]
+    fn go_relative_import_is_rejected() {
+        let root = scratch("go_relative");
+        let out = resolved(crate::language::LangId::Go, "\"./util\"", &root, &root);
+        assert_eq!(out, None);
+    }
+
+    #[test]
+    fn go_module_prefix_requires_a_boundary() {
+        let root = scratch("go_prefix");
+        std::fs::write(root.join("go.mod"), "module myproject\n").unwrap();
+
+        let out = resolved(
+            crate::language::LangId::Go,
+            "\"myproject2/pkg\"",
+            &root,
+            &root,
         );
+        assert_eq!(out, None);
+    }
+
+    #[test]
+    fn go_module_import_of_a_subpackage_resolves() {
+        let root = scratch("go_subpackage");
+        std::fs::write(root.join("go.mod"), "module myproject\n").unwrap();
+
+        let out = resolved(
+            crate::language::LangId::Go,
+            "\"myproject/internal/util\"",
+            &root,
+            &root,
+        );
+        assert_eq!(out, Some(root.join("internal/util.go")));
+    }
+
+    #[test]
+    fn c_system_include_is_not_a_project_path() {
+        let root = scratch("c_system_include");
+        let src = root.join("src");
+        std::fs::create_dir_all(&src).unwrap();
+
+        let out = resolved(crate::language::LangId::C, "<stdio.h>", &src, &root);
+        assert_eq!(out, None);
+    }
+
+    #[test]
+    fn c_missing_quoted_include_is_not_a_project_path() {
+        let root = scratch("c_missing_include");
+        let src = root.join("src");
+        std::fs::create_dir_all(&src).unwrap();
+
+        let out = resolved(crate::language::LangId::C, "\"missing.h\"", &src, &root);
+        assert_eq!(out, None);
+    }
+
+    #[test]
+    fn c_existing_quoted_include_resolves() {
+        let root = scratch("c_existing_include");
+        let src = root.join("src");
+        touch(&src.join("local.h"));
+
+        let out = resolved(crate::language::LangId::C, "\"local.h\"", &src, &root);
+        assert_eq!(out, Some(src.join("local.h")));
+    }
+
+    #[test]
+    fn rust_crate_path_walks_all_segments() {
+        let root = scratch("rust_crate_path");
+        let src = root.join("src");
+        touch(&src.join("a/b.rs"));
+
+        let out = resolved(
+            crate::language::LangId::Rust,
+            "\"crate::a::b\"",
+            &src,
+            &root,
+        );
+        assert_eq!(out, Some(src.join("a/b.rs")));
+    }
+
+    #[test]
+    fn rust_self_path_resolves_within_the_module() {
+        let root = scratch("rust_self_path");
+        let src = root.join("src");
+        touch(&src.join("here.rs"));
+
+        let out = resolved(crate::language::LangId::Rust, "\"self::here\"", &src, &root);
+        assert_eq!(out, Some(src.join("here.rs")));
     }
 
     #[test]

--- a/src/language/javascript.rs
+++ b/src/language/javascript.rs
@@ -354,6 +354,58 @@ mod tests {
         assert!(func.docstring.as_ref().unwrap().contains("JSDoc comment"));
     }
 
+    fn symbol_names(symbols: &[crate::language::RawSymbol<'_>]) -> Vec<String> {
+        symbols.iter().map(|s| s.name.to_string()).collect()
+    }
+
+    #[test]
+    fn extract_arrow_function_assigned_to_const() {
+        let src = b"const compute = (a, b) => a + b;";
+        let tree = parse(src);
+        let symbols = extract_symbols_for(LangId::JavaScript, &tree, src);
+        let found = symbols.iter().find(|s| s.name == "compute");
+        assert!(
+            found.is_some(),
+            "missing compute: {:?}",
+            symbol_names(&symbols)
+        );
+        let found = found.unwrap();
+        assert!(matches!(found.kind, SymbolKind::Function));
+        assert_eq!(found.signature.as_deref(), Some("(a, b)"));
+    }
+
+    #[test]
+    fn extract_exported_async_arrow_function() {
+        let src = b"export const handler = async () => {};";
+        let tree = parse(src);
+        let symbols = extract_symbols_for(LangId::JavaScript, &tree, src);
+        let found = symbols.iter().find(|s| s.name == "handler");
+        assert!(
+            found.is_some(),
+            "missing handler: {:?}",
+            symbol_names(&symbols)
+        );
+        let found = found.unwrap();
+        assert!(matches!(found.kind, SymbolKind::Function));
+        assert!(found.is_async);
+        assert_eq!(found.visibility, Some(Visibility::Public));
+    }
+
+    #[test]
+    fn extract_function_expression_assigned_to_const() {
+        let src = b"const greet = function inner(x) { return x; };";
+        let tree = parse(src);
+        let symbols = extract_symbols_for(LangId::JavaScript, &tree, src);
+        let found = symbols.iter().find(|s| s.name == "greet");
+        assert!(
+            found.is_some(),
+            "missing greet: {:?}",
+            symbol_names(&symbols)
+        );
+        assert!(!symbols.iter().any(|s| s.name == "inner"));
+        assert_eq!(found.unwrap().signature.as_deref(), Some("(x)"));
+    }
+
     #[test]
     fn js_insta_snapshot() {
         let src = std::fs::read_to_string(

--- a/src/language/python.rs
+++ b/src/language/python.rs
@@ -326,6 +326,95 @@ mod tests {
         assert_eq!(edges[0].kind, crate::model::FlowKind::DefUse);
     }
 
+    fn symbol_names(symbols: &[crate::language::RawSymbol<'_>]) -> Vec<String> {
+        symbols.iter().map(|s| s.name.to_string()).collect()
+    }
+
+    #[test]
+    fn module_level_assignment_is_a_constant() {
+        let src = b"MAX_RETRIES = 3\n";
+        let tree = parse(src);
+        let symbols = extract_symbols_for(LangId::Python, &tree, src);
+        let found = symbols.iter().find(|s| s.name == "MAX_RETRIES");
+        assert!(
+            found.is_some(),
+            "missing MAX_RETRIES: {:?}",
+            symbol_names(&symbols)
+        );
+        assert!(matches!(found.unwrap().kind, SymbolKind::Constant));
+    }
+
+    #[test]
+    fn function_local_assignment_is_not_a_symbol() {
+        let src = b"def f():\n    local = 1\n";
+        let tree = parse(src);
+        let symbols = extract_symbols_for(LangId::Python, &tree, src);
+        assert!(!symbols.iter().any(|s| s.name == "local"));
+    }
+
+    #[test]
+    fn relative_import_with_bare_dot_is_captured() {
+        use crate::language::extract_imports_and_references_for;
+        let src = b"from . import util\n";
+        let tree = parse(src);
+        let (imports, _) = extract_imports_and_references_for(
+            LangId::Python,
+            &tree,
+            src,
+            std::path::Path::new("pkg/mod.py"),
+        );
+        assert_eq!(imports.len(), 1, "imports: {imports:?}");
+        assert_eq!(imports[0].import_specifier, ".");
+        assert_eq!(imports[0].symbol.as_deref(), Some("util"));
+    }
+
+    #[test]
+    fn relative_import_with_module_is_captured() {
+        use crate::language::extract_imports_and_references_for;
+        let src = b"from .util import helper\n";
+        let tree = parse(src);
+        let (imports, _) = extract_imports_and_references_for(
+            LangId::Python,
+            &tree,
+            src,
+            std::path::Path::new("pkg/mod.py"),
+        );
+        assert_eq!(imports.len(), 1, "imports: {imports:?}");
+        assert_eq!(imports[0].import_specifier, ".util");
+        assert_eq!(imports[0].symbol.as_deref(), Some("helper"));
+    }
+
+    #[test]
+    fn relative_parent_import_is_captured() {
+        use crate::language::extract_imports_and_references_for;
+        let src = b"from ..pkg.mod import baz\n";
+        let tree = parse(src);
+        let (imports, _) = extract_imports_and_references_for(
+            LangId::Python,
+            &tree,
+            src,
+            std::path::Path::new("pkg/mod.py"),
+        );
+        assert_eq!(imports.len(), 1, "imports: {imports:?}");
+        assert_eq!(imports[0].import_specifier, "..pkg.mod");
+    }
+
+    #[test]
+    fn aliased_from_import_is_recorded_once() {
+        use crate::language::extract_imports_and_references_for;
+        let src = b"from a.b import c as d\n";
+        let tree = parse(src);
+        let (imports, _) = extract_imports_and_references_for(
+            LangId::Python,
+            &tree,
+            src,
+            std::path::Path::new("pkg/mod.py"),
+        );
+        assert_eq!(imports.len(), 1, "imports: {imports:?}");
+        assert_eq!(imports[0].symbol.as_deref(), Some("c"));
+        assert_eq!(imports[0].alias.as_deref(), Some("d"));
+    }
+
     #[cfg(feature = "dataflow")]
     #[test]
     fn python_dataflow_for_loop_assignment() {

--- a/src/language/typescript.rs
+++ b/src/language/typescript.rs
@@ -265,6 +265,51 @@ mod tests {
         assert!(func.docstring.as_ref().unwrap().contains("TSDoc comment"));
     }
 
+    fn symbol_names(symbols: &[crate::language::RawSymbol<'_>]) -> Vec<String> {
+        symbols.iter().map(|s| s.name.to_string()).collect()
+    }
+
+    #[test]
+    fn extract_annotated_arrow_function() {
+        let src = b"const f: T = () => {};";
+        let tree = parse(src);
+        let symbols = extract_symbols_for(LangId::TypeScript, &tree, src);
+        let found = symbols.iter().find(|s| s.name == "f");
+        assert!(found.is_some(), "missing f: {:?}", symbol_names(&symbols));
+        let found = found.unwrap();
+        assert!(matches!(found.kind, SymbolKind::Function));
+        assert_eq!(found.signature.as_deref(), Some("()"));
+    }
+
+    #[test]
+    fn extract_exported_annotated_arrow_function() {
+        let src = b"export const handler: Handler = async () => {};";
+        let tree = parse(src);
+        let symbols = extract_symbols_for(LangId::TypeScript, &tree, src);
+        let found = symbols.iter().find(|s| s.name == "handler");
+        assert!(
+            found.is_some(),
+            "missing handler: {:?}",
+            symbol_names(&symbols)
+        );
+        let found = found.unwrap();
+        assert!(matches!(found.kind, SymbolKind::Function));
+        assert!(found.is_async);
+    }
+
+    #[test]
+    fn extract_typed_function_expression() {
+        let src = b"const g = function n(): void {};";
+        let tree = parse(src);
+        let symbols = extract_symbols_for(LangId::TypeScript, &tree, src);
+        assert!(
+            symbols.iter().any(|s| s.name == "g"),
+            "missing g: {:?}",
+            symbol_names(&symbols)
+        );
+        assert!(!symbols.iter().any(|s| s.name == "n"));
+    }
+
     #[test]
     fn ts_insta_snapshot() {
         let src = std::fs::read_to_string(

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -10,6 +10,7 @@ mod integration {
     #[cfg(feature = "metacall-deploy")]
     mod deploy_test;
     mod edge_cases_test;
+    mod import_test;
     mod inspect_output_test;
     mod output_format_test;
     mod pipeline_test;

--- a/tests/integration/import_test.rs
+++ b/tests/integration/import_test.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use meta_ast::error::Severity;
 use meta_ast::extractor::extract;
 use meta_ast::graph::{CodeGraph, GraphBuilder, NodeData, edge::EdgeKind};
-use meta_ast::input::discover_files;
+use meta_ast::input::{discover_files, portable_path};
 use meta_ast::model::SnapshotId;
 
 fn project(name: &str) -> PathBuf {
@@ -35,7 +35,7 @@ fn import_edge_exists(graph: &CodeGraph, from: &str, to: &str) -> bool {
     let file_id = |suffix: &str| {
         graph
             .files()
-            .find(|(_, file)| file.path.to_string_lossy().ends_with(suffix))
+            .find(|(_, file)| portable_path(&file.path).ends_with(suffix))
             .map(|(id, _)| id)
     };
     let (Some(from_id), Some(to_id)) = (file_id(from), file_id(to)) else {

--- a/tests/integration/import_test.rs
+++ b/tests/integration/import_test.rs
@@ -1,0 +1,166 @@
+//! Import resolution at the graph level: discovery, extraction, edges.
+
+use std::path::{Path, PathBuf};
+
+use meta_ast::error::Severity;
+use meta_ast::extractor::extract;
+use meta_ast::graph::{CodeGraph, GraphBuilder, NodeData, edge::EdgeKind};
+use meta_ast::input::discover_files;
+use meta_ast::model::SnapshotId;
+
+fn project(name: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("meta_ast_import_{name}"));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn write(root: &Path, relative: &str, body: &str) {
+    let path = root.join(relative);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(&path, body).unwrap();
+}
+
+fn analyze(root: &Path) -> (CodeGraph, Vec<meta_ast::Diagnostic>) {
+    let files = discover_files(root, None).unwrap();
+    let extractions = extract(&files).files;
+    let mut diagnostics = Vec::new();
+    let snapshot_id = SnapshotId::new(1).unwrap();
+    let (graph, _scc) =
+        GraphBuilder::from_extractions(&extractions, root, snapshot_id, &mut diagnostics);
+    (graph, diagnostics)
+}
+
+fn import_edge_exists(graph: &CodeGraph, from: &str, to: &str) -> bool {
+    let file_id = |suffix: &str| {
+        graph
+            .files()
+            .find(|(_, file)| file.path.to_string_lossy().ends_with(suffix))
+            .map(|(id, _)| id)
+    };
+    let (Some(from_id), Some(to_id)) = (file_id(from), file_id(to)) else {
+        return false;
+    };
+    let (Some(from_idx), Some(to_idx)) =
+        (graph.file_node_index(from_id), graph.file_node_index(to_id))
+    else {
+        return false;
+    };
+    graph
+        .edges_of_kind(EdgeKind::Import)
+        .any(|(source, target)| source == from_idx && target == to_idx)
+}
+
+fn external_paths(graph: &CodeGraph) -> Vec<String> {
+    graph
+        .graph()
+        .node_indices()
+        .filter_map(|index| match &graph.graph()[index] {
+            NodeData::External(node) => Some(node.raw_path.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+#[test]
+fn python_relative_import_creates_an_edge_to_the_submodule() {
+    let root = project("py_relative_edge");
+    write(&root, "pkg/__init__.py", "");
+    write(&root, "pkg/util.py", "def helper(): pass\n");
+    write(&root, "pkg/mod.py", "from . import util\n");
+
+    let (graph, _diagnostics) = analyze(&root);
+
+    assert!(
+        import_edge_exists(&graph, "pkg/mod.py", "pkg/util.py"),
+        "externals: {:?}",
+        external_paths(&graph)
+    );
+    assert!(external_paths(&graph).is_empty());
+}
+
+#[test]
+fn python_double_dot_import_resolves_to_the_parent_package() {
+    let root = project("py_double_dot");
+    write(&root, "pkg/__init__.py", "");
+    write(&root, "pkg/mod.py", "from ..util import helper\n");
+    write(&root, "util.py", "def helper(): pass\n");
+
+    let (graph, _diagnostics) = analyze(&root);
+
+    assert!(
+        import_edge_exists(&graph, "pkg/mod.py", "util.py"),
+        "externals: {:?}",
+        external_paths(&graph)
+    );
+}
+
+#[test]
+fn python_third_party_import_becomes_a_bare_external_node() {
+    let root = project("py_third_party");
+    write(&root, "app.py", "import requests\n");
+
+    let (graph, _diagnostics) = analyze(&root);
+
+    assert!(
+        external_paths(&graph).contains(&"requests".to_string()),
+        "externals: {:?}",
+        external_paths(&graph)
+    );
+}
+
+#[test]
+fn c_system_include_becomes_a_bare_external_node() {
+    let root = project("c_system_include");
+    write(
+        &root,
+        "src/a.c",
+        "#include <stdio.h>\nint main(void) { return 0; }\n",
+    );
+
+    let (graph, _diagnostics) = analyze(&root);
+
+    assert!(
+        external_paths(&graph).contains(&"stdio.h".to_string()),
+        "externals: {:?}",
+        external_paths(&graph)
+    );
+}
+
+#[test]
+fn unresolved_relative_import_emits_a_warning() {
+    let root = project("py_unresolved_relative");
+    write(&root, "app.py", "from .missing import thing\n");
+
+    let (graph, diagnostics) = analyze(&root);
+
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.severity == Severity::Warning && d.path.ends_with("app.py")),
+        "diagnostics: {diagnostics:?}"
+    );
+    assert!(
+        !external_paths(&graph)
+            .iter()
+            .any(|path| path.contains("missing")),
+        "externals: {:?}",
+        external_paths(&graph)
+    );
+}
+
+#[test]
+fn python_absolute_first_party_import_still_resolves() {
+    let root = project("py_absolute_first_party");
+    write(&root, "pkg/__init__.py", "");
+    write(&root, "pkg/util.py", "def helper(): pass\n");
+    write(&root, "pkg/mod.py", "from pkg.util import helper\n");
+
+    let (graph, _diagnostics) = analyze(&root);
+
+    assert!(
+        import_edge_exists(&graph, "pkg/mod.py", "pkg/util.py"),
+        "externals: {:?}",
+        external_paths(&graph)
+    );
+}


### PR DESCRIPTION
## Summary

The regression tests that specify the defects fixed by #77, #78 and #79.

32 tests fail here: 26 unit and 6 integration. They cover unresolved and relative imports, fabricated include and package paths, parse error reporting, arrow functions and function expressions, module-level constants, C and C++ declarations, and the header catalog.

## Type of change

- [x] `test` - tests only

## Affected area

- [x] `language` (extraction)
- [x] `docs` / `tests`

## Public contract impact

- [x] No public contract change

## Verification

The suite is red here by design. The gates pass at the top of the stack (#79):

- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] `cargo nextest run --all-features` passes (fails here by design)
- [x] `cargo +1.94.0 fmt --check` passes

## Notes for reviewers

Read this branch first: each fix above turns its own subset green. 32 to 14 red after #77, 14 to 7 after #78, 7 to 0 after #79. Merge the stack, not this branch alone.
