### PR TITLE
fix(shard): one casing contract, an indexed name lookup, and reported skips

### DIFF
--- a/docs/src/STRUCTURE.md
+++ b/docs/src/STRUCTURE.md
@@ -55,11 +55,12 @@ src/
 │   ├── emitter.rs            EmitConfig, emit_inspect(), emit_graph() - CLI output dispatch
 │   ├── inspect.rs            Inspect-compatible JSON/YAML emission
 │   ├── graph.rs              Unified GraphOutput (schema_version, metadata, nodes, edges, sccs, deployability)
-│   ├── shard/                `.metast` v2 stable-name JSONL shard and index persistence
+│   ├── shard/                `.metast` stable-name JSONL shard and index persistence
 │   │   ├── mod.rs            Module root, re-exports, unit tests
 │   │   ├── error.rs          ShardError enum
 │   │   ├── file.rs           ShardFile, ShardSymbol, write_shard(), read_shard()
 │   │   ├── edge.rs           ShardEdge, ShardEdgeKind, restore_shard_edges()
+│   │   ├── index.rs          load_index(), hardened index verification
 │   │   ├── manifest.rs       ShardManifestRecord, write_manifest(), read_manifest()
 │   │   ├── header.rs         ShardHeader, write_header(), read_header()
 │   │   └── name.rs           Stable naming, descriptors, and parent hierarchy resolution
