### PR TITLE
fix(graph): rank scope candidates and resolve client calls once

### DIFF
--- a/docs/src/specs/graph-model.md
+++ b/docs/src/specs/graph-model.md
@@ -41,6 +41,15 @@ DataNode represents a value or variable instance used for def-use and flow analy
 
 `SymbolNode -> SymbolNode` representing symbol usage/call/reference candidates.
 
+A `metacall()` client call also produces a `FileNode -> SymbolNode` reference edge,
+because a call at module level has no enclosing symbol and the calling file is the
+deployment unit. Both edges come from one resolution pass and carry the same
+confidence. The file projection is complete; the symbol projection exists only when
+the call sits inside a symbol, and it is what symbol keyed consumers navigate with.
+
+A reference outside any symbol does not become an edge. The file level dependency is
+already carried by the import edge, and cursor resolution reads the scope cache.
+
 ### OwnershipEdge
 
 `FileNode -> SymbolNode` and optional `SymbolNode -> SymbolNode` for nesting.
@@ -54,7 +63,14 @@ DataNode represents a value or variable instance used for def-use and flow analy
 1. Every SymbolNode must map to exactly one FileNode.
 2. Ownership edges must form an acyclic containment structure.
 3. SCC computation applies to dependency/reference subgraph, not ownership edges. Self-loop detection and independence classification follow the same subgraph rule.
-4. Duplicate edges should be normalized by `(src, dst, edge_kind)` key. Client-call edges (FileNode to SymbolNode) can only merge with other client-call edges; scope-resolved references (SymbolNode to SymbolNode) never collide with them. Strongest evidence wins within a triple.
+4. Duplicate edges should be normalized by `(src, dst, edge_kind)` key. Strongest
+evidence wins within a triple, and the first flow kind wins. The two client-call
+projections never collide, because their source endpoints are different node kinds.
+5. A name resolves to the nearest definition only. The own file shadows a direct
+same-language import, a direct import shadows a transitive one, and a cross-language
+import ranks last. Equally ranked candidates stay visible and order by path.
+6. An import edge between two languages carries the cross-language confidence, not
+the direct one.
 
 ## 5. SCC semantics
 

--- a/src/deploy/client_call.rs
+++ b/src/deploy/client_call.rs
@@ -14,13 +14,6 @@ use crate::language::LangId;
 use crate::model::{FileExtraction, FileId, SymbolId};
 use petgraph::graph::NodeIndex;
 
-/// Result of mapping ClientCall sites to target symbol nodes.
-pub(crate) struct ClientCallResolution {
-    /// (source file node, target symbol node, confidence)
-    pub edges: Vec<(NodeIndex, NodeIndex, f32)>,
-    pub diagnostics: Vec<Diagnostic>,
-}
-
 /// Resolve a load script to a file node, trying the same strategies as
 /// add_metacall_edge (root-relative, source-file-relative, filename match,
 /// component-stripping). Returns None when no file node matches.
@@ -271,13 +264,23 @@ struct ResolvedCall {
     confidence: f32,
 }
 
-/// Resolve ClientCall sites to file-to-symbol edges for the deploy mesh.
-pub(crate) fn resolve_client_calls<F>(
+/// Both call-edge projections of one resolution pass.
+pub(crate) struct ClientCallProjections {
+    /// File node to symbol node. Deployment needs the calling file, because a
+    /// top-level call has no enclosing symbol.
+    pub file_edges: Vec<(NodeIndex, NodeIndex, f32)>,
+    /// Symbol node to symbol node. Navigation keys on the caller symbol.
+    pub symbol_edges: Vec<(SymbolId, SymbolId, f32)>,
+    pub diagnostics: Vec<Diagnostic>,
+}
+
+/// Resolve ClientCall sites once and emit both projections.
+pub(crate) fn resolve_client_call_projections<F>(
     graph: &CodeGraph,
     extractions: &[F],
     call_sites: &[CallSite],
     root: &Path,
-) -> ClientCallResolution
+) -> ClientCallProjections
 where
     F: std::borrow::Borrow<FileExtraction> + Sync,
 {
@@ -288,43 +291,28 @@ where
             path_to_idx.insert(file.path.clone(), idx);
         }
     }
