### PR TITLE
test(audit): pin watch, graph, deploy and CLI defects

### DIFF
--- a/src/deploy/client_call.rs
+++ b/src/deploy/client_call.rs
@@ -832,4 +832,25 @@ mod tests {
         );
         assert!(resolution.diagnostics.is_empty());
     }
+
+    /// A script path written with Windows separators must resolve on Unix.
+    #[test]
+    fn windows_script_separators_resolve_on_unix() {
+        let dir = std::env::temp_dir().join("meta_ast_script_separator");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("sub")).unwrap();
+        let util = dir.join("sub").join("util.js");
+        std::fs::write(&util, "export const x = 1;\n").unwrap();
+
+        let path_to_idx =
+            std::collections::HashMap::from([(util.clone(), petgraph::graph::NodeIndex::new(0))]);
+        let source = dir.join("app.py");
+
+        let resolved = resolve_script_to_file(&dir, "sub\\util.js", &source, &path_to_idx);
+        assert!(
+            resolved.is_some(),
+            "a Windows-authored script path must resolve on Unix"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }

--- a/src/deploy/cut.rs
+++ b/src/deploy/cut.rs
@@ -286,6 +286,53 @@ mod tests {
     }
 
     #[test]
+    fn cross_language_cut_names_the_files_not_ids() {
+        let mut graph = CodeGraph::new(SnapshotId::new(1).unwrap());
+        let py_id = FileId::new(1).unwrap();
+        let go_id = FileId::new(2).unwrap();
+        let py_idx = graph.add_node(NodeData::File(FileNode::new(
+            py_id,
+            PathBuf::from("orch.py"),
+            LangId::Python,
+            SnapshotId::new(1).unwrap(),
+        )));
+        let go_idx = graph.add_node(NodeData::File(FileNode::new(
+            go_id,
+            PathBuf::from("auth.go"),
+            LangId::Go,
+            SnapshotId::new(1).unwrap(),
+        )));
+        graph.file_to_index.insert(py_id, py_idx);
+        graph.file_to_index.insert(go_id, go_idx);
+        graph.add_edge_normalized(py_idx, go_idx, EdgeKind::Import, 1.0);
+        graph.add_edge_normalized(go_idx, py_idx, EdgeKind::Import, 1.0);
+
+        let scc = SccAnalysis::analyze(graph.graph());
+        let mut file_languages: HashMap<FileId, LangId> = HashMap::new();
+        file_languages.insert(py_id, LangId::Python);
+        file_languages.insert(go_id, LangId::Go);
+        let partition = partition_into_pods(&graph);
+        let cuts = find_cross_language_cuts(&scc, &graph, &file_languages, &partition);
+        let cut = cuts
+            .into_iter()
+            .find(|c| matches!(c.annotation.cut_reason, CutReason::CrossLanguageScc))
+            .expect("cross-language cycle must produce a CrossLanguageScc cut");
+
+        // ADR 0003 traceability: the annotation must name the cut files so a
+        // reader can find them. A numeric FileId is not traceable.
+        assert!(
+            cut.annotation.from_file.ends_with("orch.py"),
+            "from_file must be the source path, got {:?}",
+            cut.annotation.from_file
+        );
+        assert!(
+            cut.annotation.to_file.ends_with("auth.go"),
+            "to_file must be the target path, got {:?}",
+            cut.annotation.to_file
+        );
+    }
+
+    #[test]
     fn cross_language_cycle_produces_scc_cut() {
         let mut graph = CodeGraph::new(SnapshotId::new(1).unwrap());
         let py_id = FileId::new(1).unwrap();

--- a/src/deploy/dependency.rs
+++ b/src/deploy/dependency.rs
@@ -474,6 +474,22 @@ mod tests {
         }
     }
 
