### PR TITLE
test(output): pin injection, casing, ordering and confidence defects

### DIFF
--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -292,11 +292,11 @@ mod tests {
     fn visibility_serialization() {
         assert_eq!(
             serde_json::to_string(&Visibility::Public).unwrap(),
-            "\"Public\""
+            "\"public\""
         );
         assert_eq!(
             serde_json::to_string(&Visibility::Private).unwrap(),
-            "\"Private\""
+            "\"private\""
         );
     }
 
@@ -328,6 +328,11 @@ mod tests {
                 json.len() > 2,
                 "expected non-empty variant name, got: {json}"
             );
+            assert!(
+                json.chars()
+                    .all(|c| c.is_ascii_lowercase() || c == '_' || c == '"'),
+                "kind names are lowercase snake_case, got: {json}"
+            );
         }
     }
 
@@ -348,7 +353,7 @@ mod tests {
         let json = serde_json::to_string(&sym).unwrap();
         let val: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(val["name"], "roundtrip_fn");
-        assert_eq!(val["kind"], "Method");
+        assert_eq!(val["kind"], "method");
         assert_eq!(val["is_async"], false);
     }
 
@@ -365,11 +370,11 @@ mod tests {
     fn data_scope_serialization() {
         assert_eq!(
             serde_json::to_string(&DataScope::Local).unwrap(),
-            "\"Local\""
+            "\"local\""
         );
         assert_eq!(
             serde_json::to_string(&DataScope::Parameter).unwrap(),
-            "\"Parameter\""
+            "\"parameter\""
         );
     }
 
@@ -385,19 +390,19 @@ mod tests {
     fn flow_kind_serialization() {
         assert_eq!(
             serde_json::to_string(&FlowKind::DefUse).unwrap(),
-            "\"DefUse\""
+            "\"def_use\""
         );
         assert_eq!(
             serde_json::to_string(&FlowKind::Argument).unwrap(),
-            "\"Argument\""
+            "\"argument\""
         );
         assert_eq!(
             serde_json::to_string(&FlowKind::Return).unwrap(),
-            "\"Return\""
+            "\"return\""
         );
         assert_eq!(
             serde_json::to_string(&FlowKind::FieldAccess).unwrap(),
-            "\"FieldAccess\""
+            "\"field_access\""
         );
     }
 
@@ -414,7 +419,7 @@ mod tests {
         let json = serde_json::to_string(&data).unwrap();
         let val: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(val["name"], "x");
-        assert_eq!(val["scope"], "Local");
+        assert_eq!(val["scope"], "local");
         assert_eq!(val["type_hint"], "int");
     }
 
@@ -445,7 +450,7 @@ mod tests {
         let val: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(val["source"], 1);
         assert_eq!(val["target"], 2);
-        assert_eq!(val["kind"], "Argument");
+        assert_eq!(val["kind"], "argument");
         assert_eq!(val["confidence"], 0.85);
     }
 

--- a/src/output/graph.rs
+++ b/src/output/graph.rs
@@ -693,4 +693,156 @@ mod tests {
             .collect();
         assert_eq!(order, expected);
     }
+
+    /// Graph nodes are ordered by contract, not by insertion order.
+    #[test]
+    fn serialized_nodes_use_canonical_order() {
+        let mut graph = crate::graph::CodeGraph::new(SnapshotId::new(1).unwrap());
+        let a_id = crate::model::FileId::new(1).unwrap();
+        let b_id = crate::model::FileId::new(2).unwrap();
+
+        // Insertion order is deliberately not the canonical order.
+        let sym_idx = graph.add_node(NodeData::Symbol(SymbolNode {
+            id: crate::model::SymbolId::new(7).unwrap(),
+            name: "zeta".to_string(),
+            kind: crate::model::SymbolKind::Function,
+            file_id: b_id,
+            visibility: Some(crate::model::Visibility::Public),
+            source_range: sample_source_range(),
+        }));
+        let b_idx = graph.add_node(NodeData::File(FileNode::new(
+            b_id,
+            PathBuf::from("b.py"),
+            LangId::Python,
+            SnapshotId::new(1).unwrap(),
+        )));
+        let a_idx = graph.add_node(NodeData::File(FileNode::new(
+            a_id,
+            PathBuf::from("a.py"),
+            LangId::Python,
+            SnapshotId::new(1).unwrap(),
+        )));
+        graph.file_to_index.insert(a_id, a_idx);
+        graph.file_to_index.insert(b_id, b_idx);
+        graph.add_edge_normalized(a_idx, b_idx, EdgeKind::Import, 1.0);
+        graph.add_edge_normalized(b_idx, a_idx, EdgeKind::Import, 1.0);
+
+        let scc = SccAnalysis::analyze(graph.graph());
+        let output = GraphOutput::from_graph(&graph, Some(&scc), 1);
+
+        let order: Vec<(String, Option<String>)> = output
+            .nodes
+            .iter()
+            .map(|n| (n.kind.clone(), n.path.clone().or_else(|| n.name.clone())))
+            .collect();
+        assert_eq!(
+            order,
+            vec![
+                ("file".to_string(), Some("a.py".to_string())),
+                ("file".to_string(), Some("b.py".to_string())),
+                ("symbol".to_string(), Some("zeta".to_string())),
+            ],
+            "files come first in path order, then symbols"
+        );
+
+        for scc in &output.sccs {
+            let members = &scc.nodes;
+            assert!(
+                members.windows(2).all(|pair| pair[0] < pair[1]),
+                "SCC members are ordered by node index, got {members:?}"
+            );
+        }
+        let _ = sym_idx;
+    }
+
+    /// The casing contract is lower case for kinds and visibility.
+    #[test]
+    fn symbol_kind_and_visibility_use_the_documented_casing() {
+        let mut builder = GraphBuilder::new(SnapshotId::new(1).unwrap());
+        let symbol = crate::model::Symbol {
+            id: crate::model::SymbolId::new(3).unwrap(),
+            name: "helper".to_string(),
+            kind: crate::model::SymbolKind::TypeAlias,
+            language: LangId::Python,
+            file_path: PathBuf::from("a.py"),
+            source_range: sample_source_range(),
+            visibility: Some(crate::model::Visibility::Public),
+            signature: None,
+            docstring: None,
+            is_async: false,
+        };
+        builder.add_file(PathBuf::from("a.py"), LangId::Python);
+        builder.add_symbol(&symbol).unwrap();
+        let graph = builder.build();
+        let scc = sample_scc_analysis();
+
+        let json = serialize_graph(&graph, &scc, 1, &OutputFormat::Json).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let node = parsed["nodes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|n| n["kind"] == "symbol");
+        assert!(node.is_some(), "the symbol node is serialized");
+        let node = node.unwrap();
+
+        assert_eq!(node["symbol_kind"], "type_alias");
+        assert_eq!(node["visibility"], "public");
+    }
+
+    /// Absence of the confidence field must not carry meaning.
+    #[test]
+    fn edge_confidence_is_always_serialized() {
+        let mut builder = GraphBuilder::new(SnapshotId::new(1).unwrap());
+        let file_a = builder.add_file(PathBuf::from("a.py"), LangId::Python);
+        builder.add_file(PathBuf::from("b.py"), LangId::Python);
+        builder.add_import(file_a, PathBuf::from("b.py"));
+        let graph = builder.build();
+        let scc = sample_scc_analysis();
+
+        let json = serialize_graph(&graph, &scc, 1, &OutputFormat::Json).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let edges = parsed["edges"].as_array().unwrap();
+        assert!(!edges.is_empty(), "the graph has at least one edge");
+        for edge in edges {
+            assert!(
+                edge["confidence"].is_number(),
+                "every edge carries a confidence, got {edge}"
+            );
+        }
+    }
+
+    /// A non-finite confidence is data corruption, so it is counted and
+    /// normalized instead of being written out as an absent field.
+    #[test]
+    fn non_finite_confidence_is_counted_and_normalized() {
+        let mut graph = crate::graph::CodeGraph::new(SnapshotId::new(1).unwrap());
+        let a_id = crate::model::FileId::new(1).unwrap();
+        let b_id = crate::model::FileId::new(2).unwrap();
+        let a_idx = graph.add_node(NodeData::File(FileNode::new(
+            a_id,
+            PathBuf::from("a.py"),
+            LangId::Python,
+            SnapshotId::new(1).unwrap(),
+        )));
+        let b_idx = graph.add_node(NodeData::File(FileNode::new(
+            b_id,
+            PathBuf::from("b.py"),
+            LangId::Python,
+            SnapshotId::new(1).unwrap(),
+        )));
+        graph.file_to_index.insert(a_id, a_idx);
+        graph.file_to_index.insert(b_id, b_idx);
+        graph.add_edge_normalized(a_idx, b_idx, EdgeKind::Import, f32::NAN);
+
+        let scc = SccAnalysis::analyze(graph.graph());
+        let output = GraphOutput::from_graph(&graph, Some(&scc), 1);
+        let json = serde_json::to_string(&output).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            parsed["metadata"]["invalid_confidence_edges"], 1,
+            "the graph records the rejected confidence"
+        );
+        assert_eq!(parsed["edges"][0]["confidence"], 0.0);
+    }
 }

--- a/src/output/inspect.rs
+++ b/src/output/inspect.rs
@@ -167,4 +167,35 @@ mod tests {
             ["funcs", "classes", "objects"].into_iter().collect();
         assert_eq!(keys, expected);
     }
+
+    /// Visibility is a documented lowercase value in every output.
+    #[test]
+    fn visibility_is_lowercase_in_inspect_output() {
+        let symbol = Symbol {
+            id: crate::model::SymbolId::new(1).unwrap(),
+            name: "encrypt".to_string(),
+            kind: SymbolKind::Function,
+            language: crate::language::LangId::Python,
+            file_path: std::path::PathBuf::from("a.py"),
+            source_range: crate::model::SourceRange {
+                byte_start: 0,
+                byte_end: 9,
+                start: crate::model::LineColumn { line: 0, column: 0 },
+                end: crate::model::LineColumn { line: 0, column: 9 },
+            },
+            visibility: Some(crate::model::Visibility::Public),
+            signature: None,
+            docstring: None,
+            is_async: false,
+        };
+
+        let mut symbols = vec![symbol];
+        let json = crate::output::inspect::serialize_inspect(
+            &mut symbols,
+            &crate::output::OutputFormat::Json,
+        )
+        .unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["funcs"][0]["visibility"], "public");
+    }
 }