@@ -198,13 +199,13 @@ pub struct Symbol {
 Node and edge types:
 
 | Node | Fields |
-|------|--------|
+| ------ | -------- |
 | `FileNode` | id, path (project-root-relative), language, snapshot_id |
 | `SymbolNode` | id, name, kind, file_id, visibility, source_range |
 | `ExternalNode` | raw_path, language |
 
 | Edge | Direction |
-|------|-----------|
+| ------ | ----------- |
 | `Ownership` | FileNode -> SymbolNode, SymbolNode -> SymbolNode (nesting) |
 | `Import` | FileNode -> FileNode |
 | `Reference` | SymbolNode -> SymbolNode |
@@ -299,7 +300,7 @@ pub trait ImportResolver: Send + Sync {
 2. **`ImportResolver`** represents a stateful trait interface.
 3. Concrete adapters bridge the two:
    - `StatelessResolver`: Zero-cost wrapper delegating to static fn pointers.
-   - `PythonResolver`, `GoModResolver`, `JsResolver`, `TsConfigResolver`: Concrete structs implementing `ImportResolver`, prepped to hold caches or parse configs.
+   - `PythonResolver`, `GoModResolver`, `NodeResolver`: concrete structs implementing `ImportResolver` that memoize filesystem probes.
 4. **`make_resolver(LangId) -> Box<dyn ImportResolver>`**: Factory function constructing the stateful resolver for each language dynamically.
 
 #### Stateful Caching and Memoization Engines
@@ -307,10 +308,10 @@ pub trait ImportResolver: Send + Sync {
 To guarantee maximum throughput and avoid redundant filesystem traversal during large-scale workspace parsing, the stateful resolvers employ optimized, thread-safe caching strategies:
 
 - **`OnceLock` Module Boundary Scanning (`GoModResolver`)**: Scans for the root `go.mod` file and parses the module path at most once per execution using a standard `OnceLock`. Subsequent resolution calls query the in-memory boundary in $O(1)$ time.
-- **`RwLock` File Existence Memoization (`PythonResolver`, `JsResolver`, `TsConfigResolver`)**: Memoizes `exists()` and `is_file()` filesystem checks using an `RwLock<HashMap<PathBuf, bool>>`. This minimizes expensive system calls during TypeScript candidate extensions resolution (e.g. trying `.ts`, `.tsx`, `.js`) and Python relative path matching, while remaining safe for concurrency.
+- **`RwLock` File Existence Memoization (`PythonResolver`, `NodeResolver`)**: memoizes `exists()` and `is_file()` checks in an `RwLock<HashMap<PathBuf, bool>>`, which removes repeated system calls during candidate extension resolution while staying safe for concurrency.
 - **Stateless Fallback**: When candidate paths do not match or cannot be resolved using stateful logic, all resolvers gracefully fallback to their underlying stateless `LanguageSpec` function pointer, ensuring 100% backward compatibility.
 
-During graph assembly, resolvers are created once per run and cached inside the builder to ensure O(1) config-file reading and caching properties.
+During graph assembly, `make_resolver` builds one resolver set per graph build, so a memoized probe never outlives the build that created it.
 
 ### 3.4 Adding a New Language
 
@@ -329,13 +330,13 @@ No trait objects, no runtime plugins. Compile-time completeness checking via exh
 `detect_language(path: &Path) -> Option<LangId>` maps file extensions to `LangId` variants. Lives in `input/mod.rs`.
 
 | Extension(s) | LangId |
-|---|---|
+| --- | --- |
 | `.py`, `.pyi` | `Python` |
 | `.js`, `.mjs`, `.cjs` | `JavaScript` |
 | `.ts`, `.cts`, `.mts` | `TypeScript` |
 | `.tsx` | `Tsx` |
-| `.c` | `C` |
-| `.cc`, `.cpp`, `.cxx` | `Cpp` |
+| `.c`, `.h` | `C` |
+| `.cc`, `.cpp`, `.cxx`, `.hpp` | `Cpp` |
 | `.rs` | `Rust` |
 | `.go` | `Go` |
 | `.rb`, `.gemspec` | `Ruby` |
@@ -386,7 +387,7 @@ Parse errors do not abort extraction. The pipeline accumulates `Vec<Diagnostic>`
 ### 5.2 Pipeline Phases
 
 | Phase | Concurrency | Rationale |
-|-------|------------|-----------|
+| ------- | ------------ | ----------- |
 | File discovery | Sequential | Single walk, fast I/O |
 | Parse + Extract | rayon `par_iter` | CPU-bound, per-file independent, largest time slice |
 | Graph assembly | Sequential | petgraph mutation + cross-file resolution requires single-threaded access |
@@ -439,7 +440,7 @@ Diagnostics are accumulated in a `Vec<Diagnostic>` separate from the symbol mode
 
 1. Tree-sitter `ERROR` and `MISSING` nodes are skipped during extraction.
 2. Partial extraction is allowed and expected for malformed source files.
-3. If > 50% of a file's nodes are errors, the file is marked as unparseable but does not abort the pipeline.
+3. Any tree with an error node emits one Warning diagnostic that carries the error ratio. Extraction still returns partial results and never aborts the pipeline.
 4. Fatal errors are reserved for invalid configuration or unrecoverable I/O failures.
 
 ### 6.4 Query Compilation Failure Strategy
@@ -459,7 +460,7 @@ Tree-sitter queries are hardcoded constants in each language pack. If a query fa
 ## 7. Rust Language Features Used
 
 | Feature | Usage |
-|---------|-------|
+| --------- | ------- |
 | Edition 2024 | MSRV 1.94.0 |
 | `#[non_exhaustive]` | All public enums (`LangId`, `SymbolKind`, `Visibility`, `Severity`) |
 | Newtype pattern | `FileId`, `SymbolId`, `SnapshotId`, `DataNodeId` via `define_id_type!` macro (`NonZeroU32` inner, 1-based generator) |
@@ -480,7 +481,7 @@ Tree-sitter queries are hardcoded constants in each language pack. If a query fa
 ### 8.1 Runtime Dependencies
 
 | Crate | Version | Purpose |
-|-------|---------|---------|
+| ------- | --------- | --------- |
 | `tree-sitter` | 0.26.11 | Core parsing |
 | `tree-sitter-python` | 0.25.0 | Python grammar |
 | `tree-sitter-javascript` | 0.25.0 | JavaScript grammar |
@@ -509,7 +510,7 @@ Tree-sitter queries are hardcoded constants in each language pack. If a query fa
 ### 8.2 Development Dependencies
 
 | Crate | Version | Purpose |
-|-------|---------|---------|
+| ------- | --------- | --------- |
 | `insta` | 1.48 | Snapshot testing for JSON output contracts |
 | `criterion` | 0.8 | Benchmark gating (`pipeline`, `graph`, `incremental`) |
 | `tempfile` | 3.27 | Temporary filesystem test fixtures |
@@ -583,7 +584,7 @@ language module generates snapshots via inline unit tests. Update workflow: `car
 ### Testing Strategy
 
 | Layer | Tool | Purpose |
-|-------|------|---------|
+| ------- | ------ | --------- |
 | Language detection | Unit tests | Extension-to-LangId mapping |
 | Per-language extraction | Fixture files + unit tests | Query correctness, capture mapping |
 | JSON output contract | `insta` snapshots in `src/language/snapshots/` | Regression detection |

--- a/docs/src/specs/graph-model.md
+++ b/docs/src/specs/graph-model.md
@@ -87,8 +87,11 @@ These values also parse back through the CLI `--language` flag. The same names
 apply to the strum `Display`/`AsRefStr` and serde representations of `LangId`.
 
 Graph output schema version 2 adds `file_path` and `source_range` to serialized
-symbol nodes. `.metast` v2 shards do not persist numeric IDs. They store stable
-language-scoped endpoint names and regenerate symbol IDs when loaded.
+symbol nodes. `.metast` shards declare `SHARD_SCHEMA_VERSION` in `header.json`
+and in every record, and they spell symbol kinds and visibility in lowercase.
+They do not persist numeric IDs: they store stable language-scoped endpoint
+names and regenerate symbol IDs when loaded. A reader refuses any other version,
+so an index written before a schema bump must be regenerated.
 
 ## 7. Known limitations
 

--- a/src/language/snapshots/meta_ast__language__c__tests__c_insta_snapshot.snap
+++ b/src/language/snapshots/meta_ast__language__c__tests__c_insta_snapshot.snap
@@ -1,12 +1,11 @@
 ---
 source: src/language/c.rs
-assertion_line: 205
 expression: symbols
 ---
 [
   {
     "name": "add",
-    "kind": "Function",
+    "kind": "function",
     "source_range": {
       "byte_start": 20,
       "byte_end": 63,
@@ -26,7 +25,7 @@ expression: symbols
   },
   {
     "name": "print_hello",
-    "kind": "Function",
+    "kind": "function",
     "source_range": {
       "byte_start": 65,
       "byte_end": 122,
@@ -46,7 +45,7 @@ expression: symbols
   },
   {
     "name": "get_counter",
-    "kind": "Function",
+    "kind": "function",
     "source_range": {
       "byte_start": 149,
       "byte_end": 194,

--- a/src/language/snapshots/meta_ast__language__cpp__tests__cpp_insta_snapshot.snap
+++ b/src/language/snapshots/meta_ast__language__cpp__tests__cpp_insta_snapshot.snap
@@ -5,7 +5,7 @@ expression: symbols
 [
   {
     "name": "Animal",
-    "kind": "Class",
+    "kind": "class",
     "source_range": {
       "byte_start": 19,
       "byte_end": 251,
@@ -25,7 +25,7 @@ expression: symbols
   },
   {
     "name": "Animal",
-    "kind": "Method",
+    "kind": "method",
     "source_range": {
       "byte_start": 46,
       "byte_end": 87,
@@ -45,7 +45,7 @@ expression: symbols
   },
   {
     "name": "~Animal",
-    "kind": "Method",
+    "kind": "method",
     "source_range": {
       "byte_start": 92,
       "byte_end": 120,
@@ -65,7 +65,7 @@ expression: symbols
   },
   {
     "name": "speak",
-    "kind": "Method",
+    "kind": "method",
     "source_range": {
       "byte_start": 126,
       "byte_end": 171,
@@ -85,7 +85,7 @@ expression: symbols
   },
   {
     "name": "get_name",
-    "kind": "Method",
+    "kind": "method",
     "source_range": {
       "byte_start": 176,
       "byte_end": 216,
@@ -105,7 +105,7 @@ expression: symbols
   },
   {
     "name": "Dog",
-    "kind": "Class",
+    "kind": "class",
     "source_range": {
       "byte_start": 254,
       "byte_end": 389,
@@ -125,7 +125,7 @@ expression: symbols
   },
   {
     "name": "Dog",
-    "kind": "Method",
+    "kind": "method",
     "source_range": {
       "byte_start": 294,
       "byte_end": 333,
@@ -145,7 +145,7 @@ expression: symbols
   },
   {
     "name": "speak",
-    "kind": "Method",
+    "kind": "method",
     "source_range": {
       "byte_start": 339,
       "byte_end": 387,

--- a/src/language/snapshots/meta_ast__language__go__tests__go_insta_snapshot.snap
+++ b/src/language/snapshots/meta_ast__language__go__tests__go_insta_snapshot.snap
@@ -5,7 +5,7 @@ expression: symbols
 [
   {
     "name": "Rectangle",
-    "kind": "Struct",
+    "kind": "struct",
     "source_range": {
       "byte_start": 14,
       "byte_end": 71,
@@ -18,14 +18,14 @@ expression: symbols
         "column": 1
       }
     },
-    "visibility": "Public",
+    "visibility": "public",
     "signature": null,
     "docstring": null,
     "is_async": false
   },
   {
     "name": "Area",
-    "kind": "Method",
+    "kind": "method",
     "source_range": {
       "byte_start": 73,
       "byte_end": 138,
@@ -38,14 +38,14 @@ expression: symbols
         "column": 1
       }
     },
-    "visibility": "Public",
+    "visibility": "public",
     "signature": "()",
     "docstring": null,
     "is_async": false
   },
   {
     "name": "Perimeter",
-    "kind": "Method",
+    "kind": "method",
     "source_range": {
       "byte_start": 140,
       "byte_end": 215,
@@ -58,14 +58,14 @@ expression: symbols
         "column": 1
       }
     },
-    "visibility": "Public",
+    "visibility": "public",
     "signature": "()",
     "docstring": null,
     "is_async": false
   },
   {
     "name": "Describer",
-    "kind": "Interface",
+    "kind": "interface",
     "source_range": {
       "byte_start": 217,
       "byte_end": 264,
@@ -78,7 +78,7 @@ expression: symbols
         "column": 1
       }
     },
-    "visibility": "Public",
+    "visibility": "public",
     "signature": null,
     "docstring": null,
     "is_async": false

--- a/src/language/snapshots/meta_ast__language__javascript__tests__js_insta_snapshot.snap
+++ b/src/language/snapshots/meta_ast__language__javascript__tests__js_insta_snapshot.snap
@@ -5,7 +5,7 @@ expression: symbols
 [
   {
     "name": "hello",
-    "kind": "Function",
+    "kind": "function",
     "source_range": {
       "byte_start": 0,
       "byte_end": 40,
@@ -25,7 +25,7 @@ expression: symbols
   },
   {
     "name": "fetchData",
-    "kind": "Function",
+    "kind": "function",
     "source_range": {
       "byte_start": 42,
       "byte_end": 142,
@@ -45,7 +45,7 @@ expression: symbols
   },
   {
     "name": "compute",
-    "kind": "Function",
+    "kind": "function",
     "source_range": {
       "byte_start": 150,
       "byte_end": 196,
@@ -65,7 +65,7 @@ expression: symbols
   },
   {
     "name": "greet",
-    "kind": "Function",
+    "kind": "function",
     "source_range": {
       "byte_start": 205,
       "byte_end": 239,

--- a/src/language/snapshots/meta_ast__language__python__tests__python_insta_snapshot.snap
+++ b/src/language/snapshots/meta_ast__language__python__tests__python_insta_snapshot.snap
@@ -5,7 +5,7 @@ expression: symbols
 [
   {
     "name": "hello",
-    "kind": "Function",
+    "kind": "function",
     "source_range": {
       "byte_start": 0,
       "byte_end": 21,
@@ -25,7 +25,7 @@ expression: symbols
   },
   {
     "name": "greet",
-    "kind": "Function",
+    "kind": "function",
     "source_range": {
       "byte_start": 24,
       "byte_end": 68,
@@ -45,7 +45,7 @@ expression: symbols
   },
   {
     "name": "fetch_data",
-    "kind": "Function",
+    "kind": "function",
     "source_range": {
       "byte_start": 71,
       "byte_end": 106,
@@ -65,7 +65,7 @@ expression: symbols
   },
   {
     "name": "add",
-    "kind": "Function",
+    "kind": "function",
     "source_range": {
       "byte_start": 109,
       "byte_end": 157,

--- a/src/language/snapshots/meta_ast__language__ruby__tests__ruby_insta_snapshot.snap
+++ b/src/language/snapshots/meta_ast__language__ruby__tests__ruby_insta_snapshot.snap
@@ -1,12 +1,11 @@
 ---
 source: src/language/ruby.rs
-assertion_line: 324
 expression: symbols
 ---
 [
   {
     "name": "Widget",
-    "kind": "Module",
+    "kind": "module",
     "source_range": {
       "byte_start": 127,
       "byte_end": 911,
@@ -26,7 +25,7 @@ expression: symbols
   },
   {
     "name": "VERSION",
-    "kind": "Constant",
+    "kind": "constant",
     "source_range": {
       "byte_start": 143,
       "byte_end": 167,
@@ -46,7 +45,7 @@ expression: symbols
   },
   {
     "name": "Report",
-    "kind": "Class",
+    "kind": "class",
     "source_range": {
       "byte_start": 224,
       "byte_end": 907,
@@ -66,7 +65,7 @@ expression: symbols
   },
   {
     "name": "FORMATS",
-    "kind": "Constant",
+    "kind": "constant",
     "source_range": {
       "byte_start": 241,
       "byte_end": 271,
@@ -86,7 +85,7 @@ expression: symbols
   },
   {
     "name": "initialize",
-    "kind": "Method",
+    "kind": "method",
     "source_range": {
       "byte_start": 277,
       "byte_end": 357,
@@ -106,7 +105,7 @@ expression: symbols
   },
   {
     "name": "total",
-    "kind": "Method",
+    "kind": "method",
     "source_range": {
       "byte_start": 410,
       "byte_end": 443,
@@ -126,7 +125,7 @@ expression: symbols
   },
   {
     "name": "render",
-    "kind": "Method",
+    "kind": "method",
     "source_range": {
       "byte_start": 505,
       "byte_end": 548,
@@ -146,7 +145,7 @@ expression: symbols
   },
   {
     "name": "to_json",
-    "kind": "Method",
+    "kind": "method",
     "source_range": {
       "byte_start": 601,
       "byte_end": 649,
@@ -166,7 +165,7 @@ expression: symbols
   },
   {
     "name": "from_file",
-    "kind": "Method",
+    "kind": "method",
     "source_range": {
       "byte_start": 709,
       "byte_end": 757,
@@ -186,7 +185,7 @@ expression: symbols
   },
   {
     "name": "payload",
-    "kind": "Method",
+    "kind": "method",
     "source_range": {
       "byte_start": 776,
       "byte_end": 832,
@@ -206,7 +205,7 @@ expression: symbols
   },
   {
     "name": "format_rows",
-    "kind": "Method",
+    "kind": "method",
     "source_range": {
       "byte_start": 838,
       "byte_end": 901,
@@ -226,7 +225,7 @@ expression: symbols
   },
   {
     "name": "Auth",
-    "kind": "Module",
+    "kind": "module",
     "source_range": {
       "byte_start": 965,
       "byte_end": 1293,
@@ -246,7 +245,7 @@ expression: symbols
   },
   {
     "name": "ENDPOINT",
-    "kind": "Constant",
+    "kind": "constant",
     "source_range": {
       "byte_start": 979,
       "byte_end": 1023,
@@ -266,7 +265,7 @@ expression: symbols
   },
   {
     "name": "Token",
-    "kind": "Class",
+    "kind": "class",
     "source_range": {
       "byte_start": 1073,
       "byte_end": 1289,
@@ -286,7 +285,7 @@ expression: symbols
   },
   {
     "name": "initialize",
-    "kind": "Method",
+    "kind": "method",
     "source_range": {
       "byte_start": 1089,
       "byte_end": 1178,
@@ -306,7 +305,7 @@ expression: symbols
   },
   {
     "name": "fresh?",
-    "kind": "Method",
+    "kind": "method",
     "source_range": {
       "byte_start": 1184,
       "byte_end": 1231,
@@ -326,7 +325,7 @@ expression: symbols
   },
   {
     "name": "for",
-    "kind": "Method",
+    "kind": "method",
     "source_range": {
       "byte_start": 1237,
       "byte_end": 1283,

--- a/src/language/snapshots/meta_ast__language__rust__tests__rust_insta_snapshot.snap
+++ b/src/language/snapshots/meta_ast__language__rust__tests__rust_insta_snapshot.snap
@@ -1,12 +1,11 @@
 ---
 source: src/language/rust.rs
-assertion_line: 246
 expression: symbols
 ---
 [
   {
     "name": "Point",
-    "kind": "Struct",
+    "kind": "struct",
     "source_range": {
       "byte_start": 0,
       "byte_end": 52,
@@ -19,14 +18,14 @@ expression: symbols
         "column": 1
       }
     },
-    "visibility": "Public",
+    "visibility": "public",
     "signature": null,
     "docstring": null,
     "is_async": false
   },
   {
     "name": "Direction",
-    "kind": "Enum",
+    "kind": "enum",
     "source_range": {
       "byte_start": 54,
       "byte_end": 111,
@@ -46,7 +45,7 @@ expression: symbols
   },
   {
     "name": "Shape",
-    "kind": "Trait",
+    "kind": "trait",
     "source_range": {
       "byte_start": 113,
       "byte_end": 159,
@@ -59,14 +58,14 @@ expression: symbols
         "column": 1
       }
     },
-    "visibility": "Public",
+    "visibility": "public",
     "signature": null,
     "docstring": null,
     "is_async": false
   },
   {
     "name": "new",
-    "kind": "Method",
+    "kind": "method",
     "source_range": {
       "byte_start": 178,
       "byte_end": 242,
@@ -79,14 +78,14 @@ expression: symbols
         "column": 5
       }
     },
-    "visibility": "Public",
+    "visibility": "public",
     "signature": "(x: f64, y: f64)",
     "docstring": null,
     "is_async": false
   },
   {
     "name": "area",
-    "kind": "Method",
+    "kind": "method",
     "source_range": {
       "byte_start": 273,
       "byte_end": 314,
@@ -106,7 +105,7 @@ expression: symbols
   },
   {
     "name": "PI",
-    "kind": "Constant",
+    "kind": "constant",
     "source_range": {
       "byte_start": 318,
       "byte_end": 342,
@@ -126,7 +125,7 @@ expression: symbols
   },
   {
     "name": "MyResult",
-    "kind": "TypeAlias",
+    "kind": "type_alias",
     "source_range": {
       "byte_start": 343,
       "byte_end": 380,
@@ -146,7 +145,7 @@ expression: symbols
   },
   {
     "name": "geometry",
-    "kind": "Module",
+    "kind": "module",
     "source_range": {
       "byte_start": 381,
       "byte_end": 396,

--- a/src/language/snapshots/meta_ast__language__tsx__tests__tsx_insta_snapshot.snap
+++ b/src/language/snapshots/meta_ast__language__tsx__tests__tsx_insta_snapshot.snap
@@ -5,7 +5,7 @@ expression: symbols
 [
   {
     "name": "Props",
-    "kind": "Interface",
+    "kind": "interface",
     "source_range": {
       "byte_start": 28,
       "byte_end": 82,
@@ -25,7 +25,7 @@ expression: symbols
   },
   {
     "name": "Greeting",
-    "kind": "Function",
+    "kind": "function",
     "source_range": {
       "byte_start": 84,
       "byte_end": 176,
@@ -45,7 +45,7 @@ expression: symbols
   },
   {
     "name": "Welcome",
-    "kind": "Function",
+    "kind": "function",
     "source_range": {
       "byte_start": 184,
       "byte_end": 271,
@@ -65,7 +65,7 @@ expression: symbols
   },
   {
     "name": "App",
-    "kind": "Class",
+    "kind": "class",
     "source_range": {
       "byte_start": 281,
       "byte_end": 419,
@@ -78,14 +78,14 @@ expression: symbols
         "column": 1
       }
     },
-    "visibility": "Public",
+    "visibility": "public",
     "signature": null,
     "docstring": null,
     "is_async": false
   },
   {
     "name": "render",
-    "kind": "Method",
+    "kind": "method",
     "source_range": {
       "byte_start": 328,
       "byte_end": 417,
@@ -98,7 +98,7 @@ expression: symbols
         "column": 5
       }
     },
-    "visibility": "Public",
+    "visibility": "public",
     "signature": "()",
     "docstring": null,
     "is_async": false

--- a/src/language/snapshots/meta_ast__language__typescript__tests__ts_insta_snapshot.snap
+++ b/src/language/snapshots/meta_ast__language__typescript__tests__ts_insta_snapshot.snap
@@ -1,12 +1,11 @@
 ---
 source: src/language/typescript.rs
-assertion_line: 231
 expression: symbols
 ---
 [
   {
     "name": "Shape",
-    "kind": "Interface",
+    "kind": "interface",
     "source_range": {
       "byte_start": 0,
       "byte_end": 64,
@@ -26,7 +25,7 @@ expression: symbols
   },
   {
     "name": "Color",
-    "kind": "Interface",
+    "kind": "interface",
     "source_range": {
       "byte_start": 66,
       "byte_end": 121,
@@ -46,7 +45,7 @@ expression: symbols
   },
   {
     "name": "Point",
-    "kind": "TypeAlias",
+    "kind": "type_alias",
     "source_range": {
       "byte_start": 123,
       "byte_end": 170,
@@ -66,7 +65,7 @@ expression: symbols
   },
   {
     "name": "Vector",
-    "kind": "TypeAlias",
+    "kind": "type_alias",
     "source_range": {
       "byte_start": 172,
       "byte_end": 208,
@@ -86,7 +85,7 @@ expression: symbols
   },
   {
     "name": "Direction",
-    "kind": "Enum",
+    "kind": "enum",
     "source_range": {
       "byte_start": 210,
       "byte_end": 302,
@@ -106,7 +105,7 @@ expression: symbols
   },
   {
     "name": "Circle",
-    "kind": "Class",
+    "kind": "class",
     "source_range": {
       "byte_start": 304,
       "byte_end": 534,
@@ -126,7 +125,7 @@ expression: symbols
   },
   {
     "name": "constructor",
-    "kind": "Method",
+    "kind": "method",
     "source_range": {
       "byte_start": 340,
       "byte_end": 377,
@@ -146,7 +145,7 @@ expression: symbols
   },
   {
     "name": "area",
-    "kind": "Method",
+    "kind": "method",
     "source_range": {
       "byte_start": 383,
       "byte_end": 457,
@@ -166,7 +165,7 @@ expression: symbols
   },
   {
     "name": "perimeter",
-    "kind": "Method",
+    "kind": "method",
     "source_range": {
       "byte_start": 463,
       "byte_end": 532,

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -101,6 +101,7 @@ pub struct SourceRange {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
+#[serde(rename_all = "snake_case")]
 pub enum SymbolKind {
     Function,
     Method,
@@ -119,11 +120,45 @@ pub enum SymbolKind {
     Declaration,
 }
 
+impl SymbolKind {
+    /// Canonical lowercase name, shared by every writer: graph output, inspect
+    /// output and the stable shard names.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            SymbolKind::Function => "function",
+            SymbolKind::Method => "method",
+            SymbolKind::Class => "class",
+            SymbolKind::Struct => "struct",
+            SymbolKind::Interface => "interface",
+            SymbolKind::Trait => "trait",
+            SymbolKind::Enum => "enum",
+            SymbolKind::Object => "object",
+            SymbolKind::Constant => "constant",
+            SymbolKind::Static => "static",
+            SymbolKind::Module => "module",
+            SymbolKind::Namespace => "namespace",
+            SymbolKind::TypeAlias => "type_alias",
+            SymbolKind::Declaration => "declaration",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
+#[serde(rename_all = "snake_case")]
 pub enum Visibility {
     Public,
     Private,
+}
+
+impl Visibility {
+    /// Canonical lowercase name, shared by every writer.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Visibility::Public => "public",
+            Visibility::Private => "private",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -143,6 +178,7 @@ pub struct Symbol {
 /// Classification of a data-bearing entity's visibility scope.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[non_exhaustive]
+#[serde(rename_all = "snake_case")]
 pub enum DataScope {
     Local,
     Parameter,
@@ -186,6 +222,7 @@ pub struct FlowEdge {
 /// Semantic kind of a dataflow edge.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[non_exhaustive]
+#[serde(rename_all = "snake_case")]
 pub enum FlowKind {
     DefUse,
     Argument,

--- a/src/model/output.rs
+++ b/src/model/output.rs
@@ -115,7 +115,7 @@ mod tests {
         };
         let val: serde_json::Value = serde_json::to_value(&entry).unwrap();
         assert_eq!(val["name"], "MyClass");
-        assert_eq!(val["visibility"], "Public");
+        assert_eq!(val["visibility"], "public");
         assert_eq!(val["signature"], "class MyClass");
         assert_eq!(val["docstring"], "a class");
         assert!(val["source_range"].is_object());
@@ -132,7 +132,7 @@ mod tests {
         };
         let val: serde_json::Value = serde_json::to_value(&entry).unwrap();
         assert_eq!(val["name"], "obj");
-        assert_eq!(val["visibility"], "Private");
+        assert_eq!(val["visibility"], "private");
         assert!(val["signature"].is_null());
         assert!(val["docstring"].is_null());
     }

--- a/src/output/graph.rs
+++ b/src/output/graph.rs
@@ -292,8 +292,8 @@ impl GraphOutput {
             source_range: Some(symbol_node.source_range.clone()),
             language: None,
             name: Some(symbol_node.name.clone()),
-            symbol_kind: Some(format!("{:?}", symbol_node.kind)),
-            visibility: symbol_node.visibility.map(|v| format!("{:?}", v)),
+            symbol_kind: Some(symbol_node.kind.as_str().to_string()),
+            visibility: symbol_node.visibility.map(|v| v.as_str().to_string()),
             data_scope: None,
             type_hint: None,
         }

--- a/src/output/shard/edge.rs
+++ b/src/output/shard/edge.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use crate::graph::{CodeGraph, EdgeKind, NodeData};
 use crate::output::shard::error::ShardError;
 use crate::output::shard::file::SHARD_SCHEMA_VERSION;
-use crate::output::shard::name::stable_node_name;
+use crate::output::shard::name::StableNameIndex;
 
 /// Serialized cross-node edge in a shard file.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -115,12 +115,13 @@ pub(crate) fn validate_edge(
 
 /// Restore persisted edges after `GraphBuilder::from_extractions` regenerates graph nodes.
 pub fn restore_shard_edges(graph: &mut CodeGraph, edges: &[ShardEdge]) -> Result<(), ShardError> {
-    let endpoint_index = graph
+    let names = StableNameIndex::new(graph)?;
+    let endpoint_index: HashMap<String, _> = graph
         .graph()
         .node_indices()
         .filter(|index| !matches!(graph.graph()[*index], NodeData::Data(_)))
-        .map(|index| stable_node_name(graph, index).map(|name| (name, index)))
-        .collect::<Result<HashMap<_, _>, ShardError>>()?;
+        .filter_map(|index| names.name_of(index).map(|name| (name.to_string(), index)))
+        .collect();
 
     for (edge_index, edge) in edges.iter().enumerate() {
         validate_edge(edge, 0, edge_index)?;

--- a/src/output/shard/file.rs
+++ b/src/output/shard/file.rs
@@ -15,9 +15,13 @@ use crate::model::{
 };
 use crate::output::shard::edge::{ShardEdge, validate_edge};
 use crate::output::shard::error::ShardError;
-use crate::output::shard::name::{node_belongs_to_file, normalized_path, stable_node_name};
+use crate::output::shard::name::{StableNameIndex, node_belongs_to_file, normalized_path};
 
-pub const SHARD_SCHEMA_VERSION: u32 = 3;
+/// Shard payload version.
+///
+/// Version 4 spells symbol kinds and visibility in lowercase, so version 3
+/// records no longer parse. Regenerate the index after an upgrade.
+pub const SHARD_SCHEMA_VERSION: u32 = 4;
 
 /// A per-file shard record stored in `.meta-ast/shards/<n>.jsonl`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -66,6 +70,7 @@ impl ShardFile {
         for diagnostic in &extraction.diagnostics {
             normalized_path(&diagnostic.path)?;
         }
+        let names = StableNameIndex::new(graph)?;
         let symbols = extraction.symbols.iter().map(ShardSymbol::from).collect();
         #[cfg(feature = "dataflow")]
         let dropped_payload = dataflow_drop_diagnostic(extraction);
@@ -87,8 +92,18 @@ impl ShardFile {
                         || node_belongs_to_file(graph, edge.target(), &extraction.path))
             })
             .map(|edge| {
-                let source_name = stable_node_name(graph, edge.source())?;
-                let target_name = stable_node_name(graph, edge.target())?;
+                let source_name = names
+                    .name_of(edge.source())
+                    .ok_or(ShardError::MissingNodeOwner {
+                        node_index: edge.source().index(),
+                    })?
+                    .to_string();
+                let target_name = names
+                    .name_of(edge.target())
+                    .ok_or(ShardError::MissingNodeOwner {
+                        node_index: edge.target().index(),
+                    })?
+                    .to_string();
                 Ok(ShardEdge {
                     source_name,
                     target_name,

--- a/src/output/shard/index.rs
+++ b/src/output/shard/index.rs
@@ -49,6 +49,13 @@ pub struct IndexLoadStats {
     pub skipped: usize,
 }
 
+/// A manifest record that was not loaded, with the reason it was skipped.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShardSkip {
+    pub path: PathBuf,
+    pub reason: String,
+}
+
 /// Rebuilt index contents.
 #[derive(Debug)]
 pub struct LoadedIndex {
@@ -56,6 +63,10 @@ pub struct LoadedIndex {
     pub extractions: Vec<Arc<FileExtraction>>,
     pub edges: Vec<ShardEdge>,
     pub stats: IndexLoadStats,
+    /// One entry per skipped manifest record, in manifest order. A stale file
+    /// and a corrupt shard are not the same condition, so the caller gets the
+    /// reason instead of a bare count.
+    pub skips: Vec<ShardSkip>,
 }
 
 /// Reports whether a manifest shard name stays inside `shards/`.
@@ -89,6 +100,7 @@ pub fn load_index(
     let manifest = read_manifest(BufReader::new(File::open(dir.join(MANIFEST_FILE))?))?;
 
     let mut shards: BTreeMap<String, Vec<ShardFile>> = BTreeMap::new();
+    let mut unreadable_shards: BTreeMap<String, String> = BTreeMap::new();
     for record in &manifest {
         if !is_safe_shard_name(&record.shard) {
             return Err(ShardError::UnsafeShardName {
@@ -100,8 +112,17 @@ pub fn load_index(
         }
         let path = dir.join(&record.shard);
         let files = match File::open(&path) {
-            Ok(file) => read_shard(BufReader::new(file))?,
-            Err(_) => continue,
+            Ok(file) => match read_shard(BufReader::new(file)) {
+                Ok(files) => files,
+                Err(error) => {
+                    unreadable_shards.insert(record.shard.clone(), error.to_string());
+                    continue;
+                }
+            },
+            Err(error) => {
+                unreadable_shards.insert(record.shard.clone(), error.to_string());
+                continue;
+            }
         };
         shards.insert(record.shard.clone(), files);
     }
@@ -117,31 +138,65 @@ pub fn load_index(
     let mut extractions = Vec::new();
     let mut edges = Vec::new();
     let mut stats = IndexLoadStats::default();
+    let mut skips: Vec<ShardSkip> = Vec::new();
     for record in &manifest {
         let Some(absolute) = resolve_record_path(&root_canon, &record.path)? else {
-            stats.skipped += 1;
+            record_skip(
+                &mut stats,
+                &mut skips,
+                &record.path,
+                "the file is gone or sits outside the index root".to_string(),
+            );
             continue;
         };
         let Some(shard) = by_path.remove(&record.path) else {
-            stats.skipped += 1;
+            let reason = unreadable_shards
+                .get(&record.shard)
+                .cloned()
+                .unwrap_or_else(|| format!("no record for this path in {}", record.shard));
+            record_skip(&mut stats, &mut skips, &record.path, reason);
             continue;
         };
         let Ok(metadata) = std::fs::metadata(&absolute) else {
-            stats.skipped += 1;
+            record_skip(
+                &mut stats,
+                &mut skips,
+                &record.path,
+                "the file cannot be read".to_string(),
+            );
             continue;
         };
         if metadata.len() != record.size {
-            stats.skipped += 1;
+            record_skip(
+                &mut stats,
+                &mut skips,
+                &record.path,
+                format!(
+                    "size changed: manifest claims {} bytes, the file has {}",
+                    record.size,
+                    metadata.len()
+                ),
+            );
             continue;
         }
         let Ok(bytes) = std::fs::read(&absolute) else {
-            stats.skipped += 1;
+            record_skip(
+                &mut stats,
+                &mut skips,
+                &record.path,
+                "the file cannot be read".to_string(),
+            );
             continue;
         };
         if options.verify_content_hash
             && ShardManifestRecord::compute_hash(&bytes) != record.content_hash
         {
-            stats.skipped += 1;
+            record_skip(
+                &mut stats,
+                &mut skips,
+                &record.path,
+                "the content hash does not match the manifest".to_string(),
+            );
             continue;
         }
         let LoadedShard {
@@ -149,8 +204,8 @@ pub fn load_index(
             edges: shard_edges,
         } = match shard.load(id_gen) {
             Ok(loaded) => loaded,
-            Err(_) => {
-                stats.skipped += 1;
+            Err(error) => {
+                record_skip(&mut stats, &mut skips, &record.path, error.to_string());
                 continue;
             }
         };
@@ -164,7 +219,21 @@ pub fn load_index(
         extractions,
         edges,
         stats,
+        skips,
     })
+}
+
+fn record_skip(
+    stats: &mut IndexLoadStats,
+    skips: &mut Vec<ShardSkip>,
+    path: &Path,
+    reason: String,
+) {
+    stats.skipped += 1;
+    skips.push(ShardSkip {
+        path: path.to_path_buf(),
+        reason,
+    });
 }
 
 /// Canonical record path when it exists under the root.
@@ -186,4 +255,71 @@ fn resolve_record_path(root_canon: &Path, path: &Path) -> Result<Option<PathBuf>
         });
     }
     Ok(Some(canonical))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::output::shard::header::write_header;
+    use crate::output::shard::manifest::{ShardManifestRecord, write_manifest};
+
+    /// A record the reader refuses is skipped with its reason, so a stale work
+    /// tree, a corrupt payload and a schema mismatch stay distinguishable.
+    #[test]
+    fn skipped_records_carry_the_reason() {
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path();
+        let index_dir = root.join(INDEX_DIR_NAME);
+        std::fs::create_dir_all(index_dir.join("shards")).unwrap();
+
+        let source = root.join("a.py");
+        std::fs::write(&source, "def a():\n    pass\n").unwrap();
+
+        let mut header_bytes = Vec::new();
+        write_header(&mut header_bytes, &ShardHeader::new("2026-01-01T00:00:00Z")).unwrap();
+        std::fs::write(index_dir.join(HEADER_FILE), header_bytes).unwrap();
+
+        // Schema version 79 is not this build's version, so the record fails
+        // to load. Written raw because the writer rejects it on purpose.
+        let record = serde_json::json!({
+            "schema_version": 79,
+            "path": "a.py",
+            "language": "python",
+            "symbols": [],
+            "imports": [],
+            "references": [],
+            "diagnostics": [],
+            "ast_node_count": 1,
+            "edges": [],
+        });
+        std::fs::write(index_dir.join("shards/0.jsonl"), format!("{record}\n")).unwrap();
+
+        let bytes = std::fs::read(&source).unwrap();
+        let manifest = ShardManifestRecord::from_file_bytes(
+            PathBuf::from("a.py"),
+            &bytes,
+            0,
+            "shards/0.jsonl".to_string(),
+        );
+        let mut manifest_bytes = Vec::new();
+        write_manifest(&mut manifest_bytes, std::slice::from_ref(&manifest)).unwrap();
+        std::fs::write(index_dir.join(MANIFEST_FILE), manifest_bytes).unwrap();
+
+        let loaded = load_index(
+            root,
+            &IdGenerator::with_start(1),
+            &IndexLoadOptions::default(),
+        )
+        .unwrap();
+
+        assert_eq!(loaded.stats.loaded, 0);
+        assert_eq!(loaded.stats.skipped, 1);
+        assert_eq!(loaded.skips.len(), 1);
+        assert_eq!(loaded.skips[0].path, PathBuf::from("a.py"));
+        assert!(
+            loaded.skips[0].reason.contains("79"),
+            "the reason names the refused version: {}",
+            loaded.skips[0].reason
+        );
+    }
 }

--- a/src/output/shard/mod.rs
+++ b/src/output/shard/mod.rs
@@ -23,7 +23,8 @@ pub use file::{
 };
 pub use header::{ShardHeader, read_header, write_header};
 pub use index::{
-    INDEX_DIR_NAME, IndexLoadOptions, IndexLoadStats, LoadedIndex, is_safe_shard_name, load_index,
+    INDEX_DIR_NAME, IndexLoadOptions, IndexLoadStats, LoadedIndex, ShardSkip, is_safe_shard_name,
+    load_index,
 };
 pub use manifest::{ShardManifestRecord, read_manifest, write_manifest};
 

--- a/src/output/shard/name.rs
+++ b/src/output/shard/name.rs
@@ -1,11 +1,12 @@
 //! Stable naming and descriptor generation for shard endpoints.
 
+use std::collections::HashMap;
 use std::path::Path;
 
 use petgraph::graph::NodeIndex;
 
 use crate::graph::{CodeGraph, NodeData};
-use crate::model::SymbolKind;
+use crate::model::FileId;
 use crate::output::shard::error::ShardError;
 
 pub(crate) fn node_belongs_to_file(graph: &CodeGraph, node_index: NodeIndex, path: &Path) -> bool {
@@ -18,133 +19,168 @@ pub(crate) fn node_belongs_to_file(graph: &CodeGraph, node_index: NodeIndex, pat
     }
 }
 
-pub(crate) fn stable_node_name(
-    graph: &CodeGraph,
-    node_index: NodeIndex,
-) -> Result<String, ShardError> {
-    let node = graph
-        .graph()
-        .node_weight(node_index)
-        .ok_or(ShardError::MissingNodeOwner {
-            node_index: node_index.index(),
-        })?;
-    match node {
-        NodeData::File(file) => Ok(format!(
-            "{} file {}",
-            file.language.as_ref(),
-            escape_component(&normalized_path(&file.path)?)
-        )),
-        NodeData::Symbol(_) => stable_symbol_name(graph, node_index),
-        NodeData::External(external) => Ok(format!(
-            "{} external {}",
-            external.language.as_ref(),
-            escape_component(&external.raw_path)
-        )),
-        NodeData::Data(_) => Err(ShardError::MissingNodeOwner {
-            node_index: node_index.index(),
-        }),
-    }
+/// Stable names for every node of one graph.
+///
+/// A shard export needs one name per edge endpoint, and a shard restore needs
+/// one per node. Answering a single lookup rescans the graph (parent and
+/// ordinal search), so the scan happens once here: parents come from a stack
+/// over range-sorted symbols, and ordinals from one sort per
+/// (parent, name, kind) group.
+pub(crate) struct StableNameIndex {
+    names: HashMap<NodeIndex, String>,
 }
 
-pub(crate) fn stable_symbol_name(
-    graph: &CodeGraph,
-    node_index: NodeIndex,
-) -> Result<String, ShardError> {
-    let NodeData::Symbol(symbol) = &graph.graph()[node_index] else {
-        return Err(ShardError::MissingNodeOwner {
-            node_index: node_index.index(),
-        });
-    };
-    let file = graph
-        .file_node(symbol.file_id)
-        .ok_or(ShardError::MissingNodeOwner {
-            node_index: node_index.index(),
-        })?;
-    let mut hierarchy = Vec::new();
-    let mut current = Some(node_index);
-    while let Some(index) = current {
-        hierarchy.push(index);
-        current = parent_symbol(graph, index);
-    }
-    hierarchy.reverse();
+impl StableNameIndex {
+    pub(crate) fn new(graph: &CodeGraph) -> Result<Self, ShardError> {
+        let missing = |index: NodeIndex| ShardError::MissingNodeOwner {
+            node_index: index.index(),
+        };
+        let g = graph.graph();
 
-    let descriptors = hierarchy
-        .into_iter()
-        .map(|index| symbol_descriptor(graph, index))
-        .collect::<Vec<_>>()
-        .join(" . ");
-    Ok(format!(
-        "{} {} . {} .",
-        file.language.as_ref(),
-        escape_component(&normalized_path(&file.path)?),
-        descriptors
-    ))
-}
-
-pub(crate) fn symbol_descriptor(graph: &CodeGraph, node_index: NodeIndex) -> String {
-    let NodeData::Symbol(symbol) = &graph.graph()[node_index] else {
-        return String::new();
-    };
-    let parent = parent_symbol(graph, node_index);
-    let ordinal = graph
-        .graph()
-        .node_indices()
-        .filter(|candidate_index| {
-            if *candidate_index == node_index {
-                return false;
+        // Range and identity of every symbol, and the symbols of each file.
+        let mut ranges: HashMap<NodeIndex, (usize, usize, u32)> = HashMap::new();
+        let mut by_file: HashMap<FileId, Vec<NodeIndex>> = HashMap::new();
+        let mut names: HashMap<NodeIndex, String> = HashMap::new();
+        for index in g.node_indices() {
+            match &g[index] {
+                NodeData::File(file) => {
+                    names.insert(
+                        index,
+                        format!(
+                            "{} file {}",
+                            file.language.as_ref(),
+                            escape_component(&normalized_path(&file.path)?)
+                        ),
+                    );
+                }
+                NodeData::External(external) => {
+                    names.insert(
+                        index,
+                        format!(
+                            "{} external {}",
+                            external.language.as_ref(),
+                            escape_component(&external.raw_path)
+                        ),
+                    );
+                }
+                NodeData::Symbol(symbol) => {
+                    ranges.insert(
+                        index,
+                        (
+                            symbol.source_range.byte_start,
+                            symbol.source_range.byte_end,
+                            symbol.id.to_raw(),
+                        ),
+                    );
+                    by_file.entry(symbol.file_id).or_default().push(index);
+                }
+                NodeData::Data(_) => {}
             }
-            let NodeData::Symbol(candidate) = &graph.graph()[*candidate_index] else {
-                return false;
+        }
+
+        let mut parents: HashMap<NodeIndex, Option<NodeIndex>> = HashMap::new();
+        let mut ordinals: HashMap<NodeIndex, usize> = HashMap::new();
+        for group in by_file.values_mut() {
+            // Outermost first: by start, then by the wider range.
+            group.sort_by_key(|index| {
+                let (start, end, id) = ranges.get(index).copied().unwrap_or_default();
+                (start, std::cmp::Reverse(end), id)
+            });
+
+            // A symbol's parent is the nearest enclosing symbol. The stack
+            // holds the enclosing chain of the previous symbol.
+            let mut stack: Vec<NodeIndex> = Vec::new();
+            for &index in group.iter() {
+                let (start, end, _) = ranges.get(&index).copied().unwrap_or_default();
+                while let Some(&candidate) = stack.last() {
+                    let (candidate_start, candidate_end, _) =
+                        ranges.get(&candidate).copied().unwrap_or_default();
+                    let contains = candidate_start <= start
+                        && candidate_end >= end
+                        && (candidate_start < start || candidate_end > end);
+                    if contains {
+                        break;
+                    }
+                    stack.pop();
+                }
+                parents.insert(index, stack.last().copied());
+                stack.push(index);
+            }
+
+            // Ordinal: position among the symbols that share a parent, a name
+            // and a kind, ordered by range and then by identifier.
+            let mut same_name: HashMap<(Option<NodeIndex>, String, &'static str), Vec<NodeIndex>> =
+                HashMap::new();
+            for &index in group.iter() {
+                let NodeData::Symbol(symbol) = &g[index] else {
+                    return Err(missing(index));
+                };
+                same_name
+                    .entry((
+                        parents.get(&index).copied().flatten(),
+                        symbol.name.clone(),
+                        symbol.kind.as_str(),
+                    ))
+                    .or_default()
+                    .push(index);
+            }
+            for members in same_name.values_mut() {
+                members.sort_by_key(|index| ranges.get(index).copied().unwrap_or_default());
+                for (ordinal, &index) in members.iter().enumerate() {
+                    ordinals.insert(index, ordinal);
+                }
+            }
+        }
+
+        for &index in ranges.keys() {
+            let NodeData::Symbol(symbol) = &g[index] else {
+                return Err(missing(index));
             };
-            if candidate.file_id != symbol.file_id
-                || candidate.name != symbol.name
-                || candidate.kind != symbol.kind
-            {
-                return false;
-            }
-            if parent_symbol(graph, *candidate_index) != parent {
-                return false;
-            }
-            candidate.source_range.byte_start < symbol.source_range.byte_start
-                || (candidate.source_range.byte_start == symbol.source_range.byte_start
-                    && (candidate.source_range.byte_end < symbol.source_range.byte_end
-                        || (candidate.source_range.byte_end == symbol.source_range.byte_end
-                            && candidate.id < symbol.id)))
-        })
-        .count();
-    format!(
-        "{}#{}!{ordinal}",
-        escape_component(&symbol.name),
-        symbol_kind_name(symbol.kind)
-    )
-}
+            let file = graph
+                .file_node(symbol.file_id)
+                .ok_or_else(|| missing(index))?;
 
-pub(crate) fn parent_symbol(graph: &CodeGraph, node_index: NodeIndex) -> Option<NodeIndex> {
-    let NodeData::Symbol(symbol) = &graph.graph()[node_index] else {
-        return None;
-    };
-    graph
-        .graph()
-        .node_indices()
-        .filter(|candidate_index| *candidate_index != node_index)
-        .filter_map(|candidate_index| {
-            let NodeData::Symbol(candidate) = &graph.graph()[candidate_index] else {
-                return None;
-            };
-            let contains = candidate.file_id == symbol.file_id
-                && candidate.source_range.byte_start <= symbol.source_range.byte_start
-                && candidate.source_range.byte_end >= symbol.source_range.byte_end
-                && (candidate.source_range.byte_start < symbol.source_range.byte_start
-                    || candidate.source_range.byte_end > symbol.source_range.byte_end);
-            contains.then_some((
-                candidate.source_range.byte_end - candidate.source_range.byte_start,
-                candidate.source_range.byte_start,
-                candidate.source_range.byte_end,
-                candidate_index,
-            ))
-        })
-        .min_by_key(|(span, start, end, _)| (*span, *start, *end))
-        .map(|(_, _, _, index)| index)
+            let mut hierarchy = vec![index];
+            let mut ancestor = parents.get(&index).copied().flatten();
+            while let Some(current) = ancestor {
+                hierarchy.push(current);
+                ancestor = parents.get(&current).copied().flatten();
+            }
+            hierarchy.reverse();
+
+            let descriptors = hierarchy
+                .iter()
+                .map(|&current| {
+                    let NodeData::Symbol(ancestor_symbol) = &g[current] else {
+                        return String::new();
+                    };
+                    format!(
+                        "{}#{}!{}",
+                        escape_component(&ancestor_symbol.name),
+                        ancestor_symbol.kind.as_str(),
+                        ordinals.get(&current).copied().unwrap_or_default()
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join(" . ");
+            names.insert(
+                index,
+                format!(
+                    "{} {} . {} .",
+                    file.language.as_ref(),
+                    escape_component(&normalized_path(&file.path)?),
+                    descriptors
+                ),
+            );
+        }
+
+        Ok(Self { names })
+    }
+
+    /// Stable name of a node. `None` for a data node or an unknown index.
+    pub(crate) fn name_of(&self, node_index: NodeIndex) -> Option<&str> {
+        self.names.get(&node_index).map(String::as_str)
+    }
 }
 
 pub(crate) fn normalized_path(path: &Path) -> Result<String, ShardError> {
@@ -170,23 +206,4 @@ pub(crate) fn escape_component(value: &str) -> String {
         }
     }
     escaped
-}
-
-pub(crate) fn symbol_kind_name(kind: SymbolKind) -> &'static str {
-    match kind {
-        SymbolKind::Function => "function",
-        SymbolKind::Method => "method",
-        SymbolKind::Class => "class",
-        SymbolKind::Struct => "struct",
-        SymbolKind::Interface => "interface",
-        SymbolKind::Trait => "trait",
-        SymbolKind::Enum => "enum",
-        SymbolKind::Object => "object",
-        SymbolKind::Constant => "constant",
-        SymbolKind::Static => "static",
-        SymbolKind::Module => "module",
-        SymbolKind::Namespace => "namespace",
-        SymbolKind::TypeAlias => "type_alias",
-        SymbolKind::Declaration => "declaration",
-    }
 }


### PR DESCRIPTION
## Summary

Kinds and visibility had three spellings: the graph writer used the Rust variant name, the shard and inspect writers inherited it through serde, and the stable-name writer used lowercase. The documented form is lowercase, so:

- `SymbolKind::as_str` and `Visibility::as_str` are the single source, and the model enums serialize in snake_case.
- `SHARD_SCHEMA_VERSION` moves to 4, because the persisted encoding changed. A reader refuses a version it does not know, and the skip reason now names it: previously a schema mismatch was counted as a stale file, so a reader could index nothing and report no error.
- Stable names rescanned the graph per symbol for the parent and the ordinal, so an export cost an O(nodes) scan per edge endpoint and a restore repeated it per node. `StableNameIndex` builds every name in one pass: parents from a stack over range-sorted symbols, ordinals from one sort per (parent, name, kind) group.

Also correct the structure notes the language work invalidated: the warning covers any error tree, `.h` and `.hpp` are in the catalog, and the resolver set is Python, Go and Node with a per-build lifetime.

## Type of change

- [x] `fix` - bug fix
- [x] `perf` - performance improvement

## Affected area

- [x] `model` / ids
- [x] `output`
- [x] `docs` / `tests`

## Public contract impact

- [x] Public contract changed; `docs/` updated (shard schema version and lowercase kinds recorded in the graph model spec)

## Verification

- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo +1.94.0 fmt --check` passes
- [x] `cargo nextest run --all-features` passes for this level (1 of the 17 base failures remains, owned by the PR above)
- [x] Snapshot changes reviewed with `cargo insta` and `.snap` files committed

## Notes for reviewers

An index written by 0.7.0 must be regenerated; the reader refuses version 3 and reports the reason. The existing shard tests pin the produced stable names, which is the equivalence check for the index rewrite.