-    let mut edges = Vec::with_capacity(resolved.len());
+
+    let mut file_edges = Vec::with_capacity(resolved.len());
+    let mut symbol_edges = Vec::with_capacity(resolved.len());
     for call in resolved {
-        let (Some(&caller_idx), Some(target_idx)) = (
+        if let (Some(&caller_idx), Some(target_idx)) = (
             path_to_idx.get(&call.source_file),
             graph.symbol_node_index(call.target),
-        ) else {
-            continue;
-        };
-        edges.push((caller_idx, target_idx, call.confidence));
+        ) {
+            file_edges.push((caller_idx, target_idx, call.confidence));
+        }
+        if let Some(caller) =
+            enclosing_symbol(extractions, &call.source_file, call.source_range.as_ref())
+        {
+            symbol_edges.push((caller, call.target, call.confidence));
+        }
     }
-    ClientCallResolution { edges, diagnostics }
-}
 
-/// Resolve ClientCall sites to symbol-to-symbol reference edges.
-///
-/// The caller is the smallest symbol in the call-site file that encloses the
-/// invocation. The graph builder applies these edges so navigation sees
-/// `metacall()` targets.
-pub(crate) fn resolve_client_call_edges<F>(
-    graph: &CodeGraph,
-    extractions: &[F],
-    call_sites: &[CallSite],
-    root: &Path,
-) -> (Vec<(SymbolId, SymbolId, f32)>, Vec<Diagnostic>)
-where
-    F: std::borrow::Borrow<FileExtraction> + Sync,
-{
-    let (resolved, diagnostics) = resolve_sites(graph, extractions, call_sites, root);
-    let edges = resolved
-        .into_iter()
-        .filter_map(|call| {
-            let caller =
-                enclosing_symbol(extractions, &call.source_file, call.source_range.as_ref())?;
-            Some((caller, call.target, call.confidence))
-        })
-        .collect();
-    (edges, diagnostics)
+    ClientCallProjections {
+        file_edges,
+        symbol_edges,
+        diagnostics,
+    }
 }
 
 fn enclosing_symbol<F>(
@@ -492,11 +480,15 @@ mod tests {
             load_from_file("orchestrator.py", vec!["math.js"]),
             client_call("orchestrator.py", "multiply", 1.0),
         ];
-        let resolution =
-            resolve_client_calls(&fx.graph, &fx.extractions, &call_sites, Path::new("."));
+        let resolution = resolve_client_call_projections(
+            &fx.graph,
+            &fx.extractions,
+            &call_sites,
+            Path::new("."),
+        );
 
-        assert_eq!(resolution.edges.len(), 1);
-        let (from, to, confidence) = resolution.edges[0];
+        assert_eq!(resolution.file_edges.len(), 1);
+        let (from, to, confidence) = resolution.file_edges[0];
         let py_idx = *fx.graph.file_to_index.get(&py_id).unwrap();
         assert_eq!(from, py_idx);
         assert_eq!(to, sym_idx);
@@ -534,12 +526,16 @@ mod tests {
             mistagged_load,
             client_call("orchestrator.py", "multiply", 1.0),
         ];
-        let resolution =
-            resolve_client_calls(&fx.graph, &fx.extractions, &call_sites, Path::new("."));
+        let resolution = resolve_client_call_projections(
+            &fx.graph,
+            &fx.extractions,
+            &call_sites,
+            Path::new("."),
+        );
 
-        assert_eq!(resolution.edges.len(), 1);
-        assert_eq!(resolution.edges[0].1, js_sym);
-        assert_eq!(resolution.edges[0].2, 1.0);
+        assert_eq!(resolution.file_edges.len(), 1);
+        assert_eq!(resolution.file_edges[0].1, js_sym);
+        assert_eq!(resolution.file_edges[0].2, 1.0);
         assert!(resolution.diagnostics.is_empty());
     }
 
@@ -567,15 +563,19 @@ mod tests {
             py_load,
             client_call("orchestrator.py", "multiply", 1.0),
         ];