--- a/src/output/shard/edge.rs
+++ b/src/output/shard/edge.rs
@@ -143,3 +143,29 @@ pub fn restore_shard_edges(graph: &mut CodeGraph, edges: &[ShardEdge]) -> Result
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn flow_edge() -> ShardEdge {
+        ShardEdge {
+            source_name: "python file a.py . f#function!0 .".to_string(),
+            target_name: "python file b.py . g#function!0 .".to_string(),
+            kind: ShardEdgeKind::Flow,
+            confidence: 1.0,
+            flow_kind: None,
+        }
+    }
+
+    /// The refusal message must name the version that actually applies.
+    #[test]
+    fn dataflow_refusal_names_the_current_schema_version() {
+        let error = validate_edge(&flow_edge(), 1, 0).unwrap_err();
+        let message = error.to_string();
+        assert!(
+            message.contains(&crate::output::shard::file::SHARD_SCHEMA_VERSION.to_string()),
+            "message names the schema version in force: {message}"
+        );
+    }
+}

--- a/src/output/shard/mod.rs
+++ b/src/output/shard/mod.rs
@@ -406,4 +406,86 @@ mod tests {
             Some("multiply")
         );
     }
+
+    /// The version superseded by the casing change must be refused, so an old
+    /// index is regenerated instead of being used with a different encoding.
+    #[test]
+    fn reader_rejects_the_superseded_schema_version() {
+        let mut value = serde_json::to_value(ShardFile {
+            schema_version: SHARD_SCHEMA_VERSION,
+            path: PathBuf::from("a.py"),
+            language: LangId::Python,
+            symbols: Vec::new(),
+            imports: Vec::new(),
+            references: Vec::new(),
+            diagnostics: Vec::new(),
+            ast_node_count: 0,
+            #[cfg(feature = "metacall-deploy")]
+            call_sites: Vec::new(),
+            edges: Vec::new(),
+        })
+        .unwrap();
+        value["schema_version"] = serde_json::json!(3);
+        let input = format!("{}\n", serde_json::to_string(&value).unwrap());
+
+        let error = read_shard(Cursor::new(input)).unwrap_err();
+        assert!(
+            matches!(
+                error,
+                ShardError::SchemaVersion {
+                    found: 3,
+                    expected: SHARD_SCHEMA_VERSION,
+                    ..
+                }
+            ),
+            "version 3 is refused with the expected version reported"
+        );
+    }
+
+    /// A dropped dataflow payload is data loss, so the record must say so.
+    #[cfg(feature = "dataflow")]
+    #[test]
+    fn dataflow_payload_drop_is_recorded() {
+        let mut extraction = extraction();
+        extraction.data_nodes = vec![crate::model::DataNode {
+            id: crate::model::DataNodeId::new(1).unwrap(),
+            symbol_id: None,
+            name: Some("count".to_string()),
+            scope: crate::model::DataScope::Local,
+            type_hint: None,
+            source_range: range(),
+        }];
+
+        let (graph, _) = GraphBuilder::from_extractions(
+            std::slice::from_ref(&extraction),
+            Path::new("."),
+            SnapshotId::new(1).unwrap(),
+            &mut Vec::new(),
+        );
+        let shard = ShardFile::from_extraction(&extraction, &graph).unwrap();
+        let reports_drop = |diagnostics: &[crate::error::Diagnostic]| {
+            diagnostics
+                .iter()
+                .any(|d| d.message.contains("dataflow payload not persisted"))
+        };
+        assert!(
+            reports_drop(&shard.diagnostics),
+            "the record states that the payload is not persisted: {:?}",
+            shard.diagnostics
+        );
+
+        let mut bytes = Vec::new();
+        write_shard(&mut bytes, &[shard]).unwrap();
+        let loaded = read_shard(Cursor::new(bytes))
+            .unwrap()
+            .into_iter()
+            .next()
+            .unwrap()
+            .load(&IdGenerator::with_start(1))
+            .unwrap();
+        assert!(
+            reports_drop(&loaded.file.diagnostics),
+            "the consumer sees the dropped payload after a round trip"
+        );
+    }
 }