+    fn python_node(raw_path: &str) -> ExternalNode {
+        ExternalNode {
+            raw_path: raw_path.to_string(),
+            language: LangId::Python,
+            classification: None,
+        }
+    }
+
+    fn go_node(raw_path: &str) -> ExternalNode {
+        ExternalNode {
+            raw_path: raw_path.to_string(),
+            language: LangId::Go,
+            classification: None,
+        }
+    }
+
     fn test_dir(name: &str) -> std::path::PathBuf {
         let dir = std::env::temp_dir().join(format!("meta_ast_ruby_dep_{name}"));
         if dir.exists() {
@@ -539,5 +555,103 @@ mod tests {
             }
             other => panic!("expected Unresolved, got {other:?}"),
         }
+    }
+
+    /// A lockfile entry name must match the package exactly, not as a substring.
+    #[test]
+    fn lockfile_match_requires_the_exact_entry() {
+        let dir = test_dir("lockfile_boundary");
+        let lf = dir.join("uv.lock");
+        std::fs::write(
+            &lf,
+            "[[package]]\nname = \"requests-toolbelt\"\nversion = \"4.0.0\"\n",
+        )
+        .unwrap();
+
+        assert_eq!(
+            parse_version_from_lockfile(&lf, "requests"),
+            None,
+            "requests must not match the requests-toolbelt entry"
+        );
+        assert_eq!(
+            parse_version_from_lockfile(&lf, "requests-toolbelt").as_deref(),
+            Some("4.0.0")
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A lockfile that does not list the package must not be reported as the
+    /// source of a resolved dependency.
+    #[test]
+    fn lockfile_without_the_entry_is_not_a_lockfile_hit() {
+        let dir = test_dir("lockfile_missing_entry");
+        std::fs::write(
+            dir.join("uv.lock"),
+            "[[package]]\nname = \"requests-toolbelt\"\nversion = \"4.0.0\"\n",
+        )
+        .unwrap();
+
+        let classification = classify_python(&python_node("requests"), &dir);
+        assert!(
+            !matches!(
+                classification,
+                ExternalClassification::Classified {
+                    source: DependencySource::Lockfile,
+                    ..
+                }
+            ),
+            "an entry the lockfile does not contain is not a lockfile hit: {classification:?}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A go.sum module path must match exactly, not as a prefix.
+    #[test]
+    fn go_sum_requires_an_exact_module_path() {
+        let dir = test_dir("go_sum_boundary");
+        let lf = dir.join("go.sum");
+        std::fs::write(&lf, "github.com/foo/bar/baz v1.0.0 h1:AAAA=\n").unwrap();
+
+        assert_eq!(
+            parse_version_from_go_sum(&lf, "github.com/foo/bar"),
+            None,
+            "a prefix must not match a different module"
+        );
+        assert_eq!(
+            parse_version_from_go_sum(&lf, "github.com/foo/bar/baz").as_deref(),
+            Some("v1.0.0")
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// go.mod `require` lines carry the version.
+    #[test]
+    fn go_mod_require_line_yields_a_version() {
+        let dir = test_dir("go_mod_require");
+        std::fs::write(
+            dir.join("go.mod"),
+            "module example.com/app\n\ngo 1.21\n\nrequire github.com/foo/bar v1.2.3\n",
+        )
+        .unwrap();
+
+        let classification = classify_go(&go_node("github.com/foo/bar"), &dir);
+        match classification {
+            ExternalClassification::Classified {
+                version,
+                language,
+                source,
+                ..
+            } => {
+                assert_eq!(language, LangId::Go);
+                assert_eq!(source, DependencySource::Manifest);
+                let version = version.unwrap_or_default();
+                assert!(
+                    version.contains("1.2.3"),
+                    "the go.mod require version must be read, got {version:?}"
+                );
+            }
+            other => panic!("expected Classified, got {other:?}"),
+        }
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/src/deploy/manifest.rs
+++ b/src/deploy/manifest.rs
@@ -177,3 +177,131 @@ pub fn generate_pod_manifest(
         },
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::deploy::cut::{CutAnnotation, CutReason};
+    use crate::deploy::metrics::PodMetrics;
+    use crate::deploy::pod::{InterPodEdge, Pod, PodPartition};
+    use crate::graph::EdgeKind;
+    use crate::graph::node::{FileNode, NodeData};
+    use crate::language::LangId;
+    use crate::model::ids::{FileId, SnapshotId};
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+
+    fn test_partition() -> (PodPartition, CodeGraph) {
+        let mut graph = CodeGraph::new(SnapshotId::new(1).unwrap());
+        let py = FileId::new(1).unwrap();
+        let js = FileId::new(2).unwrap();
+        for (fid, path, lang) in [
+            (py, "a.py", LangId::Python),
+            (js, "b.js", LangId::JavaScript),
+        ] {
+            let idx = graph.add_node(NodeData::File(FileNode::new(
+                fid,
+                PathBuf::from(path),
+                lang,
+                SnapshotId::new(1).unwrap(),
+            )));
+            graph.file_to_index.insert(fid, idx);
+        }
+
+        let partition = PodPartition {
+            pods: vec![
+                Pod {
+                    id: 0,
+                    files: vec![py],
+                    language: LangId::Python,
+                },
+                Pod {
+                    id: 1,
+                    files: vec![js],
+                    language: LangId::JavaScript,
+                },
+            ],
+            inter_pod_edges: vec![InterPodEdge {
+                from_pod: 0,
+                to_pod: 1,
+                from_file: py,
+                to_file: js,
+                kind: EdgeKind::Import,
+                confidence: 0.6,
+                is_cross_language: true,
+            }],
+            file_languages: HashMap::from([(py, LangId::Python), (js, LangId::JavaScript)]),
+        };
+        (partition, graph)
+    }
+
+    fn cut(reason: CutReason, confidence: f32) -> CutEdge {
+        CutEdge {
+            from_pod: 0,
+            to_pod: 1,
+            annotation: CutAnnotation {
+                from_file: "a.py".to_string(),
+                to_file: "b.js".to_string(),
+                cut_reason: reason,
+                original_confidence: confidence,
+            },
+        }
+    }
+
+    /// Two cuts on one pod pair must surface as a single rpc_stub edge and keep
+    /// both annotations.
+    #[test]
+    fn two_cuts_on_one_pod_pair_emit_one_rpc_stub() {
+        let (partition, graph) = test_partition();
+        let metrics = vec![
+            PodMetrics {
+                total_ast_nodes: 1,
+                file_count: 1,
+                symbol_count: 0,
+            },
+            PodMetrics {
+                total_ast_nodes: 1,
+                file_count: 1,
+                symbol_count: 0,
+            },
+        ];
+        let cuts = vec![
+            cut(CutReason::CrossLanguageScc, 0.6),
+            cut(
+                CutReason::OversizedPod {
+                    pod_size: 4,
+                    max_size: 3,
+                },
+                0.3,
+            ),
+        ];
+
+        let manifest = generate_pod_manifest(&partition, &metrics, &cuts, &HashMap::new(), &graph);
+
+        let stubs: Vec<&ManifestEdge> = manifest
+            .edges
+            .iter()
+            .filter(|e| e.kind == "rpc_stub")
+            .collect();
+        assert_eq!(
+            stubs.len(),
+            1,
+            "one rpc_stub per pod pair, got {}: {:?}",
+            stubs.len(),
+            stubs
+                .iter()
+                .map(|e| (e.from_pod, e.to_pod))
+                .collect::<Vec<_>>()
+        );
+
+        let json = serde_json::to_string(&manifest).unwrap();
+        assert!(
+            json.contains("CrossLanguageScc"),
+            "the SCC cut annotation must survive"
+        );
+        assert!(
+            json.contains("OversizedPod"),
+            "the oversized cut annotation must survive"
+        );
+    }
+}

--- a/src/deploy/metrics.rs
+++ b/src/deploy/metrics.rs
@@ -88,3 +88,68 @@ pub fn compute_pod_metrics(
     }
     pod_metrics
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::deploy::pod::{Pod, PodPartition};
+    use crate::graph::node::{FileNode, NodeData};
+    use crate::language::LangId;
+    use crate::model::ids::{FileId, SnapshotId};
+    use std::collections::HashMap;
+
+    /// The aggregate must saturate instead of overflowing.
+    #[test]
+    fn pod_metrics_total_saturates() {
+        let mut graph = CodeGraph::new(SnapshotId::new(1).unwrap());
+        let a = FileId::new(1).unwrap();
+        let b = FileId::new(2).unwrap();
+        for (fid, path) in [(a, "a.py"), (b, "b.py")] {
+            let idx = graph.add_node(NodeData::File(FileNode::new(
+                fid,
+                PathBuf::from(path),
+                LangId::Python,
+                SnapshotId::new(1).unwrap(),
+            )));
+            graph.file_to_index.insert(fid, idx);
+        }
+
+        let partition = PodPartition {
+            pods: vec![Pod {
+                id: 0,
+                files: vec![a, b],
+                language: LangId::Python,
+            }],
+            inter_pod_edges: Vec::new(),
+            file_languages: HashMap::from([(a, LangId::Python), (b, LangId::Python)]),
+        };
+        let file_metrics = HashMap::from([
+            (
+                PathBuf::from("a.py"),
+                FileMetrics {
+                    ast_node_count: usize::MAX,
+                    symbol_count: 0,
+                    import_count: 0,
+                    reference_count: 0,
+                },
+            ),
+            (
+                PathBuf::from("b.py"),
+                FileMetrics {
+                    ast_node_count: usize::MAX,
+                    symbol_count: 0,
+                    import_count: 0,
+                    reference_count: 0,
+                },
+            ),
+        ]);
+
+        let metrics = compute_pod_metrics(&partition, &file_metrics, &graph);
+        assert_eq!(metrics.len(), 1);
+        assert_eq!(
+            metrics[0].total_ast_nodes,
+            usize::MAX,
+            "the aggregate must saturate, not overflow"
+        );
+    }
+}

--- a/src/deploy/pod.rs
+++ b/src/deploy/pod.rs
@@ -396,4 +396,45 @@ mod tests {
         assert_eq!(partition.inter_pod_edges.len(), 1);
         assert_eq!(partition.inter_pod_edges[0].confidence, 1.0);
     }
+
+    /// A symbol whose file has no file node must not panic the partition pass.
+    #[test]
+    fn partition_skips_symbols_with_a_missing_file_node() {
+        let mut graph = CodeGraph::new(SnapshotId::new(1).unwrap());
+        let real = FileId::new(1).unwrap();
+        let real_idx = graph.add_node(NodeData::File(FileNode::new(
+            real,
+            PathBuf::from("a.py"),
+            LangId::Python,
+            SnapshotId::new(1).unwrap(),
+        )));
+        graph.file_to_index.insert(real, real_idx);
+
+        // A symbol from a file that the partition does not know about.
+        let stale_file = FileId::new(99).unwrap();
+        let stale_sym = graph.add_node(NodeData::Symbol(SymbolNode {
+            id: SymbolId::new(501).unwrap(),
+            name: "stale".to_string(),
+            kind: SymbolKind::Function,
+            file_id: stale_file,
+            visibility: None,
+            source_range: test_range(),
+        }));
+        let real_sym = graph.add_node(NodeData::Symbol(SymbolNode {
+            id: SymbolId::new(502).unwrap(),
+            name: "real".to_string(),
+            kind: SymbolKind::Function,
+            file_id: real,
+            visibility: None,
+            source_range: test_range(),
+        }));
+        graph.add_edge_normalized(stale_sym, real_sym, EdgeKind::Reference, 0.5);
+
+        let partition = partition_into_pods(&graph);
+        assert_eq!(partition.pods.len(), 1, "only the known file forms a pod");
+        assert!(
+            !partition.pods[0].files.contains(&stale_file),
+            "the stale symbol's file must not enter a pod"
+        );
+    }
 }

--- a/src/deploy/scanner.rs
+++ b/src/deploy/scanner.rs
@@ -741,4 +741,75 @@ mod tests {
         let sites = scan_file(LangId::Python, &tree, source, Path::new("test.py"));
         assert!(sites.is_empty());
     }
+
+    /// Rust classification must not accept a look-alike helper name, and the
+    /// genuine `metacall::load::*` names must still be detected.
+    #[test]
+    fn test_scan_rust_rejects_lookalike_helpers() {
+        let source = br#"
+fn f() { let a = reader.read_from_file("a"); }
+fn g() { let b = loader.load_from_memory_cache("b"); }
+fn h() { let c = copy_from_file_buffer("c"); }
+fn i() { let d = cache_from_configuration("d"); }
+"#;
+        let tree = parse(LangId::Rust, source);
+        let sites = scan_file(LangId::Rust, &tree, source, Path::new("lib.rs"));
+        assert!(
+            sites.is_empty(),
+            "look-alike helpers must not be MetaCall sites: {:?}",
+            sites
+                .iter()
+                .map(|s| (&s.variant, &s.scripts))
+                .collect::<Vec<_>>()
+        );
+
+        let genuine = b"metacall::load::from_file(Tag::NodeJS, [\"index.js\"], None)";
+        let tree = parse(LangId::Rust, genuine);
+        let sites = scan_file(LangId::Rust, &tree, genuine, Path::new("lib.rs"));
+        assert_eq!(sites.len(), 1, "the real load API must still be detected");
+        assert_eq!(sites[0].variant, CallSiteVariant::LoadFromFile);
+    }
+
+    /// The script-language predicates must accept the full MetaCall client API,
+    /// not only `metacall` and `metacall_await`.
+    #[test]
+    fn test_scan_python_accepts_the_full_client_api() {
+        let source = br#"
+metacallv("multiply", 2, 3)
+metacallt("multiply", "int", "int")
+metacall_no_arg()
+metacall_untyped("multiply", 2, 3)
+metacallfms_await("x")
+metacall_await_s("x", 1)
+"#;
+        let tree = parse(LangId::Python, source);
+        let sites = scan_file(LangId::Python, &tree, source, Path::new("test.py"));
+        let names: Vec<&str> = sites
+            .iter()
+            .filter_map(|s| s.function_name.as_deref().or(s.target_lang.as_deref()))
+            .collect();
+        assert_eq!(
+            sites.len(),
+            6,
+            "every client API name must be scanned, got {names:?}"
+        );
+    }
+
+    /// The Go package selector must match the package exactly.
+    ///
+    /// Two arguments are required: with one argument tree-sitter-go parses
+    /// `pkg.Fn(x)` as a type conversion, not a call.
+    #[test]
+    fn test_scan_go_rejects_a_lookalike_package() {
+        let source = b"metacallmock.Call(\"x\", 1)";
+        let tree = parse(LangId::Go, source);
+        let sites = scan_file(LangId::Go, &tree, source, Path::new("main.go"));
+        assert!(sites.is_empty(), "metacallmock is not the MetaCall package");
+
+        let genuine = b"metacall.Call(\"x\", 1)";
+        let tree = parse(LangId::Go, genuine);
+        let sites = scan_file(LangId::Go, &tree, genuine, Path::new("main.go"));
+        assert_eq!(sites.len(), 1);
+        assert_eq!(sites[0].variant, CallSiteVariant::ClientCall);
+    }
 }

--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -265,6 +265,85 @@ mod tests {
     }
 
     #[test]
+    fn symbol_ids_are_contiguous_in_path_order() {
+        let dir = test_dir().join("numbering");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let mut files = Vec::new();
+        for index in (0..24).rev() {
+            let path = dir.join(format!("f{index:02}.py"));
+            let body: String = (0..5)
+                .map(|n| format!("def g{index}_{n}(): pass\n"))
+                .collect();
+            std::fs::write(&path, body).unwrap();
+            files.push((path, LangId::Python));
+        }
+
+        let result = extract(&files);
+        let mut per_file: Vec<(PathBuf, Vec<u32>)> = result
+            .files
+            .iter()
+            .map(|file| {
+                (
+                    file.path.clone(),
+                    file.symbols.iter().map(|s| s.id.to_raw()).collect(),
+                )
+            })
+            .collect();
+        per_file.sort_by(|a, b| a.0.cmp(&b.0));
+
+        let mut next = 1u32;
+        for (path, ids) in &per_file {
+            assert_eq!(ids.len(), 5, "{}", path.display());
+            assert_eq!(
+                ids.first().copied(),
+                Some(next),
+                "ids of {} must start at {next} in path order",
+                path.display()
+            );
+            let last = ids.last().copied().unwrap();
+            assert_eq!(
+                last,
+                next + ids.len() as u32 - 1,
+                "ids of {} must be contiguous",
+                path.display()
+            );
+            next = last + 1;
+        }
+    }
+
+    #[test]
+    fn symbol_ids_are_stable_across_runs() {
+        let dir = test_dir().join("stable_numbering");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let mut files = Vec::new();
+        for index in 0..8 {
+            let path = dir.join(format!("s{index}.py"));
+            std::fs::write(
+                &path,
+                format!("def h{index}(): pass\ndef k{index}(): pass\n"),
+            )
+            .unwrap();
+            files.push((path, LangId::Python));
+        }
+
+        let map = |result: ExtractionResult| {
+            let mut entries: Vec<(String, u32)> = result
+                .files
+                .iter()
+                .flat_map(|file| file.symbols.iter().map(|s| (s.name.clone(), s.id.to_raw())))
+                .collect();
+            entries.sort();
+            entries
+        };
+
+        assert_eq!(map(extract(&files)), map(extract(&files)));
+    }
+
+    #[test]
     fn extract_single_python_file() {
         let path = write_temp("single.py", b"def hello(): pass\n");
         let result = extract(&[(path.clone(), LangId::Python)]);

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -382,6 +382,61 @@ mod tests {
     }
 
     #[test]
+    fn file_iteration_is_path_sorted() {
+        let mut builder = GraphBuilder::new(SnapshotId::new(1).unwrap());
+        for name in ["e.rs", "a.rs", "d.rs", "b.rs", "c.rs"] {
+            builder.add_file(PathBuf::from(name), LangId::Rust);
+        }
+
+        let graph = builder.build();
+        let paths: Vec<PathBuf> = graph.files().map(|(_, file)| file.path.clone()).collect();
+        let mut sorted = paths.clone();
+        sorted.sort();
+
+        assert_eq!(paths, sorted, "file iteration must be path sorted");
+        let again: Vec<PathBuf> = graph.files().map(|(_, file)| file.path.clone()).collect();
+        assert_eq!(paths, again, "file iteration must be stable");
+    }
+
+    #[test]
+    fn symbol_iteration_is_path_then_name_sorted() {
+        let mut builder = GraphBuilder::new(SnapshotId::new(1).unwrap());
+        let entries = [
+            ("b.rs", 3, "zeta"),
+            ("a.rs", 1, "beta"),
+            ("a.rs", 2, "alpha"),
+            ("c.rs", 4, "gamma"),
+        ];
+        for (path, id, name) in entries.iter() {
+            builder.add_file(PathBuf::from(path), LangId::Rust);
+            let mut symbol = test_symbol(*id, name);
+            symbol.file_path = PathBuf::from(path);
+            builder.add_symbol(&symbol).unwrap();
+        }
+        let mut sorted_entries = entries;
+        sorted_entries.sort_by_key(|(path, _, name)| (*path, *name));
+
+        let graph = builder.build();
+        let ordered: Vec<(String, String)> = graph
+            .symbols()
+            .map(|(_, symbol)| {
+                let path = graph
+                    .file_node(symbol.file_id)
+                    .map(|file| file.path.display().to_string())
+                    .unwrap_or_default();
+                (path, symbol.name.clone())
+            })
+            .collect();
+        let entries = sorted_entries;
+        let expected: Vec<(String, String)> = entries
+            .iter()
+            .map(|(path, _, name)| (path.to_string(), name.to_string()))
+            .collect();
+
+        assert_eq!(ordered, expected, "symbols must be path then name sorted");
+    }
+
+    #[test]
     fn code_graph_iteration_over_symbols() {
         let mut builder = GraphBuilder::new(SnapshotId::new(1).unwrap());
         let _file_id = builder.add_file(PathBuf::from("test.rs"), LangId::Rust);

--- a/src/graph/resolver.rs
+++ b/src/graph/resolver.rs
@@ -646,4 +646,109 @@ mod tests {
         );
         assert_eq!(edges[0].1, SymbolId::new(99).unwrap());
     }
+
+    #[test]
+    fn local_symbol_shadows_the_imported_symbol() {
+        let mut symbol_index: SymbolIndex = HashMap::new();
+        symbol_index.insert(
+            FileId::new(1).unwrap(),
+            vec![(
+                SymbolId::new(10).unwrap(),
+                "helper".into(),
+                LangId::Python,
+                Some(Visibility::Public),
+            )],
+        );
+        symbol_index.insert(
+            FileId::new(2).unwrap(),
+            vec![(
+                SymbolId::new(20).unwrap(),
+                "helper".into(),
+                LangId::Python,
+                Some(Visibility::Public),
+            )],
+        );
+
+        let ctx = ResolutionContext {
+            symbol_index,
+            import_adjacency: HashMap::from([(
+                FileId::new(1).unwrap(),
+                vec![FileId::new(2).unwrap()],
+            )]),
+            file_languages: HashMap::from([
+                (FileId::new(1).unwrap(), LangId::Python),
+                (FileId::new(2).unwrap(), LangId::Python),
+            ]),
+            file_paths: HashMap::from([
+                (FileId::new(1).unwrap(), PathBuf::from("/proj/main.py")),
+                (FileId::new(2).unwrap(), PathBuf::from("/proj/lib.py")),
+            ]),
+        };
+
+        let cache = FlattenedScopeCache::build(&ctx, &mut Vec::new());
+        let matches = cache.resolve(FileId::new(1).unwrap(), "helper").unwrap();
+        assert_eq!(
+            matches.len(),
+            1,
+            "the local definition must shadow the imported one"
+        );
+        assert_eq!(matches[0].0, SymbolId::new(10).unwrap());
+        assert_eq!(matches[0].1, 1.0);
+    }
+
+    #[test]
+    fn imported_candidates_are_ranked_by_path_not_by_id() {
+        let mut symbol_index: SymbolIndex = HashMap::new();
+        symbol_index.insert(FileId::new(1).unwrap(), vec![]);
+        // File 2 sorts before file 3 by path but holds the higher symbol id.
+        symbol_index.insert(
+            FileId::new(2).unwrap(),
+            vec![(
+                SymbolId::new(30).unwrap(),
+                "util".into(),
+                LangId::Python,
+                Some(Visibility::Public),
+            )],
+        );
+        symbol_index.insert(
+            FileId::new(3).unwrap(),
+            vec![(
+                SymbolId::new(20).unwrap(),
+                "util".into(),
+                LangId::Python,
+                Some(Visibility::Public),
+            )],
+        );
+
+        let ctx = ResolutionContext {
+            symbol_index,
+            import_adjacency: HashMap::from([(
+                FileId::new(1).unwrap(),
+                vec![FileId::new(2).unwrap(), FileId::new(3).unwrap()],
+            )]),
+            file_languages: HashMap::from([
+                (FileId::new(1).unwrap(), LangId::Python),
+                (FileId::new(2).unwrap(), LangId::Python),
+                (FileId::new(3).unwrap(), LangId::Python),
+            ]),
+            file_paths: HashMap::from([
+                (FileId::new(1).unwrap(), PathBuf::from("/proj/app.py")),
+                (FileId::new(2).unwrap(), PathBuf::from("/proj/a_util.py")),
+                (FileId::new(3).unwrap(), PathBuf::from("/proj/z_util.py")),
+            ]),
+        };
+
+        let cache = FlattenedScopeCache::build(&ctx, &mut Vec::new());
+        let matches = cache.resolve(FileId::new(1).unwrap(), "util").unwrap();
+        assert_eq!(
+            matches.len(),
+            2,
+            "an ambiguous import keeps both candidates"
+        );
+        assert_eq!(
+            matches[0].0,
+            SymbolId::new(30).unwrap(),
+            "candidate order must follow the file path, not the raw symbol id"
+        );
+    }
 }

--- a/src/reanalyze.rs
+++ b/src/reanalyze.rs
@@ -363,11 +363,6 @@ mod tests {
         std::os::unix::fs::MetadataExt::uid(&std::fs::metadata(path).unwrap()) == 0
     }
 
-    #[cfg(not(unix))]
-    fn writes_as_root(_path: &Path) -> bool {
-        false
-    }
-
     #[test]
     fn cold_analysis_populates_state() {
         let root = temp_dir("cold");
@@ -649,6 +644,8 @@ mod tests {
         assert_eq!(cs.files_added, 0);
     }
 
+    /// Only Unix can deny a read to a normal user.
+    #[cfg(unix)]
     #[test]
     fn read_failure_keeps_the_cached_entry() {
         let root = temp_dir("read_failure");

--- a/src/reanalyze.rs
+++ b/src/reanalyze.rs
@@ -357,6 +357,17 @@ mod tests {
             .collect()
     }
 
+    /// Root ignores file permissions, so the read-failure case cannot run as root.
+    #[cfg(unix)]
+    fn writes_as_root(path: &Path) -> bool {
+        std::os::unix::fs::MetadataExt::uid(&std::fs::metadata(path).unwrap()) == 0
+    }
+
+    #[cfg(not(unix))]
+    fn writes_as_root(_path: &Path) -> bool {
+        false
+    }
+
     #[test]
     fn cold_analysis_populates_state() {
         let root = temp_dir("cold");
@@ -636,6 +647,114 @@ mod tests {
             reanalyze_extractions(&root, None, &[outside], &mut state).unwrap();
         assert!(extractions.is_empty());
         assert_eq!(cs.files_added, 0);
+    }
+
+    #[test]
+    fn read_failure_keeps_the_cached_entry() {
+        let root = temp_dir("read_failure");
+        let a = write_file(&root, "a.py", "def kept(): pass\n");
+
+        let mut state = WatchState::new();
+        let (first, cs, _) = incremental_reanalyze(&root, None, &mut state).unwrap();
+        assert_eq!(cs.files_added, 1);
+        let id_before = first.graph.symbols().next().unwrap().0.to_raw();
+
+        if writes_as_root(&a) {
+            return;
+        }
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&a).unwrap().permissions();
+            perms.set_mode(0o000);
+            std::fs::set_permissions(&a, perms).unwrap();
+        }
+
+        let (_, cs2, diags2) = incremental_reanalyze(&root, None, &mut state).unwrap();
+        assert_eq!(cs2.files_removed, 0, "a read failure is not a removal");
+        assert_eq!(
+            cs2.files_unchanged, 1,
+            "a read failure keeps the cached file"
+        );
+        assert_eq!(state.cache.extractions.len(), 1);
+        assert!(!diags2.is_empty(), "the read failure must be reported");
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&a).unwrap().permissions();
+            perms.set_mode(0o644);
+            std::fs::set_permissions(&a, perms).unwrap();
+        }
+
+        let (third, cs3, _) = incremental_reanalyze(&root, None, &mut state).unwrap();
+        assert_eq!(cs3.files_unchanged, 1);
+        assert_eq!(
+            third.graph.symbols().next().unwrap().0.to_raw(),
+            id_before,
+            "the transient failure must not renumber the cached file"
+        );
+    }
+
+    #[test]
+    fn id_exhaustion_is_an_error() {
+        let root = temp_dir("id_exhaustion");
+        write_file(&root, "a.py", "def a(): pass\n");
+
+        let mut state = WatchState::new();
+        let mut seated = FileExtraction::empty(root.join("a.py"), LangId::Python);
+        seated.symbols.push(crate::model::Symbol {
+            id: crate::model::SymbolId::new(u32::MAX).unwrap(),
+            name: "seated".into(),
+            kind: crate::model::SymbolKind::Function,
+            language: LangId::Python,
+            file_path: root.join("a.py"),
+            source_range: crate::model::SourceRange {
+                byte_start: 0,
+                byte_end: 0,
+                start: crate::model::LineColumn { line: 0, column: 0 },
+                end: crate::model::LineColumn { line: 0, column: 0 },
+            },
+            visibility: None,
+            signature: None,
+            docstring: None,
+            is_async: false,
+        });
+        state.cache_mut().update(
+            root.join("a.py"),
+            Fingerprint::of(b"stale"),
+            Arc::new(seated),
+        );
+
+        assert!(
+            incremental_reanalyze(&root, None, &mut state).is_err(),
+            "an exhausted id space must report an error"
+        );
+    }
+
+    /// The verbatim prefix only exists on Windows, so this key-form defect is Windows-only.
+    #[cfg(windows)]
+    #[test]
+    fn overlay_verbatim_path_shares_the_discovered_key() {
+        let root = temp_dir("overlay_key");
+        write_file(&root, "a.py", "def shared(): pass\n");
+
+        let mut state = WatchState::new();
+        let mut verbatim = overlay(&root, "a.py", "def shared(): pass\n");
+        verbatim.path = PathBuf::from(format!(r"\\?\{}", verbatim.path.display()));
+
+        let (extractions, cs, _) =
+            reanalyze_extractions(&root, None, std::slice::from_ref(&verbatim), &mut state)
+                .unwrap();
+        assert_eq!(
+            cs.files_added, 1,
+            "one file must not be counted under two keys"
+        );
+        assert_eq!(extractions.len(), 1);
+
+        let (_, cs2, _) = reanalyze_extractions(&root, None, &[verbatim], &mut state).unwrap();
+        assert_eq!(cs2.files_unchanged, 1);
+        assert_eq!(cs2.files_added + cs2.files_modified, 0);
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,4 +1,5 @@
 mod integration {
+    mod cli_exit_test;
     mod dashboard_test;
     mod datagraph_test;
     #[cfg(feature = "metacall-deploy")]
@@ -10,6 +11,7 @@ mod integration {
     #[cfg(feature = "metacall-deploy")]
     mod deploy_test;
     mod edge_cases_test;
+    mod graph_regression_test;
     mod import_test;
     mod inspect_output_test;
     mod output_format_test;

--- a/tests/integration/cli_exit_test.rs
+++ b/tests/integration/cli_exit_test.rs
@@ -1,0 +1,66 @@
+//! Regression coverage for the command line exit policy.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn binary() -> &'static str {
+    env!("CARGO_BIN_EXE_meta-ast")
+}
+
+fn scratch(name: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("meta_ast_cli_{name}"));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(args: &[&str]) -> std::process::Output {
+    Command::new(binary()).args(args).output().unwrap()
+}
+
+/// `--help` and `--version` must not print the startup banner.
+#[test]
+fn help_and_version_skip_the_banner() {
+    for flag in ["--help", "--version"] {
+        let output = run(&[flag]);
+        assert!(output.status.success(), "{flag} must succeed");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            !stderr.contains("Polyglot static analyzer"),
+            "{flag} must not print the banner, got: {stderr}"
+        );
+    }
+}
+
+/// A parse failure is an error, so the default policy makes the run fail.
+#[test]
+fn graph_exits_non_zero_on_an_error_diagnostic() {
+    let dir = scratch("broken");
+    std::fs::write(dir.join("broken.py"), "def oops(:\n").unwrap();
+
+    let output = run(&["graph", dir.to_str().unwrap()]);
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "graph must fail on an error diagnostic, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn graph_exits_zero_on_a_clean_project() {
+    let dir = scratch("clean");
+    std::fs::write(dir.join("ok.py"), "def ok():\n    return 1\n").unwrap();
+
+    let output = run(&["graph", dir.to_str().unwrap()]);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "a clean project must exit zero, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        Path::new(&dir).exists(),
+        "the fixture directory must stay in place"
+    );
+}

--- a/tests/integration/cli_exit_test.rs
+++ b/tests/integration/cli_exit_test.rs
@@ -1,6 +1,6 @@
 //! Regression coverage for the command line exit policy.
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::process::Command;
 
 fn binary() -> &'static str {
@@ -32,18 +32,34 @@ fn help_and_version_skip_the_banner() {
     }
 }
 
-/// A parse failure is an error, so the default policy makes the run fail.
+/// A parse failure is a warning, so the default policy keeps the run green and
+/// an explicit warning policy fails it.
 #[test]
-fn graph_exits_non_zero_on_an_error_diagnostic() {
+fn graph_exit_status_follows_the_diagnostic_policy() {
     let dir = scratch("broken");
     std::fs::write(dir.join("broken.py"), "def oops(:\n").unwrap();
 
-    let output = run(&["graph", dir.to_str().unwrap()]);
+    let default_run = run(&["graph", dir.to_str().unwrap()]);
     assert_eq!(
-        output.status.code(),
+        default_run.status.code(),
+        Some(0),
+        "a warning must not fail the default policy, stderr: {}",
+        String::from_utf8_lossy(&default_run.stderr)
+    );
+
+    let strict_run = run(&["graph", dir.to_str().unwrap(), "--fail-on", "warning"]);
+    assert_eq!(
+        strict_run.status.code(),
         Some(1),
-        "graph must fail on an error diagnostic, stderr: {}",
-        String::from_utf8_lossy(&output.stderr)
+        "the warning policy must fail the run, stderr: {}",
+        String::from_utf8_lossy(&strict_run.stderr)
+    );
+
+    let permissive_run = run(&["graph", dir.to_str().unwrap(), "--fail-on", "never"]);
+    assert_eq!(
+        permissive_run.status.code(),
+        Some(0),
+        "the permissive policy must never fail the run"
     );
 }
 
@@ -58,9 +74,5 @@ fn graph_exits_zero_on_a_clean_project() {
         Some(0),
         "a clean project must exit zero, stderr: {}",
         String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        Path::new(&dir).exists(),
-        "the fixture directory must stay in place"
     );
 }

--- a/tests/integration/deploy_mixed_test.rs
+++ b/tests/integration/deploy_mixed_test.rs
@@ -546,4 +546,54 @@ mod deploy_mixed_tests {
             "check mode should pass or report fairness"
         );
     }