-        let resolution =
-            resolve_client_calls(&fx.graph, &fx.extractions, &call_sites, Path::new("."));
+        let resolution = resolve_client_call_projections(
+            &fx.graph,
+            &fx.extractions,
+            &call_sites,
+            Path::new("."),
+        );
 
-        let mut targets: Vec<_> = resolution.edges.iter().map(|(_, to, _)| *to).collect();
+        let mut targets: Vec<_> = resolution.file_edges.iter().map(|(_, to, _)| *to).collect();
         targets.sort();
         let mut expected = vec![js_sym, py_sym];
         expected.sort();
         assert_eq!(targets, expected);
-        assert!(resolution.edges.iter().all(|(_, _, c)| *c == 0.8));
+        assert!(resolution.file_edges.iter().all(|(_, _, c)| *c == 0.8));
     }
 
     #[test]
@@ -610,9 +610,13 @@ mod tests {
             source_range: None,
             confidence: 1.0,
         };
-        let resolution =
-            resolve_client_calls(&fx.graph, &fx.extractions, &[config_site], Path::new("."));
-        assert!(resolution.edges.is_empty());
+        let resolution = resolve_client_call_projections(
+            &fx.graph,
+            &fx.extractions,
+            &[config_site],
+            Path::new("."),
+        );
+        assert!(resolution.file_edges.is_empty());
         assert_eq!(resolution.diagnostics.len(), 1);
         assert_eq!(resolution.diagnostics[0].severity, Severity::Warning);
         assert_eq!(
@@ -636,17 +640,22 @@ mod tests {
             load_from_file("orchestrator.py", vec!["math.js", "utils.js"]),
             client_call("orchestrator.py", "multiply", 1.0),
         ];
-        let resolution =
-            resolve_client_calls(&fx.graph, &fx.extractions, &call_sites, Path::new("."));
+        let resolution = resolve_client_call_projections(
+            &fx.graph,
+            &fx.extractions,
+            &call_sites,
+            Path::new("."),
+        );
 
-        assert_eq!(resolution.edges.len(), 2);
+        assert_eq!(resolution.file_edges.len(), 2);
         let py_idx = *fx.graph.file_to_index.get(&py_id).unwrap();
-        let mut targets: Vec<NodeIndex> = resolution.edges.iter().map(|(_, to, _)| *to).collect();
+        let mut targets: Vec<NodeIndex> =
+            resolution.file_edges.iter().map(|(_, to, _)| *to).collect();
         targets.sort();
         let mut expected = vec![s1, s2];
         expected.sort();
         assert_eq!(targets, expected);
-        for (from, _, confidence) in &resolution.edges {
+        for (from, _, confidence) in &resolution.file_edges {
             assert_eq!(*from, py_idx);
             assert_eq!(*confidence, 0.8);
         }
@@ -662,11 +671,15 @@ mod tests {
         let sym_idx = fx.add_symbol(&helper, js_id, "helpers.js", LangId::JavaScript);
 
         let call_sites = vec![client_call("orchestrator.py", "helper", 1.0)];
-        let resolution =
-            resolve_client_calls(&fx.graph, &fx.extractions, &call_sites, Path::new("."));
+        let resolution = resolve_client_call_projections(
+            &fx.graph,
+            &fx.extractions,
+            &call_sites,
+            Path::new("."),
+        );
 
-        assert_eq!(resolution.edges.len(), 1);
-        let (from, to, confidence) = resolution.edges[0];
+        assert_eq!(resolution.file_edges.len(), 1);
+        let (from, to, confidence) = resolution.file_edges[0];
         let py_idx = *fx.graph.file_to_index.get(&py_id).unwrap();
         assert_eq!(from, py_idx);
         assert_eq!(to, sym_idx);
@@ -686,17 +699,22 @@ mod tests {
         let s2 = fx.add_symbol(&h2, b_id, "utils.js", LangId::JavaScript);
 
         let call_sites = vec![client_call("orchestrator.py", "helper", 1.0)];
-        let resolution =
-            resolve_client_calls(&fx.graph, &fx.extractions, &call_sites, Path::new("."));
+        let resolution = resolve_client_call_projections(
+            &fx.graph,
+            &fx.extractions,
+            &call_sites,
+            Path::new("."),
+        );
 
-        assert_eq!(resolution.edges.len(), 2);
+        assert_eq!(resolution.file_edges.len(), 2);
         let py_idx = *fx.graph.file_to_index.get(&py_id).unwrap();
-        let mut targets: Vec<NodeIndex> = resolution.edges.iter().map(|(_, to, _)| *to).collect();
+        let mut targets: Vec<NodeIndex> =
+            resolution.file_edges.iter().map(|(_, to, _)| *to).collect();
         targets.sort();
         let mut expected = vec![s1, s2];
         expected.sort();
         assert_eq!(targets, expected);
-        for (from, _, confidence) in &resolution.edges {
+        for (from, _, confidence) in &resolution.file_edges {
             assert_eq!(*from, py_idx);
             assert_eq!(*confidence, 0.5);
         }
@@ -714,11 +732,15 @@ mod tests {
         // A computed first argument keeps the source text as function_name and
         // drops the site confidence to 0.4 (scanner convention).
         let call_sites = vec![client_call("orchestrator.py", "fn_var", 0.4)];
-        let resolution =
-            resolve_client_calls(&fx.graph, &fx.extractions, &call_sites, Path::new("."));
+        let resolution = resolve_client_call_projections(
+            &fx.graph,
+            &fx.extractions,
+            &call_sites,
+            Path::new("."),
+        );
 
-        assert_eq!(resolution.edges.len(), 1);
-        let (from, to, confidence) = resolution.edges[0];
+        assert_eq!(resolution.file_edges.len(), 1);
+        let (from, to, confidence) = resolution.file_edges[0];
         let py_idx = *fx.graph.file_to_index.get(&py_id).unwrap();
         assert_eq!(from, py_idx);
         assert_eq!(to, sym_idx);
@@ -732,10 +754,14 @@ mod tests {
         let _ = fx.add_file("orchestrator.py", LangId::Python);
 
         let call_sites = vec![client_call("orchestrator.py", "no_such_fn", 1.0)];
-        let resolution =
-            resolve_client_calls(&fx.graph, &fx.extractions, &call_sites, Path::new("."));
+        let resolution = resolve_client_call_projections(
+            &fx.graph,
+            &fx.extractions,
+            &call_sites,
+            Path::new("."),
+        );
 
-        assert!(resolution.edges.is_empty());
+        assert!(resolution.file_edges.is_empty());
         assert_eq!(resolution.diagnostics.len(), 1);
         let diag = &resolution.diagnostics[0];
         assert_eq!(diag.path, PathBuf::from("orchestrator.py"));
@@ -806,10 +832,14 @@ mod tests {
 
         // Computed-name client call: file -> sym @ 0.4.
         let call_sites = vec![client_call("orchestrator.py", "multiply", 0.4)];
-        let resolution =
-            resolve_client_calls(&fx.graph, &fx.extractions, &call_sites, Path::new("."));
-        assert_eq!(resolution.edges.len(), 1);
-        let (from, to, confidence) = resolution.edges[0];
+        let resolution = resolve_client_call_projections(
+            &fx.graph,
+            &fx.extractions,
+            &call_sites,
+            Path::new("."),
+        );
+        assert_eq!(resolution.file_edges.len(), 1);
+        let (from, to, confidence) = resolution.file_edges[0];
         assert_eq!((from, to, confidence), (py_idx, sym_idx, 0.4));
         fx.graph
             .add_edge_normalized(from, to, EdgeKind::Reference, confidence);

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -156,20 +156,6 @@ pub fn run_deploy(config: DeployConfig) -> anyhow::Result<()> {
             );
         }
     }
-    // 6b. Inject client-call edges (metacall('fn', ...) -> target symbol)
-    // and collect unresolved-invocation diagnostics.
-    let client_resolution = client_call::resolve_client_calls(
-        &analysis.graph,
-        &analysis.extractions,
-        &all_call_sites,
-        &config.root,
-    );
-    for (from_idx, to_idx, confidence) in client_resolution.edges {
-        analysis
-            .graph
-            .add_edge_normalized(from_idx, to_idx, EdgeKind::Reference, confidence);
-    }
-    diagnostics.extend(client_resolution.diagnostics);
 
     // 6c. Report orphaned MetaCall configuration files and surface every
     // diagnostic collected during analysis and edge injection.

--- a/src/graph/builder.rs
+++ b/src/graph/builder.rs
@@ -15,7 +15,7 @@ use petgraph::graph::{DiGraph, EdgeIndex, NodeIndex};
 use petgraph::visit::EdgeRef;
 
 use crate::graph::CodeGraph;
-use crate::graph::edge::{EdgeData, EdgeKind};
+use crate::graph::edge::{CONFIDENCE_CROSS_LANGUAGE, CONFIDENCE_OWN_OR_DIRECT, EdgeData, EdgeKind};
 #[cfg(feature = "dataflow")]
 use crate::graph::node::DataGraphNode;
 use crate::graph::node::{ExternalNode, FileNode, NodeData, SymbolNode};
@@ -92,7 +92,6 @@ impl GraphBuilder {
         };
 
         let idx = self.graph.add_node(NodeData::File(node));
-
         self.file_to_index.insert(id, idx);
         self.path_to_file.insert(path, id);
 
@@ -200,11 +199,20 @@ impl GraphBuilder {
         let Some(&from_idx) = self.file_to_index.get(&from) else {
             return; // Source not in graph
         };
+        let Some(source_language) = self.graph[from_idx].as_file().map(|file| file.language) else {
+            return; // Index without a file node: the graph is inconsistent
+        };
 
         // Resolve target path to file ID if it exists in our graph
         if let Some(&to_id) = self.path_to_file.get(&to) {
             if let Some(&to_idx) = self.file_to_index.get(&to_id) {
-                self.add_edge_internal(from_idx, to_idx, EdgeKind::Import, 1.0);
+                let target_language = self.graph[to_idx].as_file().map(|file| file.language);
+                let confidence = if target_language == Some(source_language) {
+                    CONFIDENCE_OWN_OR_DIRECT
+                } else {
+                    CONFIDENCE_CROSS_LANGUAGE
+                };
+                self.add_edge_internal(from_idx, to_idx, EdgeKind::Import, confidence);
             }
             return;
         }
@@ -214,19 +222,9 @@ impl GraphBuilder {
         let to_idx = if let Some(&idx) = self.external_index.get(&raw_path) {
             idx
         } else {
-            // Determine language from source file
-            let language = self
-                .path_to_file
-                .iter()
-                .find(|(_, id)| **id == from)
-                .map(|(p, _)| {
-                    crate::input::detect_language(p).unwrap_or(crate::language::LangId::Python)
-                })
-                .unwrap_or(crate::language::LangId::Python);
-
             let node = ExternalNode {
                 raw_path: raw_path.clone(),
-                language,
+                language: source_language,
                 classification: None,
             };
             let idx = self.graph.add_node(NodeData::External(node));
@@ -234,12 +232,25 @@ impl GraphBuilder {
             idx
         };
 
-        self.add_edge_internal(from_idx, to_idx, EdgeKind::Import, 1.0);
+        self.add_edge_internal(from_idx, to_idx, EdgeKind::Import, CONFIDENCE_OWN_OR_DIRECT);
     }
 
     /// Internal edge addition with flow kind, respecting normalization.
     #[cfg(feature = "dataflow")]
     fn add_edge_internal_with_flow(
+        &mut self,
+        source: NodeIndex,
+        target: NodeIndex,
+        kind: EdgeKind,
+        confidence: f32,
+        flow_kind: Option<crate::model::FlowKind>,
+    ) {
+        self.insert_edge(source, target, kind, confidence, flow_kind);
+    }
+
+    /// The one normalization rule: max merge confidence on a repeated triple,
+    /// and the first flow kind wins.
+    fn insert_edge(
         &mut self,
         source: NodeIndex,
         target: NodeIndex,
@@ -257,15 +268,9 @@ impl GraphBuilder {
             }
             return;
         }
-        let edge_idx = self.graph.add_edge(
-            source,
-            target,
-            EdgeData {
-                kind,
-                confidence,
-                flow_kind,
-            },
-        );
+        let mut edge_data = EdgeData::with_confidence(kind, confidence);
+        edge_data.flow_kind = flow_kind;
+        let edge_idx = self.graph.add_edge(source, target, edge_data);
         self.edge_index.insert(key, edge_idx);
     }
 
@@ -296,18 +301,7 @@ impl GraphBuilder {
         kind: EdgeKind,
         confidence: f32,
     ) {
-        let confidence = confidence.clamp(0.0, 1.0);
-        let key = (source, target, kind);
-        if let Some(&edge_idx) = self.edge_index.get(&key) {
-            let existing = &mut self.graph[edge_idx];
-            existing.confidence = existing.confidence.max(confidence);
-            return;
-        }
-
-        let edge_data = EdgeData::with_confidence(kind, confidence);
-
-        let edge_idx = self.graph.add_edge(source, target, edge_data);
-        self.edge_index.insert(key, edge_idx);
+        self.insert_edge(source, target, kind, confidence, None);
     }
 
     /// Returns the FileId for a given file path, if registered.
@@ -525,15 +519,17 @@ impl GraphBuilder {
                 .flat_map(|file| file.borrow().call_sites.iter().cloned())
                 .collect();
             if !call_sites.is_empty() {
-                let (call_edges, call_diagnostics) =
-                    crate::deploy::client_call::resolve_client_call_edges(
-                        &graph,
-                        extractions,
-                        &call_sites,
-                        root,
-                    );
-                diagnostics.extend(call_diagnostics);
-                for (from, to, confidence) in call_edges {
+                let projections = crate::deploy::client_call::resolve_client_call_projections(
+                    &graph,
+                    extractions,
+                    &call_sites,
+                    root,
+                );
+                diagnostics.extend(projections.diagnostics);
+                for (from_idx, to_idx, confidence) in projections.file_edges {
+                    graph.add_edge_normalized(from_idx, to_idx, EdgeKind::Reference, confidence);
+                }
+                for (from, to, confidence) in projections.symbol_edges {
                     if let (Some(from_idx), Some(to_idx)) =
                         (graph.symbol_node_index(from), graph.symbol_node_index(to))
                     {

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -124,6 +124,22 @@ impl CodeGraph {
     pub fn add_node(&mut self, node: NodeData) -> NodeIndex {
         self.graph.add_node(node)
     }
+
+    /// Add a file node and register it in the file index.
+    pub fn add_file_node(&mut self, node: FileNode) -> NodeIndex {
+        let file_id = node.id;
+        let idx = self.graph.add_node(NodeData::File(node));
+        self.file_to_index.insert(file_id, idx);
+        idx
+    }
+
+    /// Add a symbol node and register it in the symbol index.
+    pub fn add_symbol_node(&mut self, node: SymbolNode) -> NodeIndex {
+        let symbol_id = node.id;
+        let idx = self.graph.add_node(NodeData::Symbol(node));
+        self.symbol_to_index.insert(symbol_id, idx);
+        idx
+    }
     pub fn file_node_index(&self, file_id: FileId) -> Option<NodeIndex> {
         self.file_to_index.get(&file_id).copied()
     }
@@ -234,18 +250,41 @@ impl CodeGraph {
     }
 
     pub fn files(&self) -> impl Iterator<Item = (FileId, &FileNode)> + '_ {
-        self.file_to_index.iter().filter_map(|(file_id, &idx)| {
-            self.graph
-                .node_weight(idx)
-                .and_then(|data| data.as_file().map(|f| (*file_id, f)))
-        })
+        let mut files: Vec<(FileId, &FileNode)> = self
+            .file_to_index
+            .iter()
+            .filter_map(|(file_id, &idx)| {
+                self.graph
+                    .node_weight(idx)
+                    .and_then(|data| data.as_file().map(|f| (*file_id, f)))
+            })
+            .collect();
+        files.sort_by(|a, b| a.1.path.cmp(&b.1.path));
+        files.into_iter()
     }
+
+    /// Files in path order.
+    ///
+    /// Callers that need a stable sequence, such as a shard export or a
+    /// partition, must not rely on hash map order.
     pub fn symbols(&self) -> impl Iterator<Item = (SymbolId, &SymbolNode)> + '_ {
-        self.symbol_to_index.iter().filter_map(|(symbol_id, &idx)| {
-            self.graph
-                .node_weight(idx)
-                .and_then(|data| data.as_symbol().map(|s| (*symbol_id, s)))
-        })
+        let mut symbols: Vec<(SymbolId, &SymbolNode)> = self
+            .symbol_to_index
+            .iter()
+            .filter_map(|(symbol_id, &idx)| {
+                self.graph
+                    .node_weight(idx)
+                    .and_then(|data| data.as_symbol().map(|s| (*symbol_id, s)))
+            })
+            .collect();
+        symbols.sort_by(|a, b| {
+            let left = self.file_node(a.1.file_id).map(|file| &file.path);
+            let right = self.file_node(b.1.file_id).map(|file| &file.path);
+            left.cmp(&right)
+                .then(a.1.name.cmp(&b.1.name))
+                .then(a.0.to_raw().cmp(&b.0.to_raw()))
+        });
+        symbols.into_iter()
     }
     pub fn edges_of_kind(
         &self,

--- a/src/graph/resolver.rs
+++ b/src/graph/resolver.rs
@@ -176,11 +176,7 @@ impl FlattenedScopeCache {
                         name: name.clone(),
                         confidence,
                         rank,
-                        path: ctx
-                            .file_paths
-                            .get(&current)
-                            .cloned()
-                            .unwrap_or_default(),
+                        path: ctx.file_paths.get(&current).cloned().unwrap_or_default(),
                     });
                 }
             }

--- a/src/graph/resolver.rs
+++ b/src/graph/resolver.rs
@@ -20,6 +20,15 @@ pub type ScopeMap = HashMap<String, Vec<(SymbolId, f32)>>;
 pub(crate) type SymbolIndexEntry = (SymbolId, String, LangId, Option<Visibility>);
 pub(crate) type SymbolIndex = HashMap<FileId, Vec<SymbolIndexEntry>>;
 
+/// One visible symbol candidate before shadowing and ranking.
+struct Candidate {
+    symbol: SymbolId,
+    confidence: f32,
+    rank: u8,
+    path: PathBuf,
+    name: String,
+}
+
 /// Bundles the data needed for scope resolution across files.
 pub struct ResolutionContext {
     pub symbol_index: SymbolIndex,
@@ -78,7 +87,7 @@ impl FlattenedScopeCache {
     /// - 0.8: transitive import, same language
     /// - 0.6: cross-language imports
     pub fn build(ctx: &ResolutionContext, diagnostics: &mut Vec<Diagnostic>) -> Self {
-        let results: Vec<(FileId, ScopeMap, Vec<Diagnostic>)> = ctx
+        let mut results: Vec<(FileId, ScopeMap, Vec<Diagnostic>)> = ctx
             .symbol_index
             .par_iter()
             .map(|(&file_id, _)| {
@@ -86,6 +95,10 @@ impl FlattenedScopeCache {
                 (file_id, scope, diags)
             })
             .collect();
+
+        // The parallel pass returns in hash order; diagnostics must follow the
+        // file path so two runs report the same sequence.
+        results.sort_by(|a, b| ctx.file_paths.get(&a.0).cmp(&ctx.file_paths.get(&b.0)));
 
         let mut scopes = HashMap::with_capacity(results.len());
         for (file_id, scope, diags) in results {
@@ -100,6 +113,7 @@ impl FlattenedScopeCache {
         let mut diagnostics = Vec::new();
         let source_lang = ctx.file_languages.get(&file_id).copied();
         let mut scope: ScopeMap = HashMap::new();
+        let mut candidates: Vec<Candidate> = Vec::new();
         let mut visited: HashSet<FileId> = HashSet::new();
         let mut queue: VecDeque<(FileId, usize)> = VecDeque::new();
 
@@ -144,11 +158,30 @@ impl FlattenedScopeCache {
                         CONFIDENCE_TRANSITIVE
                     };
 
-                    if let Some(entries) = scope.get_mut(name) {
-                        entries.push((*sym_id, confidence));
+                    // Rank classes follow the shadowing rule: the own file wins,
+                    // then a direct same-language import, then a transitive one,
+                    // and a cross-language import comes last.
+                    let rank = if distance == 0 {
+                        0u8
+                    } else if distance == 1 && same_lang {
+                        1
+                    } else if same_lang {
+                        2
                     } else {
-                        scope.insert(name.clone(), vec![(*sym_id, confidence)]);
-                    }
+                        3
+                    };
+
+                    candidates.push(Candidate {
+                        symbol: *sym_id,
+                        name: name.clone(),
+                        confidence,
+                        rank,
+                        path: ctx
+                            .file_paths
+                            .get(&current)
+                            .cloned()
+                            .unwrap_or_default(),
+                    });
                 }
             }
 
@@ -182,13 +215,35 @@ impl FlattenedScopeCache {
             }
         }
 
-        // Sort each entry: higher confidence first, then by symbol_id (stable)
-        for entries in scope.values_mut() {
-            entries.sort_by(|a, b| {
-                b.1.partial_cmp(&a.1)
-                    .unwrap_or(std::cmp::Ordering::Equal)
-                    .then(a.0.to_raw().cmp(&b.0.to_raw()))
+        // Nearer definitions shadow farther ones. The remaining candidates keep
+        // a total order: rank, confidence, path, then identifier. The raw
+        // identifier comes last, because it is unique only inside a run.
+        let mut grouped: HashMap<String, Vec<Candidate>> = HashMap::new();
+        for candidate in candidates {
+            grouped
+                .entry(candidate.name.clone())
+                .or_default()
+                .push(candidate);
+        }
+        for (name, mut group) in grouped {
+            let best = group.iter().map(|candidate| candidate.rank).min();
+            if let Some(best) = best {
+                group.retain(|candidate| candidate.rank == best);
+            }
+            group.sort_by(|a, b| {
+                a.rank
+                    .cmp(&b.rank)
+                    .then(b.confidence.total_cmp(&a.confidence))
+                    .then(a.path.cmp(&b.path))
+                    .then(a.symbol.to_raw().cmp(&b.symbol.to_raw()))
             });
+            scope.insert(
+                name,
+                group
+                    .into_iter()
+                    .map(|candidate| (candidate.symbol, candidate.confidence))
+                    .collect(),
+            );
         }
 
         (scope, diagnostics)
@@ -268,10 +323,7 @@ where
 
                     if let Some(source) = source_sym {
                         for &(target_id, confidence) in matches {
-                            // Don't add self-references (symbol to itself)
-                            if source.id != target_id {
-                                local_edges.push((source.id, target_id, confidence));
-                            }
+                            local_edges.push((source.id, target_id, confidence));
                         }
                     }
                 } else {


### PR DESCRIPTION
## Summary

Graph resolution. Fixes G2 to G9 and G11, plus N-G1 and the duplicated client-call pass.

- Scope candidates rank by proximity: the own file shadows a direct same-language import, which shadows a transitive one, and a cross-language import ranks last. Equally ranked candidates stay visible and order by path, never by the raw identifier.
- A recursive call now creates the self loop the graph model describes, so `DeployabilityHint::SelfLoop` is reachable.
- Client calls resolve once and yield both projections: a file-to-symbol edge for deployment, which also covers top-level calls, and a symbol-to-symbol edge for navigation. The deploy path no longer injects a second copy and no longer reads every load configuration twice.
- Import edges follow the confidence ladder and take their language from the file node, so a file whose path has no known extension no longer falls back to Python.
- `files()` and `symbols()` iterate in path order; the builder has one edge normalization rule; `CodeGraph` gained typed node helpers.
- `G8` is by design and documented: a reference outside any symbol is not promoted to an edge, because the import edge already carries the file level dependency and cursor resolution reads the scope cache.

## Type of change

- [x] `fix` - bug fix

## Affected area

- [x] `graph` / SCC
- [x] `deploy` (feature)