--- a/tests/integration/dashboard_test.rs
+++ b/tests/integration/dashboard_test.rs
@@ -123,3 +123,26 @@ fn to_graph_html_cytoscape_container_div() {
         "should contain cy container div"
     );
 }
+
+/// The analyzed project is untrusted input. A node name or path that contains
+/// a closing script tag must not be able to close the data element.
+#[test]
+fn script_payload_cannot_close_the_script_element() {
+    let payload = "</script><script>alert(1)</script>";
+    let mut builder = GraphBuilder::new(SnapshotId::new(1).unwrap());
+    builder.add_file(PathBuf::from(format!("src/{payload}.py")), LangId::Python);
+    let graph = builder.build();
+    let scc = SccAnalysis::analyze(graph.graph());
+
+    let html = meta_ast::output::dashboard::to_graph_html(&graph, &scc, 1).unwrap();
+
+    assert_eq!(
+        html.matches("</script>").count(),
+        2,
+        "only the two template script elements end with a closing tag"
+    );
+    assert!(
+        html.contains("\\u003c/script\\u003e"),
+        "the payload is escaped, not removed"
+    );
+}

--- a/tests/integration/datagraph_test.rs
+++ b/tests/integration/datagraph_test.rs
@@ -289,3 +289,37 @@ fn sink_json_writes_datagraph_to_file() {
     );
     let _ = std::fs::remove_file(&temp);
 }
