### PR TITLE
fix(watch): keep the cache on a read failure and number identifiers in path order

### DIFF
--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -174,7 +174,7 @@ pub fn run_deploy(config: DeployConfig) -> anyhow::Result<()> {
     // 6c. Report orphaned MetaCall configuration files and surface every
     // diagnostic collected during analysis and edge injection.
     diagnostics.extend(orphaned_config_diagnostics(&config.root, &all_call_sites));
-    diagnostics.sort_by(|a, b| (&a.path, &a.message).cmp(&(&b.path, &b.message)));
+    diagnostics.sort_by(|a, b| a.sort_key().cmp(&b.sort_key()));
     diagnostics.dedup_by(|a, b| a.path == b.path && a.message == b.message);
     for diag in &diagnostics {
         tracing::warn!(

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,6 +17,22 @@ pub struct Diagnostic {
     pub source_range: Option<SourceRange>,
 }
 
+impl Diagnostic {
+    /// Total ordering key: path, message, then the source position.
+    ///
+    /// The range keeps two diagnostics with the same path and message in a
+    /// stable order, so a run never reorders them between passes.
+    pub fn sort_key(&self) -> (&std::path::Path, &str, usize) {
+        (
+            self.path.as_path(),
+            self.message.as_str(),
+            self.source_range
+                .as_ref()
+                .map_or(usize::MAX, |range| range.byte_start),
+        )
+    }
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("IO: {0}")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -34,6 +34,9 @@ pub enum Error {
     #[error("config: {0}")]
     Config(String),
 
+    #[error("identifier space exhausted")]
+    IdExhausted,
+
     #[error("invalid source URI '{uri}': {message}")]
     InvalidSourceUri { uri: String, message: String },
 

--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -8,6 +8,7 @@
 //! symbol listing is needed (e.g. inspect mode); skips the import and
 //! reference query passes, roughly halving per-file extraction time.
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use rayon::prelude::*;
@@ -105,16 +106,96 @@ pub fn extract_with_id_gen(
     opts: &ExtractOptions,
     id_generators: &ExtractionIdGenerators,
 ) -> ExtractionResult {
-    let mut file_extractions: Vec<_> = files
+    // Phase one parses in parallel with file-local numbering, so no atomic
+    // ordering reaches the output. Phase two numbers the files in path order.
+    let mut file_extractions: Vec<FileExtraction> = files
         .par_iter()
-        .map(|(path, lang)| extract_single_file(path, lang, id_generators, opts))
+        .map(|(path, lang)| {
+            let local = ExtractionIdGenerators::new();
+            extract_single_file(path, lang, &local, opts)
+        })
         .collect();
 
     file_extractions.sort_by(|a, b| a.path.cmp(&b.path));
 
+    for file in &mut file_extractions {
+        renumber(file, id_generators);
+    }
+
     ExtractionResult {
         files: file_extractions,
     }
+}
+
+/// Map the file-local identifiers onto the shared generator.
+///
+/// The new numbering follows the symbol and data node order inside the file,
+/// which is deterministic for identical input.
+fn renumber(file: &mut FileExtraction, id_generators: &ExtractionIdGenerators) {
+    let symbol_map = if file.symbols.is_empty() {
+        HashMap::new()
+    } else {
+        let counter = IdGenerator::<SymbolId>::with_start(
+            id_generators.symbols.reserve(file.symbols.len() as u32),
+        );
+        let mut map = HashMap::with_capacity(file.symbols.len());
+        for symbol in &mut file.symbols {
+            let next = counter.next();
+            map.insert(symbol.id.to_raw(), next.to_raw());
+            symbol.id = next;
+        }
+        map
+    };
+
+    #[cfg(feature = "dataflow")]
+    renumber_data_nodes(file, id_generators, &symbol_map);
+
+    #[cfg(not(feature = "dataflow"))]
+    drop(symbol_map);
+}
+
+#[cfg(feature = "dataflow")]
+fn renumber_data_nodes(
+    file: &mut FileExtraction,
+    id_generators: &ExtractionIdGenerators,
+    symbol_map: &HashMap<u32, u32>,
+) {
+    use crate::model::DataNodeId;
+
+    if file.data_nodes.is_empty() {
+        file.flow_edges.clear();
+        return;
+    }
+
+    let counter = IdGenerator::<DataNodeId>::with_start(
+        id_generators.data_nodes.reserve(file.data_nodes.len() as u32),
+    );
+    let mut node_map = HashMap::with_capacity(file.data_nodes.len());
+    for node in &mut file.data_nodes {
+        let next = counter.next();
+        node_map.insert(node.id.to_raw(), next.to_raw());
+        node.id = next;
+        node.symbol_id = node
+            .symbol_id
+            .and_then(|id| symbol_map.get(&id.to_raw()).copied())
+            .and_then(SymbolId::new);
+    }
+
+    let node_ids: HashMap<u32, DataNodeId> = node_map
+        .iter()
+        .filter_map(|(&old, &new)| Some((old, DataNodeId::new(new)?)))
+        .collect();
+    file.flow_edges.retain_mut(|edge| {
+        let (Some(source), Some(target)) = (
+            node_ids.get(&edge.source.to_raw()).copied(),
+            node_ids.get(&edge.target.to_raw()).copied(),
+        ) else {
+            return false;
+        };
+        edge.source = source;
+        edge.target = target;
+        true
+    });
 }
 
 fn extract_single_file(

--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -168,7 +168,9 @@ fn renumber_data_nodes(
     }
 
     let counter = IdGenerator::<DataNodeId>::with_start(
-        id_generators.data_nodes.reserve(file.data_nodes.len() as u32),
+        id_generators
+            .data_nodes
+            .reserve(file.data_nodes.len() as u32),
     );
     let mut node_map = HashMap::with_capacity(file.data_nodes.len());
     for node in &mut file.data_nodes {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -61,7 +61,9 @@ pub fn discover_files(
         if let Some(lang_id) = detect_language(root)
             && languages.is_none_or(|langs| langs.contains(&lang_id))
         {
-            results.push((root.to_path_buf(), lang_id));
+            // The walk branch strips the Windows verbatim prefix; the single file
+            // branch must hand out the same key form.
+            results.push((simplified_path(root), lang_id));
         }
         return Ok(results);
     }

--- a/src/model/ids.rs
+++ b/src/model/ids.rs
@@ -85,6 +85,23 @@ impl<T> IdGenerator<T> {
             .expect("IdGenerator exhausted u32 space (allocated > u32::MAX ids)");
         T::from(nz)
     }
+
+    /// Reserve `count` contiguous identifiers and return the first slot.
+    ///
+    /// A caller that numbers a whole unit of work reserves one block, so the
+    /// block order follows the caller's order and never the thread timing.
+    /// An empty reservation returns the next slot without consuming it.
+    pub fn reserve(&self, count: u32) -> u32 {
+        if count == 0 {
+            return self.counter.load(Ordering::SeqCst);
+        }
+        let start = self.counter.fetch_add(count, Ordering::SeqCst);
+        assert!(
+            start != 0 && start.checked_add(count - 1).is_some(),
+            "IdGenerator exhausted u32 space (reserved > u32::MAX ids)"
+        );
+        start
+    }
 }
 
 impl<T> Default for IdGenerator<T> {

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -44,7 +44,7 @@ pub fn analyze_graph(
 
     let (graph, scc) =
         GraphBuilder::from_extractions(&arc_extractions, root, snapshot_id, &mut diagnostics);
-    diagnostics.sort_by(|a, b| (&a.path, &a.message).cmp(&(&b.path, &b.message)));
+    diagnostics.sort_by(|a, b| a.sort_key().cmp(&b.sort_key()));
 
     Ok((
         GraphAnalysis {

--- a/src/reanalyze.rs
+++ b/src/reanalyze.rs
@@ -271,7 +271,10 @@ pub fn reanalyze_extractions(
 
     let mut merged: Vec<Arc<FileExtraction>> =
         Vec::with_capacity(state.cache.len() + new_extractions.len());
-    for (path, fp) in &current_fingerprints {
+    for path in targets.keys() {
+        let Some(fp) = current_fingerprints.get(path) else {
+            continue;
+        };
         if state.cache.fingerprint_of(path) == Some(*fp)
             && let Some(extraction) = state.cache.get(path)
         {
@@ -292,10 +295,10 @@ pub fn reanalyze_extractions(
         .flat_map(|file| file.diagnostics.iter().cloned())
         .collect();
     let mut read_diagnostics = read_diagnostics;
-    read_diagnostics.sort_by(|a, b| (&a.path, &a.message).cmp(&(&b.path, &b.message)));
+    read_diagnostics.sort_by(|a, b| a.sort_key().cmp(&b.sort_key()));
     diagnostics.extend(read_diagnostics);
     diagnostics.extend(overlay_diagnostics);
-    diagnostics.sort_by(|a, b| (&a.path, &a.message).cmp(&(&b.path, &b.message)));
+    diagnostics.sort_by(|a, b| a.sort_key().cmp(&b.sort_key()));
 
     Ok((merged, change_set, diagnostics))
 }
@@ -317,7 +320,7 @@ pub fn incremental_reanalyze(
 
     let snapshot_id = state.next_snapshot_id()?;
     let (graph, scc) = GraphBuilder::from_extractions(&merged, root, snapshot_id, &mut diagnostics);
-    diagnostics.sort_by(|a, b| (&a.path, &a.message).cmp(&(&b.path, &b.message)));
+    diagnostics.sort_by(|a, b| a.sort_key().cmp(&b.sort_key()));
 
     tracing::info!(
         total = merged.len(),

--- a/src/reanalyze.rs
+++ b/src/reanalyze.rs
@@ -81,9 +81,12 @@ impl WatchState {
     }
 
     /// Allocate the next monotonic snapshot ID.
-    pub(crate) fn next_snapshot_id(&mut self) -> SnapshotId {
-        self.snapshot_counter += 1;
-        SnapshotId::new(self.snapshot_counter).expect("snapshot counter exhausted (> u32::MAX)")
+    pub(crate) fn next_snapshot_id(&mut self) -> Result<SnapshotId, crate::Error> {
+        self.snapshot_counter = self
+            .snapshot_counter
+            .checked_add(1)
+            .ok_or(crate::Error::IdExhausted)?;
+        SnapshotId::new(self.snapshot_counter).ok_or(crate::Error::IdExhausted)
     }
 }
 
@@ -209,12 +212,17 @@ pub fn reanalyze_extractions(
     }
 
     let max_id = state.cache.max_symbol_id();
+    let next_symbol_id = max_id.checked_add(1).ok_or(crate::Error::IdExhausted)?;
     #[cfg(feature = "dataflow")]
-    let max_data_id = state.cache.max_data_node_id();
+    let next_data_id = state
+        .cache
+        .max_data_node_id()
+        .checked_add(1)
+        .ok_or(crate::Error::IdExhausted)?;
     #[cfg(feature = "dataflow")]
-    let id_generators = ExtractionIdGenerators::with_starts(max_id + 1, max_data_id + 1);
+    let id_generators = ExtractionIdGenerators::with_starts(next_symbol_id, next_data_id);
     #[cfg(not(feature = "dataflow"))]
-    let id_generators = ExtractionIdGenerators::with_symbol_start(max_id + 1);
+    let id_generators = ExtractionIdGenerators::with_symbol_start(next_symbol_id);
 
     let options = ExtractOptions {
         skip_imports_and_refs: false,
@@ -302,7 +310,7 @@ pub fn incremental_reanalyze(
     let started = Instant::now();
     let (merged, change_set, mut diagnostics) = reanalyze_extractions(root, languages, &[], state)?;
 
-    let snapshot_id = state.next_snapshot_id();
+    let snapshot_id = state.next_snapshot_id()?;
     let (graph, scc) = GraphBuilder::from_extractions(&merged, root, snapshot_id, &mut diagnostics);
     diagnostics.sort_by(|a, b| (&a.path, &a.message).cmp(&(&b.path, &b.message)));
 
@@ -767,9 +775,16 @@ mod tests {
     #[test]
     fn snapshot_id_allocation_is_monotonic() {
         let mut state = WatchState::new();
-        let s1 = state.next_snapshot_id();
-        let s2 = state.next_snapshot_id();
+        let s1 = state.next_snapshot_id().unwrap();
+        let s2 = state.next_snapshot_id().unwrap();
         assert_eq!(s1.to_raw(), 1);
         assert_eq!(s2.to_raw(), 2);
+    }
+
+    #[test]
+    fn snapshot_counter_exhaustion_is_an_error() {
+        let mut state = WatchState::new();
+        state.snapshot_counter = u32::MAX;
+        assert!(state.next_snapshot_id().is_err());
     }
 }

--- a/src/reanalyze.rs
+++ b/src/reanalyze.rs
@@ -7,7 +7,7 @@
 //! This module is not gated by the `watch` feature. Only the OS watcher in
 //! [`crate::watch`] needs that feature.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Instant;
@@ -158,8 +158,16 @@ pub fn reanalyze_extractions(
     let mut changed_disk: Vec<(PathBuf, LangId)> = Vec::new();
     let mut changed_overlays: Vec<&Overlay> = Vec::new();
 
+    // A file that cannot be read keeps its cached extraction. Its fingerprint is
+    // missing, so the stale sweep must not treat it as deleted.
+    let failed_reads: HashSet<PathBuf> =
+        read_diagnostics.iter().map(|diag| diag.path.clone()).collect();
+
     for (path, lang) in &targets {
         let Some(curr_fp) = current_fingerprints.get(path) else {
+            if failed_reads.contains(path) {
+                change_set.files_unchanged += 1;
+            }
             continue;
         };
         let changed = match state.cache.fingerprint_of(path) {
@@ -188,7 +196,9 @@ pub fn reanalyze_extractions(
     let stale: Vec<PathBuf> = state
         .cache
         .paths()
-        .filter(|path| !current_fingerprints.contains_key(*path))
+        .filter(|path| {
+            !current_fingerprints.contains_key(*path) && !failed_reads.contains(*path)
+        })
         .cloned()
         .collect();
     if !stale.is_empty() {

--- a/src/reanalyze.rs
+++ b/src/reanalyze.rs
@@ -112,15 +112,17 @@ pub fn reanalyze_extractions(
 ) -> Result<ReanalysisOutput, crate::Error> {
     let files = input::discover_files(root, languages)?;
 
-    let overlay_by_path: HashMap<&Path, &Overlay> = overlays
+    // Key every overlay by the same path form the walk produces, so one file
+    // never enters the target set under two keys.
+    let overlay_by_path: HashMap<PathBuf, &Overlay> = overlays
         .iter()
-        .filter(|overlay| overlay.path.starts_with(root))
-        .map(|overlay| (overlay.path.as_path(), overlay))
+        .map(|overlay| (input::simplified_path(&overlay.path), overlay))
+        .filter(|(path, _)| path.starts_with(root))
         .collect();
 
     let mut targets: BTreeMap<PathBuf, LangId> = files.into_iter().collect();
-    for overlay in overlay_by_path.values() {
-        targets.entry(overlay.path.clone()).or_insert(overlay.lang);
+    for (path, overlay) in &overlay_by_path {
+        targets.entry(path.clone()).or_insert(overlay.lang);
     }
 
     let (current_fingerprints, read_diagnostics): (HashMap<PathBuf, Fingerprint>, Vec<Diagnostic>) =
@@ -129,7 +131,7 @@ pub fn reanalyze_extractions(
             .fold(
                 || (HashMap::new(), Vec::new()),
                 |(mut map, mut diags), (path, _)| {
-                    match overlay_by_path.get(path.as_path()) {
+                    match overlay_by_path.get(path) {
                         Some(overlay) => {
                             map.insert(path.clone(), Fingerprint::of(overlay.text.as_bytes()));
                         }
@@ -159,7 +161,7 @@ pub fn reanalyze_extractions(
 
     let mut change_set = ChangeSet::default();
     let mut changed_disk: Vec<(PathBuf, LangId)> = Vec::new();
-    let mut changed_overlays: Vec<&Overlay> = Vec::new();
+    let mut changed_overlays: Vec<(PathBuf, &Overlay)> = Vec::new();
 
     // A file that cannot be read keeps its cached extraction. Its fingerprint is
     // missing, so the stale sweep must not treat it as deleted.
@@ -190,8 +192,8 @@ pub fn reanalyze_extractions(
         if !changed {
             continue;
         }
-        match overlay_by_path.get(path.as_path()) {
-            Some(overlay) => changed_overlays.push(*overlay),
+        match overlay_by_path.get(path) {
+            Some(overlay) => changed_overlays.push((path.clone(), overlay)),
             None => changed_disk.push((path.clone(), *lang)),
         }
     }
@@ -235,7 +237,7 @@ pub fn reanalyze_extractions(
     };
 
     let mut overlay_diagnostics: Vec<Diagnostic> = Vec::new();
-    for overlay in &changed_overlays {
+    for (path, overlay) in &changed_overlays {
         match extractor::extract_text_with_id_gen(
             InMemorySource {
                 uri: overlay.uri.as_str(),
@@ -246,17 +248,20 @@ pub fn reanalyze_extractions(
             &options,
             &id_generators,
         ) {
-            Ok(versioned) => new_extractions.push(versioned.file),
+            Ok(mut versioned) => {
+                versioned.file.path = path.clone();
+                new_extractions.push(versioned.file);
+            }
             Err(error) => {
                 let message = error.to_string();
                 overlay_diagnostics.push(Diagnostic {
-                    path: overlay.path.clone(),
+                    path: path.clone(),
                     severity: Severity::Error,
                     message: message.clone(),
                     source_range: None,
                 });
                 new_extractions.push(FileExtraction::failed(
-                    overlay.path.clone(),
+                    path.clone(),
                     overlay.lang,
                     message,
                 ));

--- a/src/reanalyze.rs
+++ b/src/reanalyze.rs
@@ -165,8 +165,10 @@ pub fn reanalyze_extractions(
 
     // A file that cannot be read keeps its cached extraction. Its fingerprint is
     // missing, so the stale sweep must not treat it as deleted.
-    let failed_reads: HashSet<PathBuf> =
-        read_diagnostics.iter().map(|diag| diag.path.clone()).collect();
+    let failed_reads: HashSet<PathBuf> = read_diagnostics
+        .iter()
+        .map(|diag| diag.path.clone())
+        .collect();
 
     for (path, lang) in &targets {
         let Some(curr_fp) = current_fingerprints.get(path) else {
@@ -201,9 +203,7 @@ pub fn reanalyze_extractions(
     let stale: Vec<PathBuf> = state
         .cache
         .paths()
-        .filter(|path| {
-            !current_fingerprints.contains_key(*path) && !failed_reads.contains(*path)
-        })
+        .filter(|path| !current_fingerprints.contains_key(*path) && !failed_reads.contains(*path))
         .cloned()
         .collect();
     if !stale.is_empty() {
@@ -260,11 +260,7 @@ pub fn reanalyze_extractions(
                     message: message.clone(),
                     source_range: None,
                 });
-                new_extractions.push(FileExtraction::failed(
-                    path.clone(),
-                    overlay.lang,
-                    message,
-                ));
+                new_extractions.push(FileExtraction::failed(path.clone(), overlay.lang, message));
             }
         }
     }

--- a/src/watch/config.rs
+++ b/src/watch/config.rs
@@ -6,6 +6,10 @@ use std::time::Duration;
 use crate::language::LangId;
 use crate::output::OutputFormat;
 
+/// Floor for the debounce duration. Zero turns the watcher into a hot loop on
+/// chatty file systems.
+pub const MIN_DEBOUNCE: Duration = Duration::from_millis(50);
+
 /// Configuration parameters governing the debounced file-system watcher.
 #[derive(Debug, Clone)]
 pub struct WatchConfig {
@@ -35,6 +39,11 @@ impl WatchConfig {
             languages: None,
         }
     }
+
+    /// Effective debounce duration, never below [`MIN_DEBOUNCE`].
+    pub fn debounce(&self) -> Duration {
+        self.debounce.max(MIN_DEBOUNCE)
+    }
 }
 
 impl Default for WatchConfig {
@@ -51,10 +60,20 @@ mod tests {
     fn watch_config_default_values() {
         let cfg = WatchConfig::default();
         assert_eq!(cfg.debounce, Duration::from_millis(200));
+        assert_eq!(cfg.debounce(), Duration::from_millis(200));
         assert_eq!(cfg.format, OutputFormat::Json);
         assert!(cfg.output.is_none());
         assert!(!cfg.html);
         assert!(cfg.open_browser);
         assert!(cfg.languages.is_none());
+    }
+
+    #[test]
+    fn debounce_has_a_floor() {
+        let cfg = WatchConfig {
+            debounce: Duration::ZERO,
+            ..WatchConfig::new()
+        };
+        assert_eq!(cfg.debounce(), MIN_DEBOUNCE);
     }
 }

--- a/src/watch/watcher.rs
+++ b/src/watch/watcher.rs
@@ -3,12 +3,18 @@
 //! Listens for file-system events using `notify-debouncer-mini`, triggers
 //! incremental re-analysis, and invokes the change callback.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
 
 use crate::input;
+use crate::language::LangId;
 use crate::pipeline::GraphAnalysis;
 use crate::reanalyze::{ChangeSet, WatchState, incremental_reanalyze};
 use crate::watch::config::WatchConfig;
+
+/// How long the loop waits for events before it checks the stop flag again.
+const IDLE_POLL: Duration = Duration::from_millis(100);
 
 /// Start a debounced file-system watcher on `root` and re-analyse on changes.
 ///
@@ -16,11 +22,26 @@ use crate::watch::config::WatchConfig;
 /// every subsequent incremental re-analysis. Typical usage: emit serialized
 /// graph output on each change.
 ///
-/// This function blocks until the watcher encounters an unrecoverable error
-/// or the underlying channel disconnects.
+/// This function blocks until the watcher channel disconnects, or until a
+/// failed tick is the only outcome left. Interrupts terminate the process.
+/// Use [`run_watch_until`] to stop the loop from another thread.
 pub fn run_watch(
     root: PathBuf,
     config: WatchConfig,
+    on_change: impl FnMut(&GraphAnalysis, &ChangeSet) -> Result<(), anyhow::Error>,
+) -> anyhow::Result<()> {
+    let stop = AtomicBool::new(false);
+    run_watch_until(root, config, &stop, on_change)
+}
+
+/// Like [`run_watch`], but the loop also stops when `stop` is set.
+///
+/// A tick that fails to emit or to re-analyse is counted and reported once the
+/// loop ends, so a long watch run cannot hide a broken output path.
+pub fn run_watch_until(
+    root: PathBuf,
+    config: WatchConfig,
+    stop: &AtomicBool,
     mut on_change: impl FnMut(&GraphAnalysis, &ChangeSet) -> Result<(), anyhow::Error>,
 ) -> anyhow::Result<()> {
     use notify_debouncer_mini::{DebounceEventResult, new_debouncer};
@@ -28,6 +49,7 @@ pub fn run_watch(
     let mut state = WatchState::new();
 
     let languages = config.languages.as_deref();
+    let debounce = config.debounce();
 
     tracing::info!(root = %root.display(), "Running initial analysis");
     let (analysis, change_set, diags) = incremental_reanalyze(&root, languages, &mut state)?;
@@ -44,7 +66,7 @@ pub fn run_watch(
     on_change(&analysis, &change_set)?;
 
     let (tx, rx) = std::sync::mpsc::channel::<DebounceEventResult>();
-    let mut debouncer = new_debouncer(config.debounce, move |res| {
+    let mut debouncer = new_debouncer(debounce, move |res| {
         let _ = tx.send(res);
     })?;
 
@@ -55,19 +77,23 @@ pub fn run_watch(
 
     tracing::info!(
         root = %root.display(),
-        debounce_ms = config.debounce.as_millis(),
+        debounce_ms = debounce.as_millis(),
         "Watching for file changes",
     );
 
-    for res in rx {
+    let mut failures = 0usize;
+    while !stop.load(Ordering::Relaxed) {
+        let res = match rx.recv_timeout(IDLE_POLL) {
+            Ok(res) => res,
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => continue,
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
+        };
+
         match res {
             Ok(events) => {
-                let relevant = events.iter().any(|e| {
-                    e.path.is_dir()
-                        || input::detect_language(&e.path)
-                            .is_some_and(|lang| languages.is_none_or(|langs| langs.contains(&lang)))
-                });
-                if !relevant && !events.is_empty() {
+                let relevant =
+                    has_relevant_path(events.iter().map(|event| event.path.as_path()), languages);
+                if !relevant {
                     continue;
                 }
 
@@ -83,17 +109,70 @@ pub fn run_watch(
                             );
                         }
                         if let Err(e) = on_change(&analysis, &change_set) {
+                            failures += 1;
                             tracing::error!("Emit error: {e}");
                         }
                     }
-                    Err(e) => tracing::error!("Re-analysis error: {e}"),
+                    Err(e) => {
+                        failures += 1;
+                        tracing::error!("Re-analysis error: {e}");
+                    }
                 }
             }
             Err(e) => {
+                failures += 1;
                 tracing::error!("Watch error: {e}");
             }
         }
     }
 
+    if failures > 0 {
+        anyhow::bail!("watch stopped after {failures} failed tick(s)");
+    }
+
     Ok(())
+}
+
+/// A batch matters only when it touches a source file of a wanted language.
+///
+/// Directory metadata events fire on every child change and carry no source
+/// path, so they never justify a full re-analysis on their own.
+fn has_relevant_path<'a>(
+    paths: impl Iterator<Item = &'a Path>,
+    languages: Option<&[LangId]>,
+) -> bool {
+    paths.into_iter().any(|path| {
+        input::detect_language(path)
+            .is_some_and(|lang| languages.is_none_or(|langs| langs.contains(&lang)))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn directory_events_are_not_relevant() {
+        let paths = [Path::new("/tmp/project"), Path::new("/tmp/project/sub")];
+        assert!(!has_relevant_path(paths.iter().copied(), None));
+    }
+
+    #[test]
+    fn source_events_are_relevant() {
+        let paths = [Path::new("/tmp/project"), Path::new("/tmp/project/main.py")];
+        assert!(has_relevant_path(paths.iter().copied(), None));
+    }
+
+    #[test]
+    fn language_filter_applies_to_events() {
+        let paths = [Path::new("/tmp/project/main.py")];
+        assert!(!has_relevant_path(
+            paths.iter().copied(),
+            Some(&[LangId::Rust])
+        ));
+        assert!(has_relevant_path(
+            paths.iter().copied(),
+            Some(&[LangId::Python])
+        ));
+    }
 }


### PR DESCRIPTION
## Summary

Watch and incremental integrity. Fixes W1 to W8 and N-W1 from the audit.

- A read failure no longer evicts a valid cache entry; the file keeps its identifiers and is counted as unchanged.
- The snapshot counter and the cached identifier seeds use checked addition and report an error instead of panicking.
- Identifiers are numbered in path order after the parallel parse, so two runs on the same tree agree (`ARCHITECTURE.md` claim).
- Overlay, discovery and cache keys use one path form, so a file cannot enter the target set twice.
- The cache merge and the diagnostic order follow the sorted target map, and diagnostics order by path, message and position.
- The debounce has a floor, a directory-only event batch no longer forces a full re-analysis, and the loop can be stopped and reports the ticks that failed.

## Type of change

- [x] `fix` - bug fix

## Affected area

- [x] `model` / ids
- [x] `watch` (feature)

## Notes

N-W2 stays open: it needs a bytes-taking extractor entry, and the double read only costs a repeated read (a mismatch self-heals on the next tick).