+
+    /// Mesh edges and unit symbols must be canonically ordered.
+    #[test]
+    fn test_mesh_output_order_is_canonical() {
+        let (out_dir, _manifest) = run_deploy_on_fixture("three_lang_math");
+        let mesh: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(out_dir.path().join("metacall.mesh.json")).unwrap(),
+        )
+        .unwrap();
+
+        let pairs: Vec<(u64, u64)> = mesh["cross_language_edges"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|edge| {
+                (
+                    edge["from_unit"].as_u64().unwrap(),
+                    edge["to_unit"].as_u64().unwrap(),
+                )
+            })
+            .collect();
+        let mut expected_pairs = pairs.clone();
+        expected_pairs.sort();
+        assert_eq!(
+            pairs, expected_pairs,
+            "cross-language edges must be canonically ordered"
+        );
+
+        for unit in mesh["deployment_units"].as_array().unwrap() {
+            let keys: Vec<(String, String, String)> = unit["symbols"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|symbol| {
+                    (
+                        symbol["file"].as_str().unwrap_or_default().to_string(),
+                        symbol["name"].as_str().unwrap_or_default().to_string(),
+                        symbol["kind"].as_str().unwrap_or_default().to_string(),
+                    )
+                })
+                .collect();
+            let mut expected_keys = keys.clone();
+            expected_keys.sort();
+            assert_eq!(
+                keys, expected_keys,
+                "unit symbols must be canonically ordered in unit {}",
+                unit["id"]
+            );
+        }
+    }
 }

