### PR TITLE
fix(output): escape the dashboard payload and stop hiding output defects

### DIFF
--- a/src/output/dashboard.rs
+++ b/src/output/dashboard.rs
@@ -12,12 +12,34 @@ pub fn to_graph_html(
     snapshot_id: u64,
 ) -> anyhow::Result<String> {
     let graph_output = GraphOutput::from_graph(graph, Some(scc_analysis), snapshot_id);
-    let json_data = serde_json::to_string(&graph_output)?;
+    let json_data = escape_script_payload(&serde_json::to_string(&graph_output)?);
 
     let html = HTML_TEMPLATE
         .replacen("__CDN_SCRIPT__", &cdn_script(), 1)
         .replacen("__DATA__", &json_data, 1);
     Ok(html)
+}
+
+/// Escape a JSON payload for a `<script>` element.
+///
+/// JSON escaping protects a JSON parser, not the HTML parser inside the
+/// element: the element ends at the first `</script`, so `<`, `>`, `&` and
+/// the JavaScript line separators become `\uXXXX` escapes. Every escape
+/// decodes to the same character, so a JSON consumer reads the original
+/// payload. The analyzed project is untrusted input.
+fn escape_script_payload(json: &str) -> String {
+    let mut escaped = String::with_capacity(json.len());
+    for ch in json.chars() {
+        match ch {
+            '<' => escaped.push_str("\\u003c"),
+            '>' => escaped.push_str("\\u003e"),
+            '&' => escaped.push_str("\\u0026"),
+            '\u{2028}' => escaped.push_str("\\u2028"),
+            '\u{2029}' => escaped.push_str("\\u2029"),
+            other => escaped.push(other),
+        }
+    }
+    escaped
 }
 
 fn cdn_script() -> String {

--- a/src/output/emitter.rs
+++ b/src/output/emitter.rs
@@ -47,12 +47,25 @@ pub fn emit_graph(analysis: &GraphAnalysis, config: &EmitConfig) -> anyhow::Resu
             .output
             .clone()
             .unwrap_or_else(|| PathBuf::from("project.metast"));
-        let path_str = path.to_string_lossy().to_string();
         std::fs::write(&path, html)?;
         if config.open_browser {
-            let open_res = webbrowser::open(&path_str);
-            if let Err(e) = open_res {
-                tracing::warn!(error = %e, "could not open browser");
+            // A file URL keeps a non-UTF-8 path intact. `to_string_lossy` would
+            // replace the unencodable bytes, and the OS handler expects a URL.
+            let absolute = if path.is_absolute() {
+                path.clone()
+            } else {
+                std::env::current_dir()?.join(&path)
+            };
+            match url::Url::from_file_path(&absolute) {
+                Ok(url) => {
+                    if let Err(e) = webbrowser::open(url.as_str()) {
+                        tracing::warn!(error = %e, "could not open browser");
+                    }
+                }
+                Err(()) => tracing::warn!(
+                    path = %absolute.display(),
+                    "cannot open the dashboard in a browser"
+                ),
             }
         }
     } else {

--- a/src/output/graph.rs
+++ b/src/output/graph.rs
@@ -52,6 +52,8 @@ pub struct GraphMetadata {
     pub symbol_count: usize,
     /// Number of data-bearing nodes
     pub data_node_count: usize,
+    /// Edges whose confidence was not finite and was normalized to `0.0`
+    pub invalid_confidence_edges: usize,
 }
 
 /// Serialized node representation.
@@ -99,9 +101,12 @@ pub struct SerializedEdge {
     pub target: usize,
     /// Edge kind: "ownership", "import", "reference", or "flow"
     pub kind: String,
-    /// Confidence score (0.0-1.0), omitted when 1.0
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub confidence: Option<f32>,
+    /// Confidence score in the range 0.0-1.0.
+    ///
+    /// Always serialized: absence must not have to mean `1.0`. A non-finite
+    /// value is corruption and is written as `0.0` (see
+    /// `GraphMetadata::invalid_confidence_edges`).
+    pub confidence: f32,
     /// Flow kind for dataflow edges (def_use, argument, return, field_access)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub flow_kind: Option<String>,
@@ -181,6 +186,7 @@ impl GraphOutput {
         let mut file_count = 0;
         let mut symbol_count = 0;
         let mut data_node_count = 0;
+        let mut invalid_confidence_edges = 0;
 
         for node_data in g.node_weights() {
             match node_data {
@@ -188,6 +194,11 @@ impl GraphOutput {
                 NodeData::Symbol(_) => symbol_count += 1,
                 NodeData::External(_) => {}
                 NodeData::Data(_) => data_node_count += 1,
+            }
+        }
+        for edge_data in g.edge_weights() {
+            if !edge_data.confidence.is_finite() {
+                invalid_confidence_edges += 1;
             }
         }
 
@@ -199,6 +210,7 @@ impl GraphOutput {
             file_count,
             symbol_count,
             data_node_count,
+            invalid_confidence_edges,
         }
     }
 
@@ -291,10 +303,12 @@ impl GraphOutput {
             .filter_map(|edge_idx| {
                 let (source, target) = g.edge_endpoints(edge_idx)?;
                 let edge_data = g.edge_weight(edge_idx)?;
-                let confidence = if edge_data.confidence < 1.0 {
-                    Some(edge_data.confidence)
+                // A non-finite confidence is corruption. It is reported in the
+                // metadata and written as 0.0, never omitted.
+                let confidence = if edge_data.confidence.is_finite() {
+                    edge_data.confidence.clamp(0.0, 1.0)
                 } else {
-                    None
+                    0.0
                 };
 
                 let flow_kind = if edge_data.kind == EdgeKind::Flow {
@@ -556,7 +570,7 @@ mod tests {
         let output = GraphOutput::from_graph(&graph, Some(&scc), 1);
         assert_eq!(output.edges.len(), 1);
         assert_eq!(output.edges[0].kind, "flow");
-        assert_eq!(output.edges[0].confidence, Some(0.9));
+        assert_eq!(output.edges[0].confidence, 0.9);
         assert_eq!(output.edges[0].flow_kind.as_deref(), Some("argument"));
     }
 
@@ -585,7 +599,7 @@ mod tests {
 
         let output = GraphOutput::from_graph(&graph, Some(&scc), 1);
         assert_eq!(output.edges[0].flow_kind, None);
-        assert_eq!(output.edges[0].confidence, None); // 1.0 → omitted
+        assert_eq!(output.edges[0].confidence, 1.0);
     }
 
     // ── Light mode (no SCC) tests ───────────────────────────────────

--- a/src/output/shard/edge.rs
+++ b/src/output/shard/edge.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::graph::{CodeGraph, EdgeKind, NodeData};
 use crate::output::shard::error::ShardError;
+use crate::output::shard::file::SHARD_SCHEMA_VERSION;
 use crate::output::shard::name::stable_node_name;
 
 /// Serialized cross-node edge in a shard file.
@@ -97,7 +98,9 @@ pub(crate) fn validate_edge(
         return Err(ShardError::InvalidEdge {
             line,
             edge_index,
-            message: "schema version 2 does not persist dataflow nodes".to_string(),
+            message: format!(
+                "schema version {SHARD_SCHEMA_VERSION} does not persist dataflow nodes"
+            ),
         });
     }
     if edge.flow_kind.is_some() {

--- a/src/output/shard/file.rs
+++ b/src/output/shard/file.rs
@@ -67,6 +67,16 @@ impl ShardFile {
             normalized_path(&diagnostic.path)?;
         }
         let symbols = extraction.symbols.iter().map(ShardSymbol::from).collect();
+        #[cfg(feature = "dataflow")]
+        let dropped_payload = dataflow_drop_diagnostic(extraction);
+        #[cfg(not(feature = "dataflow"))]
+        let dropped_payload: Option<Diagnostic> = None;
+        let diagnostics: Vec<Diagnostic> = extraction
+            .diagnostics
+            .iter()
+            .cloned()
+            .chain(dropped_payload)
+            .collect();
         let mut edges = graph
             .graph()
             .edge_references()
@@ -113,7 +123,7 @@ impl ShardFile {
             symbols,
             imports: extraction.imports.clone(),
             references: extraction.references.clone(),
-            diagnostics: extraction.diagnostics.clone(),
+            diagnostics,
             ast_node_count: extraction.ast_node_count,
             #[cfg(feature = "metacall-deploy")]
             call_sites: extraction.call_sites.clone(),
@@ -152,6 +162,26 @@ impl ShardFile {
             edges: self.edges,
         })
     }
+}
+
+/// Warning for a dataflow payload that the shard schema cannot store.
+///
+/// Schema version 3 keeps symbols, imports, references and edges. A record
+/// with dataflow nodes or flow edges loses them on write, so the record says
+/// so instead of dropping them without a word.
+#[cfg(feature = "dataflow")]
+fn dataflow_drop_diagnostic(extraction: &FileExtraction) -> Option<Diagnostic> {
+    if extraction.data_nodes.is_empty() && extraction.flow_edges.is_empty() {
+        return None;
+    }
+    Some(Diagnostic {
+        path: extraction.path.clone(),
+        severity: crate::error::Severity::Warning,
+        message: format!(
+            "dataflow payload not persisted: shard schema version {SHARD_SCHEMA_VERSION} stores symbols and edges only"
+        ),
+        source_range: None,
+    })
 }
 
 impl From<&Symbol> for ShardSymbol {

--- a/src/output/shard/mod.rs
+++ b/src/output/shard/mod.rs
@@ -1,4 +1,4 @@
-//! `.metast` v2 JSONL shard and index serialization.
+//! JSONL shard and index serialization for the `.meta-ast/` directory.
 //!
 //! Provides the persistence model for `.meta-ast/` index directories:
 //! - `shards/<n>.jsonl`: Per-file AST symbols, unresolved items, and stable-name graph edges.


### PR DESCRIPTION
## Summary

Three ways the output path trusted its input or hid a loss:

- The HTML dashboard interpolated a JSON payload into a `<script>` element. JSON escaping protects a JSON parser, not the HTML parser inside the element, so a path or symbol name containing `</script>` could close it and run script when the dashboard opened. `<`, `>`, `&` and the JavaScript line separators now become JSON escapes that decode back to the same characters.
- The shard writer dropped a dataflow payload without a word. The record now carries a Warning diagnostic, so the consumer sees the loss.
- A non-finite edge confidence survived `clamp` and was then omitted from the graph JSON, which made corruption look like a clean edge with the default confidence. Such edges are counted in the metadata and written as `0.0`; confidence is always present, so absence no longer means `1.0`.

Also: the dataflow refusal message named schema version 2 while the constant was 3, and the module doc named a version that never changed; and the dashboard browser open went through a lossy path string instead of a file URL.

## Type of change

- [x] `fix` - bug fix
- [x] `perf` - performance improvement

## Affected area

- [x] `graph` / SCC
- [x] `output`
- [x] `docs` / `tests`

## Public contract impact

- [x] Public contract changed; `docs/` updated (graph output always carries `confidence` and reports `invalid_confidence_edges`)

## Verification

- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo +1.94.0 fmt --check` passes
- [x] `cargo nextest run --all-features` passes for this level (12 of the 17 base failures remain, owned by the PRs above)

## Notes for reviewers

The escaping test covers a symbol name and a file path, because both reach the payload.
