### PR TITLE
fix(cli): give the datagraph its own output path

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Builds the cross-file dependency graph, resolves imports, and runs Tarjan SCC to
 meta-ast graph <path> [-l language] [-f json|yaml] [-o graph.json]
 meta-ast graph <path> --html                    # interactive Cytoscape.js dashboard (CDN, browser-cached)
 meta-ast graph <path> --datagraph               # export detailed datagraph.json (requires --features dataflow)
+meta-ast graph <path> --datagraph --datagraph-output dg.json   # choose the datagraph path
 meta-ast graph <path> --watch                   # watch mode: continuous re-analysis on file changes (requires --features watch)
 meta-ast graph <path> --watch --watch-debounce 100 --html -o graph.html
 ```
@@ -183,7 +184,7 @@ meta-ast deploy <path> --check                  # CI validation: verify every cu
 Generates two artifacts:
 
 | File | Description |
-|---|---|
+| --- | --- |
 | `metacall.pods.json` | Pod manifest: language-based deployment units, inter-pod edges with confidence scores, per-pod dependency lists with pinned versions, and AST node metrics |
 | `metacall.mesh.json` | SCC-derived Function Mesh topology annotation with cross-language call-site attribution |
 
@@ -196,7 +197,7 @@ See [docs/src/DEPLOY.md](docs/src/DEPLOY.md) for scanner details, confidence sco
 ## Documentation
 
 | Document | Description |
-|---|---|
+| --- | --- |
 | [docs/src/DEMO.md](docs/src/DEMO.md) | Recorded walkthroughs of every subcommand (GIFs) |
 | [docs/src/BENCHMARKS.md](docs/src/BENCHMARKS.md) | Criterion benchmark results |
 | [docs/src/FINAL_REPORT.md](docs/src/FINAL_REPORT.md) | GSoC 2026 completion report |
@@ -216,7 +217,6 @@ All docs are also published as an [mdbook site](https://metacall.github.io/meta-
 ## Roadmap
 
 The core GSoC 2026 milestones (Phases 1-7) are complete with release `v0.5.0`. Full details and post-v1 initiatives are tracked in [docs/src/ROADMAP.md](docs/src/ROADMAP.md).
-
 
 ### Post-v1 Active Roadmap
 

--- a/docs/src/STRUCTURE.md
+++ b/docs/src/STRUCTURE.md
@@ -71,7 +71,7 @@ src/
 │
 └── interface/                CLI layer
     ├── mod.rs                CLI module root
-    └── args.rs               Clap derive structs (Inspect, Graph, Deploy + -l, --format, --html, --datagraph, --watch, --watch-debounce, -o, --check)
+    └── args.rs               Clap derive structs (Inspect, Graph, Deploy + -l, --format, --html, --datagraph, --datagraph-output, --watch, --watch-debounce, -o, --check)
 │
 ├── watch/                     [feature: watch]
 │   └── mod.rs                 IncrementalCache, WatchState, incremental_reanalyze, run_watch

--- a/src/interface/args.rs
+++ b/src/interface/args.rs
@@ -90,10 +90,15 @@ pub struct GraphArgs {
     #[arg(long)]
     pub html: bool,
 
-    /// Also emit a portable datagraph.json export (requires --features dataflow)
+    /// Also emit a portable datagraph export (requires --features dataflow)
     #[cfg(feature = "dataflow")]
     #[arg(long)]
     pub datagraph: bool,
+
+    /// Output file for the datagraph export (defaults to <output stem>.datagraph.json)
+    #[cfg(feature = "dataflow")]
+    #[arg(long)]
+    pub datagraph_output: Option<std::path::PathBuf>,
 
     /// Enter watch mode: monitor the project and re-analyze on file changes
     #[cfg(feature = "watch")]

--- a/src/interface/args.rs
+++ b/src/interface/args.rs
@@ -95,7 +95,7 @@ pub struct GraphArgs {
     #[arg(long)]
     pub datagraph: bool,
 
-    /// Output file for the datagraph export (defaults to <output stem>.datagraph.json)
+    /// Output file for the datagraph export (defaults to the graph output name plus `.datagraph.json`)
     #[cfg(feature = "dataflow")]
     #[arg(long)]
     pub datagraph_output: Option<std::path::PathBuf>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -161,9 +161,21 @@ fn main() -> anyhow::Result<()> {
                     "Exporting datagraph"
                 );
 
-                let output_path = args
-                    .output
-                    .unwrap_or_else(|| std::path::PathBuf::from("datagraph.json"));
+                // The datagraph has its own path. Reusing -o would make the two
+                // exports overwrite each other, and deriving only the file name
+                // would drop the graph output's directory.
+                let output_path = match (&args.datagraph_output, &args.output) {
+                    (Some(explicit), _) => explicit.clone(),
+                    (None, Some(graph_output)) => {
+                        let stem = graph_output
+                            .file_stem()
+                            .map(|stem| stem.to_string_lossy().to_string())
+                            .unwrap_or_else(|| "datagraph".to_string());
+                        graph_output.with_file_name(format!("{stem}.datagraph.json"))
+                    }
+                    (None, None) => std::path::PathBuf::from("datagraph.json"),
+                };
+                tracing::info!(path = %output_path.display(), "Writing datagraph export");
                 let sink = meta_ast::sink::JsonSink::new(Some(output_path));
                 sink.emit(&export)?;
             }

--- a/tests/integration/datagraph_test.rs
+++ b/tests/integration/datagraph_test.rs
@@ -290,36 +290,53 @@ fn sink_json_writes_datagraph_to_file() {
     let _ = std::fs::remove_file(&temp);
 }
 
-/// The datagraph export must not overwrite the graph output.
+/// The datagraph export must not reuse the graph output path.
 #[cfg(feature = "dataflow")]
 #[test]
 fn datagraph_has_its_own_output_path() {
+    let run = |datagraph_output: Option<&std::path::Path>, graph_output: &std::path::Path| {
+        let mut command = std::process::Command::new(env!("CARGO_BIN_EXE_meta-ast"));
+        command
+            .arg("graph")
+            .arg("tests/fixtures/python")
+            .arg("--datagraph")
+            .arg("-o")
+            .arg(graph_output)
+            .arg("-f")
+            .arg("json")
+            .current_dir(env!("CARGO_MANIFEST_DIR"));
+        if let Some(path) = datagraph_output {
+            command.arg("--datagraph-output").arg(path);
+        }
+        command.output().unwrap()
+    };
+
     let temp = tempfile::tempdir().unwrap();
+
+    // Without an explicit path the datagraph derives one from the graph
+    // output, so the graph output is never the file that the datagraph wrote.
     let graph_path = temp.path().join("graph.json");
-    let datagraph_path = temp.path().join("datagraph.json");
-
-    let output = std::process::Command::new(env!("CARGO_BIN_EXE_meta-ast"))
-        .arg("graph")
-        .arg("tests/fixtures/python")
-        .arg("--datagraph")
-        .arg("--datagraph-output")
-        .arg(&datagraph_path)
-        .arg("-o")
-        .arg(&graph_path)
-        .arg("-f")
-        .arg("json")
-        .current_dir(env!("CARGO_MANIFEST_DIR"))
-        .output()
-        .unwrap();
-
+    let output = run(None, &graph_path);
     assert!(
         output.status.success(),
         "graph run failed: {}",
         String::from_utf8_lossy(&output.stderr)
     );
     assert!(graph_path.is_file(), "the graph output is written");
-    assert!(datagraph_path.is_file(), "the datagraph output is written");
-    let graph = std::fs::read_to_string(&graph_path).unwrap();
-    let datagraph = std::fs::read_to_string(&datagraph_path).unwrap();
-    assert_ne!(graph, datagraph, "both outputs hold their own payload");
+    assert!(
+        temp.path().join("graph.datagraph.json").is_file(),
+        "the datagraph is written beside the graph output"
+    );
+
+    // An explicit datagraph path is used as given.
+    let explicit = temp.path().join("dg.json");
+    let second_graph = temp.path().join("graph2.json");
+    let output = run(Some(&explicit), &second_graph);
+    assert!(
+        output.status.success(),
+        "graph run failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(explicit.is_file(), "the explicit datagraph path is written");
+    assert!(second_graph.is_file(), "the graph output is written");
 }


### PR DESCRIPTION
## Summary

`--datagraph` wrote to `-o`, so a run that asked for both exports overwrote one with the other. Add `--datagraph-output`, and derive the default from the graph output path with a `.datagraph.json` suffix in the same directory. Without `-o` the default stays `datagraph.json`.

## Type of change

- [x] `fix` - bug fix

## Affected area

- [x] `interface` (CLI)
- [x] `dataflow` (feature)
- [x] `docs` / `tests`

## Public contract impact

- [x] Public contract changed; `docs/` updated (new CLI flag, README example)

## Verification

- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo nextest run --all-features` passes (584 tests)
- [x] `cargo +1.94.0 fmt --check` passes

## Notes for reviewers

The regression test first asserted that the two documents differ, which could not observe the defect because both exports carry the same payload today; it now checks the path derivation instead.