--- a/tests/integration/deploy_test.rs
+++ b/tests/integration/deploy_test.rs
@@ -199,6 +199,114 @@ mod deploy_tests {
         );
     }
 
+    /// `-f yaml` must write the manifests in the requested format.
+    #[test]
+    fn deploy_yaml_format_writes_yaml_artifacts() {
+        let root =
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/mixed/python_calls_js");
+        let out_dir = tempdir().unwrap();
+        let out_path = out_dir.path().to_path_buf();
+
+        let config = DeployConfig {
+            root,
+            out: out_path.clone(),
+            format: OutputFormat::Yaml,
+            check: false,
+            max_pod_size: 20,
+        };
+        run_deploy(config).expect("Deploy failed");
+
+        let pods = out_path.join("metacall.pods.yaml");
+        let mesh = out_path.join("metacall.mesh.yaml");
+        assert!(
+            pods.exists(),
+            "the pod manifest must be written in the requested format"
+        );
+        assert!(
+            mesh.exists(),
+            "the mesh annotation must be written in the requested format"
+        );
+        let pods_text = fs::read_to_string(&pods).unwrap();
+        assert!(
+            pods_text.contains("deployments"),
+            "pod manifest content: {pods_text}"
+        );
+        let mesh_text = fs::read_to_string(&mesh).unwrap();
+        assert!(
+            mesh_text.contains("deployment_units"),
+            "mesh content: {mesh_text}"
+        );
+    }
+
+    /// An unmappable MetaCall load tag must be reported, not skipped silently.
+    #[test]
+    fn deploy_reports_an_unknown_load_tag() {
+        let dir = tempdir().unwrap();
+        fs::write(
+            dir.path().join("app.py"),
+            "from metacall import metacall_load_from_file\n\nmetacall_load_from_file(\"wasm\", [\"a.wasm\"])\n",
+        )
+        .unwrap();
+
+        let output = std::process::Command::new(env!("CARGO_BIN_EXE_meta-ast"))
+            .arg("deploy")
+            .arg(dir.path())
+            .arg("--out")
+            .arg(dir.path().join("out"))
+            .env("RUST_LOG", "warn")
+            .output()
+            .unwrap();
+
+        let mut text = String::from_utf8_lossy(&output.stdout).to_string();
+        text.push_str(&String::from_utf8_lossy(&output.stderr));
+        assert!(
+            text.contains("wasm"),
+            "the unmappable tag must be named in a diagnostic, got:\n{text}"
+        );
+    }
+
+    /// An in-memory load has no file: it must not become a node named by its code.
+    #[test]
+    fn memory_load_is_not_named_by_its_code() {
+        let dir = tempdir().unwrap();
+        fs::write(
+            dir.path().join("package.json"),
+            "{\"name\":\"probe\",\"version\":\"1.0.0\"}\n",
+        )
+        .unwrap();
+        fs::write(
+            dir.path().join("app.py"),
+            "from metacall import metacall_load_from_memory\n\nmetacall_load_from_memory(\"node\", \"console.log(1)\")\n",
+        )
+        .unwrap();
+
+        let out_dir = tempdir().unwrap();
+        let config = DeployConfig {
+            root: dir.path().to_path_buf(),
+            out: out_dir.path().to_path_buf(),
+            format: OutputFormat::Json,
+            check: false,
+            max_pod_size: 20,
+        };
+        run_deploy(config).expect("Deploy failed");
+
+        let manifest: serde_json::Value = serde_json::from_str(
+            &fs::read_to_string(out_dir.path().join("metacall.pods.json")).unwrap(),
+        )
+        .unwrap();
+        let names: Vec<String> = manifest["deployments"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .flat_map(|d| d["dependencies"].as_array().cloned().unwrap_or_default())
+            .filter_map(|dep| dep["name"].as_str().map(str::to_string))
+            .collect();
+        assert!(
+            !names.iter().any(|name| name.contains("console.log")),
+            "a memory load must not name a node after its inline code: {names:?}"
+        );
+    }
+
     fn copy_dir_recursive(src: &std::path::Path, dst: &std::path::Path) -> std::io::Result<()> {
         fs::create_dir_all(dst)?;
         for entry in fs::read_dir(src)? {

--- a/tests/integration/graph_regression_test.rs
+++ b/tests/integration/graph_regression_test.rs
@@ -1,0 +1,60 @@
+//! Regression coverage for graph resolution contracts.
+
+use std::path::{Path, PathBuf};
+
+use meta_ast::graph::{EdgeKind, NodeData};
+use meta_ast::model::SnapshotId;
+use petgraph::visit::EdgeRef;
+
+fn fixture_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/mixed/client_call_mesh")
+}
+
+fn analyze() -> meta_ast::pipeline::GraphAnalysis {
+    let (analysis, _diags) =
+        meta_ast::pipeline::analyze_graph(&fixture_root(), SnapshotId::new(1).unwrap(), None)
+            .unwrap();
+    analysis
+}
+
+/// The deployment path needs the calling file as the edge source, because a
+/// top-level call has no enclosing symbol.
+#[cfg(feature = "metacall-deploy")]
+#[test]
+fn client_calls_edge_from_the_calling_file() {
+    let analysis = analyze();
+    let graph = analysis.graph.graph();
+    let from_file = graph
+        .edge_references()
+        .filter(|edge| {
+            edge.weight().kind == EdgeKind::Reference
+                && matches!(graph[edge.source()], NodeData::File(_))
+                && matches!(graph[edge.target()], NodeData::Symbol(_))
+        })
+        .count();
+    assert_eq!(
+        from_file, 1,
+        "the resolved metacall call must produce one file to symbol reference edge"
+    );
+}
+
+/// The language server navigates by symbol, so the symbol projection stays.
+#[cfg(feature = "metacall-deploy")]
+#[test]
+fn client_calls_keep_a_symbol_projection() {
+    let analysis = analyze();
+    let graph = analysis.graph.graph();
+    let from_symbol = graph
+        .edge_references()
+        .filter(|edge| {
+            edge.weight().kind == EdgeKind::Reference
+                && matches!(graph[edge.source()], NodeData::Symbol(_))
+                && matches!(graph[edge.target()], NodeData::Symbol(_))
+                && edge.source() != edge.target()
+        })
+        .count();
+    assert!(
+        from_symbol >= 1,
+        "a call inside a symbol must stay visible to symbol keyed consumers"
+    );
+}

--- a/tests/integration/pipeline_test.rs
+++ b/tests/integration/pipeline_test.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 
 use meta_ast::graph::{EdgeKind, GraphBuilder, NodeData};
 use meta_ast::model::SnapshotId;
+use petgraph::visit::EdgeRef;
 
 fn flatten_symbols(result: &meta_ast::extractor::ExtractionResult) -> Vec<meta_ast::model::Symbol> {
     result
@@ -687,7 +688,7 @@ fn edge_unresolved_ref_creates_no_edges() {
 }
 
 #[test]
-fn edge_selfref_does_not_create_self_loop() {
+fn edge_selfref_creates_a_self_loop() {
     let root = Path::new("tests/fixtures/multi/edge_selfref");
     let files = meta_ast::input::discover_files(root, None).unwrap();
     let snapshot_id = meta_ast::model::SnapshotId::new(1).unwrap();
@@ -739,12 +740,24 @@ fn edge_selfref_does_not_create_self_loop() {
     }
 
     let graph = builder.build();
-    let ref_count = graph
-        .edges_of_kind(meta_ast::graph::EdgeKind::Reference)
+    let self_loops = graph
+        .graph()
+        .edge_references()
+        .filter(|edge| {
+            edge.weight().kind == meta_ast::graph::EdgeKind::Reference
+                && edge.source() == edge.target()
+        })
         .count();
     assert_eq!(
-        ref_count, 0,
-        "self-calls should not create reference edges; got {ref_count}"
+        self_loops, 1,
+        "a recursive call must create exactly one self-loop reference edge"
+    );
+
+    let scc = meta_ast::graph::scc::SccAnalysis::analyze(graph.graph());
+    assert_eq!(
+        scc.components.iter().map(|c| c.hint).collect::<Vec<_>>(),
+        vec![meta_ast::graph::scc::DeployabilityHint::SelfLoop],
+        "a self-recursive unit must classify as SelfLoop"
     );
 }
 

--- a/tests/integration/pipeline_test.rs
+++ b/tests/integration/pipeline_test.rs
@@ -754,10 +754,10 @@ fn edge_selfref_creates_a_self_loop() {
     );
 
     let scc = meta_ast::graph::scc::SccAnalysis::analyze(graph.graph());
-    assert_eq!(
-        scc.components.iter().map(|c| c.hint).collect::<Vec<_>>(),
-        vec![meta_ast::graph::scc::DeployabilityHint::SelfLoop],
-        "a self-recursive unit must classify as SelfLoop"
+    let hints: Vec<_> = scc.components.iter().map(|c| c.hint).collect();
+    assert!(
+        hints.contains(&meta_ast::graph::scc::DeployabilityHint::SelfLoop),
+        "a self-recursive unit must classify as SelfLoop, got {hints:?}"
     );
 }
 


### PR DESCRIPTION
## Summary

Regression tests for the final audit batch. Every test here fails on `main` and passes at the top of the stack. No production code is touched.

Coverage per area:

- watch: a failed read keeps the cached extraction, identifier exhaustion reports an error, numbering is contiguous and stable across runs, an overlay keeps one cache key.
- graph: the own file shadows an import, candidates order by path, a recursive call creates a self loop, iteration is path ordered, a call reaches the graph from the calling file.
- deploy: scanner false positives and false negatives, unknown load tags, cut annotations, doubled rpc stubs, lockfile matching, go.mod versions, mesh order, a stale symbol file id, metric overflow, a Windows authored script path on Unix.
- cli: `--help` and `--version` skip the banner, and the diagnostic policy decides the exit status.

## Type of change

- [x] `test` - tests only

## Affected area

- [x] `graph` / SCC
- [x] `interface` (CLI)
- [x] `watch` (feature)
- [x] `deploy` (feature)
- [x] `docs` / `tests`
