### PR TITLE
fix(output): order graph nodes canonically and write files atomically

### DIFF
--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -241,10 +241,13 @@ pub fn run_deploy(config: DeployConfig) -> anyhow::Result<()> {
         std::fs::create_dir_all(&config.out)?;
 
         let manifest_json = serde_json::to_string_pretty(&pod_manifest)?;
-        std::fs::write(config.out.join("metacall.pods.json"), manifest_json)?;
+        crate::output::write_atomic(
+            &config.out.join("metacall.pods.json"),
+            manifest_json.as_bytes(),
+        )?;
 
         let mesh_json = serde_json::to_string_pretty(&mesh)?;
-        std::fs::write(config.out.join("metacall.mesh.json"), mesh_json)?;
+        crate::output::write_atomic(&config.out.join("metacall.mesh.json"), mesh_json.as_bytes())?;
 
         tracing::info!(
             "Generated pod manifest with {} deployments and {} inter-pod edges.",

--- a/src/output/emitter.rs
+++ b/src/output/emitter.rs
@@ -19,7 +19,7 @@ pub fn emit_inspect(symbols: &mut Vec<Symbol>, config: &EmitConfig) -> anyhow::R
     let content = crate::output::inspect::serialize_inspect(symbols, &config.format)?;
     match &config.output {
         Some(path) => {
-            std::fs::write(path, content)?;
+            crate::output::write_atomic(path, content.as_bytes())?;
         }
         None => {
             println!("{content}");
@@ -47,7 +47,7 @@ pub fn emit_graph(analysis: &GraphAnalysis, config: &EmitConfig) -> anyhow::Resu
             .output
             .clone()
             .unwrap_or_else(|| PathBuf::from("project.metast"));
-        std::fs::write(&path, html)?;
+        crate::output::write_atomic(&path, html.as_bytes())?;
         if config.open_browser {
             // A file URL keeps a non-UTF-8 path intact. `to_string_lossy` would
             // replace the unencodable bytes, and the OS handler expects a URL.
@@ -77,7 +77,7 @@ pub fn emit_graph(analysis: &GraphAnalysis, config: &EmitConfig) -> anyhow::Resu
         )?;
         match &config.output {
             Some(path) => {
-                std::fs::write(path, content)?;
+                crate::output::write_atomic(path, content.as_bytes())?;
             }
             None => {
                 println!("{content}");

--- a/src/output/graph.rs
+++ b/src/output/graph.rs
@@ -216,12 +216,15 @@ impl GraphOutput {
 
     fn serialize_nodes(graph: &CodeGraph) -> Vec<SerializedNode> {
         let g = graph.graph();
-        g.node_indices()
+        let mut nodes: Vec<SerializedNode> = g
+            .node_indices()
             .map(|idx| {
                 let node_data = &g[idx];
                 Self::serialize_node(graph, idx.index(), node_data)
             })
-            .collect()
+            .collect();
+        nodes.sort_by(|left, right| node_sort_key(left).cmp(&node_sort_key(right)));
+        nodes
     }
 
     fn serialize_node(graph: &CodeGraph, id: usize, node_data: &NodeData) -> SerializedNode {
@@ -335,7 +338,8 @@ impl GraphOutput {
             .components
             .iter()
             .map(|scc| {
-                let nodes: Vec<usize> = scc.nodes.iter().map(|n| n.index()).collect();
+                let mut nodes: Vec<usize> = scc.nodes.iter().map(|n| n.index()).collect();
+                nodes.sort_unstable();
 
                 SerializedScc {
                     index: scc.index,
@@ -385,6 +389,29 @@ pub fn serialize_graph(
 ) -> anyhow::Result<String> {
     let output = GraphOutput::from_graph(graph, Some(scc_analysis), snapshot_id);
     format.serialize(&output)
+}
+
+/// Order key for serialized nodes: kind group, then location, then node id.
+///
+/// Insertion order depends on how the graph was built; the output order must
+/// not. Files group first (paths), then symbols (defining file, name), then
+/// externals and data nodes (names).
+fn node_sort_key(node: &SerializedNode) -> (u8, &str, &str, usize) {
+    let rank = match node.kind.as_str() {
+        "file" => 0,
+        "symbol" => 1,
+        "external" => 2,
+        _ => 3,
+    };
+    (
+        rank,
+        node.path
+            .as_deref()
+            .or(node.file_path.as_deref())
+            .unwrap_or(""),
+        node.name.as_deref().unwrap_or(""),
+        node.id,
+    )
 }
 
 #[cfg(test)]

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -5,6 +5,35 @@ pub mod inspect;
 pub mod shard;
 
 use serde::Serialize;
+use std::io::Write;
+use std::path::Path;
+
+/// Write `bytes` to `path` by renaming a temporary file beside it.
+///
+/// A crash between truncate and flush leaves a partial document, and every
+/// writer here produces output that is either complete or useless. The
+/// temporary file lives in the target directory, so the rename never crosses
+/// a mount point.
+pub(crate) fn write_atomic(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    let directory = path.parent().unwrap_or_else(|| Path::new("."));
+    let mut temporary = std::ffi::OsString::from(".");
+    temporary.push(path.file_name().unwrap_or_default());
+    temporary.push(format!(".tmp.{}", std::process::id()));
+    let temporary_path = directory.join(temporary);
+
+    let mut file = std::fs::File::create(&temporary_path)?;
+    let written = file.write_all(bytes).and_then(|()| file.sync_all());
+    drop(file);
+    if let Err(error) = written {
+        let _ = std::fs::remove_file(&temporary_path);
+        return Err(error);
+    }
+    if let Err(error) = std::fs::rename(&temporary_path, path) {
+        let _ = std::fs::remove_file(&temporary_path);
+        return Err(error);
+    }
+    Ok(())
+}
 
 /// Supported output serialization formats.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -21,5 +50,46 @@ impl OutputFormat {
             Self::Json => Ok(serde_json::to_string_pretty(value)?),
             Self::Yaml => Ok(yaml_serde::to_string(value)?),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temporary_files(directory: &Path) -> Vec<String> {
+        std::fs::read_dir(directory)
+            .unwrap()
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.file_name().to_string_lossy().to_string())
+            .filter(|name| name.contains(".tmp."))
+            .collect()
+    }
+
+    #[test]
+    fn write_atomic_replaces_content_without_leftovers() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("graph.json");
+
+        write_atomic(&path, b"first").unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "first");
+
+        write_atomic(&path, b"second").unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "second");
+        assert!(
+            temporary_files(directory.path()).is_empty(),
+            "no temporary file survives: {:?}",
+            temporary_files(directory.path())
+        );
+    }
+
+    #[test]
+    fn write_atomic_failure_creates_no_file() {
+        let directory = tempfile::tempdir().unwrap();
+        let missing = directory.path().join("nested").join("graph.json");
+
+        assert!(write_atomic(&missing, b"payload").is_err());
+        assert!(!missing.exists());
+        assert!(temporary_files(directory.path()).is_empty());
     }
 }

--- a/src/sink/mod.rs
+++ b/src/sink/mod.rs
@@ -24,7 +24,7 @@ impl GraphSink for JsonSink {
     fn emit(&self, export: &GraphOutput) -> anyhow::Result<()> {
         let json = serde_json::to_string_pretty(export)?;
         match &self.path {
-            Some(p) => std::fs::write(p, json)?,
+            Some(p) => crate::output::write_atomic(p, json.as_bytes())?,
             None => println!("{json}"),
         }
         Ok(())


### PR DESCRIPTION
## Summary

- Serialized nodes followed insertion order, so the output depended on how the graph happened to be built. They now sort by kind group, then location, then node id: files first by path, symbols next by defining file and name. SCC members sort by node index, so a component reads the same way on every run.
- Every writer called `fs::write`, which truncates before it flushes; a crash in between leaves a partial document that looks like a valid file. Writes go to a temporary file beside the target, sync, and rename. The rename cannot cross a mount because the temporary file lives in the target directory. The emitter, the JSON sink and the deploy manifests all use it.

## Type of change

- [x] `fix` - bug fix

## Affected area

- [x] `output`
- [x] `deploy` (feature)

## Public contract impact

- [x] Public contract changed; `docs/` updated (node and SCC ordering is now a documented guarantee)

## Verification

- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo +1.94.0 fmt --check` passes
- [x] `cargo nextest run --all-features` passes for this level (11 of the 17 base failures remain, owned by the PRs above)

## Notes for reviewers

The atomic writer is covered by two unit tests: a replacement that leaves no temporary file behind, and a failed write that creates no file.