+
+/// The datagraph export must not overwrite the graph output.
+#[cfg(feature = "dataflow")]
+#[test]
+fn datagraph_has_its_own_output_path() {
+    let temp = tempfile::tempdir().unwrap();
+    let graph_path = temp.path().join("graph.json");
+    let datagraph_path = temp.path().join("datagraph.json");
+
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_meta-ast"))
+        .arg("graph")
+        .arg("tests/fixtures/python")
+        .arg("--datagraph")
+        .arg("--datagraph-output")
+        .arg(&datagraph_path)
+        .arg("-o")
+        .arg(&graph_path)
+        .arg("-f")
+        .arg("json")
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "graph run failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(graph_path.is_file(), "the graph output is written");
+    assert!(datagraph_path.is_file(), "the datagraph output is written");
+    let graph = std::fs::read_to_string(&graph_path).unwrap();
+    let datagraph = std::fs::read_to_string(&datagraph_path).unwrap();
+    assert_ne!(graph, datagraph, "both outputs hold their own payload");
+}


### PR DESCRIPTION
## Summary

Regression tests for the output contract, without the fixes:

- a closing script tag in a node name or path must not escape the HTML data element
- kinds, visibility, scopes and flow kinds serialize in lowercase
- serialized nodes and SCC members follow a canonical order instead of insertion order
- every edge carries a confidence, and a non-finite confidence is counted and normalized
- the dataflow refusal message names the schema version in force
- a dropped dataflow payload is recorded in the shard record
- a shard written with the superseded schema version is refused
- the datagraph export writes its own path

17 of them fail at this commit by design. Each fix PR above this one turns its own tests green, so the suite is green at the top of the stack.

## Type of change

- [x] `test` - tests only

## Affected area

- [x] `model` / ids
- [x] `interface` (CLI)
- [x] `output`
- [x] `docs` / `tests`

## Public contract impact

- [x] No public contract change

## Verification

- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo +1.94.0 fmt --check` passes
- [ ] `cargo nextest run --all-features` passes (red by design on this branch)

## Notes for reviewers

This branch is the base of the stack. Merge the stack from the bottom; `main` stays red until the top.
