### PR TITLE
fix(deploy): classify call sites exactly and keep every cut annotation

### DIFF
--- a/docs/src/DEPLOY.md
+++ b/docs/src/DEPLOY.md
@@ -7,8 +7,8 @@ Feature-gated. Build with `--features metacall-deploy`.
 The `deploy` subcommand scans polyglot projects for MetaCall load and client call sites. It partitions files into same-language pods, resolves external dependencies from lockfiles, and generates two deployment artifacts:
 
 | Artifact | Description |
-|---|---|
-| `metacall.pods.json` | Pod manifest with deployment units, inter-pod edges, dependency lists, and AST metrics |
+| --- | --- |
+| `metacall.pods.json` | Pod manifest (version 1.1) with deployment units, inter-pod edges, per-pair cut annotations, dependency lists, and AST metrics |
 | `metacall.mesh.json` | Function Mesh topology with SCC deployment units and call-site attribution |
 
 With `-f yaml` the same documents are written as `metacall.pods.yaml` and
@@ -31,7 +31,7 @@ meta-ast deploy <path> --check
 ### Options
 
 | Flag | Default | Description |
-|---|---|---|
+| --- | --- | --- |
 | `-o, --out <dir>` | `.` | Directory to write generated artifacts |
 | `-f, --format <json\|yaml>` | `json` | Serialization format |
 | `--check` | off | Fairness check mode: exits non-zero on missing RPC stubs |
@@ -85,7 +85,7 @@ src/deploy/
 ### Supported variants
 
 | Variant | Detected functions |
-|---|---|
+| --- | --- |
 | `LoadFromFile` | `metacall_load_from_file`, `LoadFromFile` (Go), bare `use` import (Rust), `load::from_single_file` (Rust) |
 | `LoadFromMemory` | `metacall_load_from_memory`, `LoadFromMemory` |
 | `LoadFromPackage` | `metacall_load_from_package`, `LoadFromPackage` |
@@ -95,7 +95,7 @@ src/deploy/
 ### Confidence scoring
 
 | Case | Score |
-|---|---|
+| --- | --- |
 | String literal argument | `1.0` |
 | Unique match in load-confirmed files (Phase A) | `1.0` |
 | Multiple matches in load-confirmed files (Phase A) | `0.8` |
@@ -128,12 +128,12 @@ Files sharing the same `LangId` and connected by Import or Reference edges join 
 
 ### Confidence fusion
 
-When both an Import edge and a Reference edge connect the same pod pair, confidence scores multiply to form a combined weight in [0.0, 1.0]. If only one edge type exists, its confidence is used directly.
+When an Import edge and a Reference edge connect the same pod pair, the fusion keeps the stronger confidence (`max`), never the product. A repeated `(source, target, kind)` triple merges the same way.
 
 ### Language tag mapping
 
 | Language | Tag |
-|---|---|
+| --- | --- |
 | Python | `py` |
 | JavaScript | `node` |
 | TypeScript / TSX | `ts` |
@@ -160,7 +160,7 @@ C and C++ share the `c` loader (libclang). Go has no MetaCall loader yet; deploy
 `dependency::resolve_dependencies` collects external imports per pod and inspects project lockfiles and manifests.
 
 | Language(s) | Resolver | Lockfile (preferred) | Manifest (fallback) |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | Python | `classify_python` | `uv.lock`, `poetry.lock`, `Pipfile.lock` | `pyproject.toml`, `requirements.txt` |
 | JS / TS / TSX | `classify_node_ecosystem` | `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml` | `package.json` |
 | Rust | `classify_rust` | `Cargo.lock` | `Cargo.toml` |
@@ -177,7 +177,7 @@ Lockfiles supply pinned versions (`source: "Lockfile"`). Manifest fallbacks set 
 
 ```json
 {
-  "version": "1.0",
+  "version": "1.1",
   "deployments": [
     {
       "id": 0,
@@ -205,7 +205,7 @@ Lockfiles supply pinned versions (`source: "Lockfile"`). Manifest fallbacks set 
       "kind": "import",
       "confidence": 1.0,
       "is_cross_language": true,
-      "cut_annotation": null
+      "cut_annotations": []
     }
   ],
   "metrics": {
@@ -256,9 +256,9 @@ Units with `is_mesh_candidate = true` and `is_cross_language = false` deploy ind
 
 `check::check_cut_fairness` validates RPC stub contracts:
 
-1. Every cut edge appears in `manifest.edges[]` with a `cut_annotation`.
+1. Every cut edge appears in `manifest.edges[]` with cut annotations.
 2. Cut edges have `kind: "rpc_stub"`.
-3. Non-cut edges omit `cut_annotation`.
+3. Non-cut edges carry no cut annotation.
 
 `run_deploy` exits non-zero if fairness checks fail.
 

--- a/docs/src/DEPLOY.md
+++ b/docs/src/DEPLOY.md
@@ -11,6 +11,10 @@ The `deploy` subcommand scans polyglot projects for MetaCall load and client cal
 | `metacall.pods.json` | Pod manifest with deployment units, inter-pod edges, dependency lists, and AST metrics |
 | `metacall.mesh.json` | Function Mesh topology with SCC deployment units and call-site attribution |
 
+With `-f yaml` the same documents are written as `metacall.pods.yaml` and
+`metacall.mesh.yaml`. MetaCall core reads JSON only, so the YAML form is a
+meta-ast artifact for people and for tooling that prefers YAML.
+
 ## Usage
 
 ```bash

--- a/src/deploy/check.rs
+++ b/src/deploy/check.rs
@@ -12,8 +12,8 @@ use crate::deploy::manifest::PodManifest;
 /// Verify that every cut edge has a corresponding manifest entry.
 ///
 /// Principles (aligned with ADR 0003):
-/// - Every cut edge must appear in `manifest.edges[]` with `cut_annotation`.
-/// - No non-cut edge may have a `cut_annotation`.
+/// - Every cut edge must appear in `manifest.edges[]` with cut annotations.
+/// - No non-cut edge may carry cut annotations.
 /// - Every cut edge must have `kind: "rpc_stub"`.
 pub fn check_cut_fairness(manifest: &PodManifest, cuts: &[CutEdge]) -> Vec<String> {
     let mut diagnostics = Vec::new();
@@ -22,11 +22,11 @@ pub fn check_cut_fairness(manifest: &PodManifest, cuts: &[CutEdge]) -> Vec<Strin
 
     for cut in cuts {
         let present = manifest.edges.iter().any(|e| {
-            e.from_pod == cut.from_pod && e.to_pod == cut.to_pod && e.cut_annotation.is_some()
+            e.from_pod == cut.from_pod && e.to_pod == cut.to_pod && !e.cut_annotations.is_empty()
         });
         if !present {
             diagnostics.push(format!(
-                "cut edge ({}, {}) missing from manifest or missing cut_annotation",
+                "cut edge ({}, {}) missing from manifest or missing cut annotation",
                 cut.from_pod, cut.to_pod
             ));
         }
@@ -49,9 +49,9 @@ pub fn check_cut_fairness(manifest: &PodManifest, cuts: &[CutEdge]) -> Vec<Strin
     }
 
     for edge in &manifest.edges {
-        if edge.cut_annotation.is_some() && !cut_pairs.contains(&(edge.from_pod, edge.to_pod)) {
+        if !edge.cut_annotations.is_empty() && !cut_pairs.contains(&(edge.from_pod, edge.to_pod)) {
             diagnostics.push(format!(
-                "edge ({}, {}) has cut_annotation but is not in the cut list",
+                "edge ({}, {}) has cut annotations but is not in the cut list",
                 edge.from_pod, edge.to_pod
             ));
         }

--- a/src/deploy/client_call.rs
+++ b/src/deploy/client_call.rs
@@ -23,6 +23,24 @@ pub(crate) fn resolve_script_to_file(
     source_file: &Path,
     path_to_idx: &HashMap<PathBuf, NodeIndex>,
 ) -> Option<NodeIndex> {
+    if let Some(idx) = resolve_script_candidate(root, script, source_file, path_to_idx) {
+        return Some(idx);
+    }
+    // A script written on Windows uses backslashes, which are not separators on
+    // Unix, so the normalized form is a second candidate.
+    let normalized = script.replace('\\', "/");
+    if normalized != script {
+        return resolve_script_candidate(root, &normalized, source_file, path_to_idx);
+    }
+    None
+}
+
+fn resolve_script_candidate(
+    root: &Path,
+    script: &str,
+    source_file: &Path,
+    path_to_idx: &HashMap<PathBuf, NodeIndex>,
+) -> Option<NodeIndex> {
     // Strategy 1: root-relative.
     let candidate = root.join(script);
     if let Some(&idx) = path_to_idx.get(&candidate) {

--- a/src/deploy/cut.rs
+++ b/src/deploy/cut.rs
@@ -129,14 +129,22 @@ pub fn find_cross_language_cuts(
         }
 
         if let Some((src, dst, conf)) = best_edge {
-            let from_pod = file_to_pod.get(&src).copied().unwrap_or(0);
-            let to_pod = file_to_pod.get(&dst).copied().unwrap_or(0);
+            let (Some(&from_pod), Some(&to_pod)) = (file_to_pod.get(&src), file_to_pod.get(&dst))
+            else {
+                // A cut anchored at pod zero would blame an unrelated pod.
+                tracing::warn!(
+                    from = src.to_raw(),
+                    to = dst.to_raw(),
+                    "cut skipped: an endpoint has no pod"
+                );
+                continue;
+            };
             cuts.push(CutEdge {
                 from_pod,
                 to_pod,
                 annotation: CutAnnotation {
-                    from_file: src.to_raw().to_string(),
-                    to_file: dst.to_raw().to_string(),
+                    from_file: file_label(graph, src),
+                    to_file: file_label(graph, dst),
                     cut_reason: CutReason::CrossLanguageScc,
                     original_confidence: conf,
                 },
@@ -145,6 +153,15 @@ pub fn find_cross_language_cuts(
     }
 
     cuts
+}
+
+/// A portable path for a file node. A missing node keeps the identifier form so
+/// the anomaly is visible instead of silently pointing at another file.
+fn file_label(graph: &CodeGraph, file_id: FileId) -> String {
+    graph
+        .file_node(file_id)
+        .map(|file| crate::input::portable_path(&file.path))
+        .unwrap_or_else(|| format!("file#{}", file_id.to_raw()))
 }
 
 /// Find the weakest internal edge in an oversized pod and mark it for splitting.
@@ -190,8 +207,8 @@ pub fn find_oversized_pod_cut(pod: &Pod, graph: &CodeGraph, max_size: usize) -> 
         from_pod: pod.id,
         to_pod: pod.id,
         annotation: CutAnnotation {
-            from_file: src.to_raw().to_string(),
-            to_file: dst.to_raw().to_string(),
+            from_file: file_label(graph, src),
+            to_file: file_label(graph, dst),
             cut_reason: CutReason::OversizedPod {
                 pod_size: pod.files.len(),
                 max_size,

--- a/src/deploy/dependency.rs
+++ b/src/deploy/dependency.rs
@@ -120,10 +120,13 @@ fn classify_python(external: &ExternalNode, root: &Path) -> ExternalClassificati
         root.join("Pipfile.lock"),
     ];
     for lf in &lockfiles {
-        if lf.exists() {
+        if !lf.exists() {
+            continue;
+        }
+        if let Some(version) = parse_version_from_lockfile(lf, &external.raw_path) {
             return ExternalClassification::Classified {
                 package_name: external.raw_path.clone(),
-                version: parse_version_from_lockfile(lf, &external.raw_path),
+                version: Some(version),
                 language: LangId::Python,
                 source: DependencySource::Lockfile,
             };
@@ -177,10 +180,13 @@ fn classify_node_ecosystem(external: &ExternalNode, root: &Path) -> ExternalClas
         root.join("pnpm-lock.yaml"),
     ];
     for lf in &lockfiles {
-        if lf.exists() {
+        if !lf.exists() {
+            continue;
+        }
+        if let Some(version) = parse_version_from_lockfile(lf, &external.raw_path) {
             return ExternalClassification::Classified {
                 package_name: external.raw_path.clone(),
-                version: parse_version_from_lockfile(lf, &external.raw_path),
+                version: Some(version),
                 language: external.language,
                 source: DependencySource::Lockfile,
             };
@@ -205,10 +211,12 @@ fn classify_node_ecosystem(external: &ExternalNode, root: &Path) -> ExternalClas
                 continue;
             }
             let lock_path = subdir.join("package-lock.json");
-            if lock_path.exists() {
+            if lock_path.exists()
+                && let Some(version) = parse_version_from_lockfile(&lock_path, &external.raw_path)
+            {
                 return ExternalClassification::Classified {
                     package_name: external.raw_path.clone(),
-                    version: parse_version_from_lockfile(&lock_path, &external.raw_path),
+                    version: Some(version),
                     language: external.language,
                     source: DependencySource::Lockfile,
                 };
@@ -260,10 +268,12 @@ fn classify_rust(external: &ExternalNode, root: &Path) -> ExternalClassification
 
 fn classify_go(external: &ExternalNode, root: &Path) -> ExternalClassification {
     let lf = root.join("go.sum");
-    if lf.exists() {
+    if lf.exists()
+        && let Some(version) = parse_version_from_go_sum(&lf, &external.raw_path)
+    {
         return ExternalClassification::Classified {
             package_name: external.raw_path.clone(),
-            version: parse_version_from_go_sum(&lf, &external.raw_path),
+            version: Some(version),
             language: LangId::Go,
             source: DependencySource::Lockfile,
         };
@@ -273,7 +283,7 @@ fn classify_go(external: &ExternalNode, root: &Path) -> ExternalClassification {
     if mf.exists() {
         return ExternalClassification::Classified {
             package_name: external.raw_path.clone(),
-            version: None,
+            version: parse_version_from_go_mod(&mf, &external.raw_path),
             language: LangId::Go,
             source: DependencySource::Manifest,
         };
@@ -344,18 +354,76 @@ fn classify_c_cpp_best_effort(external: &ExternalNode, root: &Path) -> ExternalC
 /// Best-effort version extraction from a lockfile by searching for the
 /// package name followed by a version-like string. Returns None if the
 /// package isn't found or the file can't be read.
+/// True when the line names exactly this entry, in any lockfile grammar:
+/// `name = "x"`, `x==1.2.3`, `"x": {`, `x (1.2.3)`, `"x@^1.2.3":`.
+fn names_entry(line: &str, package: &str) -> bool {
+    let trimmed = line.trim().trim_start_matches('-').trim();
+    for token in trimmed.split(|c: char| {
+        matches!(
+            c,
+            '=' | ' ' | '"' | '(' | ')' | '[' | ']' | ':' | ',' | '\'' | '{'
+        )
+    }) {
+        let token = token.trim();
+        if token == package {
+            return true;
+        }
+        if let Some(rest) = token.strip_prefix(package)
+            && matches!(
+                rest.chars().next(),
+                Some('@') | Some('^') | Some('~') | Some('>')
+            )
+        {
+            return true;
+        }
+    }
+    false
+}
+
+/// A `version = "x.y.z"` style assignment, whatever the surrounding syntax.
+fn version_assignment(line: &str) -> Option<String> {
+    let trimmed = line.trim().trim_start_matches('-').trim();
+    let rest = trimmed.strip_prefix("version")?.trim_start();
+    if !(rest.starts_with('=') || rest.starts_with(':') || rest.starts_with('"')) {
+        return None;
+    }
+    extract_semver(rest)
+}
+
 fn parse_version_from_lockfile(path: &Path, package: &str) -> Option<String> {
     let content = std::fs::read_to_string(path).ok()?;
-    // Search for the package name, then grab the next quoted/hyphenated
-    // version-like token on the same or next line.
+    let mut inside_entry = false;
+
     for line in content.lines() {
-        if line.contains(package) {
-            // Look for a semver-like pattern on this line or the next few.
-            for candidate in content.lines().skip_while(|l| !l.contains(package)).take(5) {
-                if let Some(v) = extract_semver(candidate) {
-                    return Some(v);
+        let trimmed = line.trim();
+
+        // A new section or entry header closes the open entry.
+        if trimmed.starts_with('[') {
+            inside_entry = false;
+        }
+
+        if names_entry(trimmed, package) {
+            if let Some(version) = version_assignment(trimmed) {
+                return Some(version);
+            }
+            if trimmed.contains("==") || trimmed.contains(">=") || trimmed.contains("~=") {
+                if let Some(version) = extract_semver(trimmed) {
+                    return Some(version);
                 }
             }
+            inside_entry = true;
+            continue;
+        }
+
+        if !inside_entry {
+            continue;
+        }
+        if let Some(version) = version_assignment(trimmed) {
+            return Some(version);
+        }
+        // A blank line ends a TOML entry that carried no version.
+        if trimmed.is_empty() {
+            inside_entry = false;
         }
     }
     None
@@ -398,14 +466,47 @@ fn parse_version_from_cargo_lock(path: &Path, package: &str) -> Option<String> {
 
 fn parse_version_from_go_sum(path: &Path, package: &str) -> Option<String> {
     let content = std::fs::read_to_string(path).ok()?;
-    // go.sum format: <module> <version> <hash>
-    // Take the first line matching the package.
+    // go.sum format: <module> <version> <hash>, one line per module version.
     for line in content.lines() {
-        if line.starts_with(package) {
-            let parts: Vec<&str> = line.split_whitespace().collect();
-            if parts.len() >= 2 {
-                return Some(parts[1].to_string());
-            }
+        let mut parts = line.split_whitespace();
+        if parts.next() != Some(package) {
+            continue;
+        }
+        if let Some(version) = parts.next() {
+            return Some(version.to_string());
+        }
+    }
+    None
+}
+
+/// Read a `require` line, in single or block form, and drop the `v` prefix.
+fn parse_version_from_go_mod(path: &Path, module: &str) -> Option<String> {
+    let content = std::fs::read_to_string(path).ok()?;
+    let mut inside_block = false;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("require (") {
+            inside_block = true;
+            continue;
+        }
+        if inside_block && trimmed.starts_with(')') {
+            inside_block = false;
+            continue;
+        }
+        let entry = if let Some(rest) = trimmed.strip_prefix("require ") {
+            rest
+        } else if inside_block {
+            trimmed
+        } else {
+            continue;
+        };
+        let mut parts = entry.split_whitespace();
+        if parts.next() != Some(module) {
+            continue;
+        }
+        if let Some(version) = parts.next() {
+            return Some(version.trim_start_matches('v').to_string());
         }
     }
     None

--- a/src/deploy/dependency.rs
+++ b/src/deploy/dependency.rs
@@ -406,10 +406,10 @@ fn parse_version_from_lockfile(path: &Path, package: &str) -> Option<String> {
             if let Some(version) = version_assignment(trimmed) {
                 return Some(version);
             }
-            if trimmed.contains("==") || trimmed.contains(">=") || trimmed.contains("~=") {
-                if let Some(version) = extract_semver(trimmed) {
-                    return Some(version);
-                }
+            if (trimmed.contains("==") || trimmed.contains(">=") || trimmed.contains("~="))
+                && let Some(version) = extract_semver(trimmed)
+            {
+                return Some(version);
             }
             inside_entry = true;
             continue;

--- a/src/deploy/manifest.rs
+++ b/src/deploy/manifest.rs
@@ -148,12 +148,6 @@ pub fn generate_pod_manifest(
         .collect();
 
     // Mark cut edges that weren't already in inter_pod_edges as rpc_stub edges.
-    let inter_pod_pairs: std::collections::HashSet<(usize, usize)> = partition
-        .inter_pod_edges
-        .iter()
-        .map(|ip| (ip.from_pod, ip.to_pod))
-        .collect();
-
     // Every cut pair must surface as one `rpc_stub` edge (ADR 0003: a forced
     // split is only safe if the call boundary is explicitly represented). The
     // pair carries every annotation, and a repeated pair does not add a stub.
@@ -258,6 +252,41 @@ mod tests {
             file_languages: HashMap::from([(py, LangId::Python), (js, LangId::JavaScript)]),
         };
         (partition, graph)
+    }
+
+    #[test]
+    fn pod_file_without_a_graph_node_is_counted() {
+        let (mut partition, graph) = test_partition();
+        let missing = FileId::new(99).unwrap();
+        partition.pods[0].files.push(missing);
+
+        let metrics = vec![
+            PodMetrics {
+                total_ast_nodes: 1,
+                file_count: 1,
+                symbol_count: 0,
+            },
+            PodMetrics {
+                total_ast_nodes: 1,
+                file_count: 1,
+                symbol_count: 0,
+            },
+        ];
+
+        let manifest = generate_pod_manifest(&partition, &metrics, &[], &HashMap::new(), &graph);
+
+        assert_eq!(
+            manifest.metrics.dropped_files, 1,
+            "a pod file with no graph node must be counted"
+        );
+        assert!(
+            !manifest.deployments[0]
+                .files
+                .iter()
+                .any(|file| file.contains("99")),
+            "the missing file must not appear in the deployment: {:?}",
+            manifest.deployments[0].files
+        );
     }
 
     fn cut(reason: CutReason, confidence: f32) -> CutEdge {

--- a/src/deploy/manifest.rs
+++ b/src/deploy/manifest.rs
@@ -42,8 +42,8 @@ pub struct ManifestEdge {
     pub kind: String,
     pub confidence: f32,
     pub is_cross_language: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub cut_annotation: Option<CutAnnotation>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub cut_annotations: Vec<CutAnnotation>,
 }
 
 /// Global aggregate metrics for the entire manifest.
@@ -52,6 +52,9 @@ pub struct GlobalMetrics {
     pub total_pods: usize,
     pub cross_language_edges: usize,
     pub total_ast_nodes: usize,
+    /// Pod files the graph or the metrics pass could not resolve.
+    #[serde(default)]
+    pub dropped_files: usize,
 }
 
 /// Generate a `PodManifest` from partition, metrics, cuts, and dependencies.
@@ -63,25 +66,42 @@ pub fn generate_pod_manifest(
     graph: &CodeGraph,
 ) -> PodManifest {
     let mut deployments = Vec::with_capacity(partition.pods.len());
+    let mut dropped_files = 0usize;
 
     for (i, pod) in partition.pods.iter().enumerate() {
         let tag = crate::deploy::tags::metacall_tag(pod.language);
+        let mut dropped = 0usize;
         let files: Vec<String> = pod
             .files
             .iter()
-            .filter_map(|fid| {
-                graph
-                    .file_node(*fid)
-                    .map(|f| crate::input::portable_path(&f.path))
+            .filter_map(|fid| match graph.file_node(*fid) {
+                Some(file) => Some(crate::input::portable_path(&file.path)),
+                None => {
+                    dropped += 1;
+                    tracing::warn!(
+                        pod = pod.id,
+                        file = fid.to_raw(),
+                        "pod file has no graph node"
+                    );
+                    None
+                }
             })
             .collect();
 
         let deps = dependencies.get(&pod.id).cloned().unwrap_or_default();
-        let pm = pod_metrics.get(i).cloned().unwrap_or(PodMetrics {
-            total_ast_nodes: 0,
-            file_count: 0,
-            symbol_count: 0,
-        });
+        let pm = match pod_metrics.get(i).cloned() {
+            Some(metrics) => metrics,
+            None => {
+                dropped += 1;
+                tracing::warn!(pod = pod.id, "pod has no metrics entry");
+                PodMetrics {
+                    total_ast_nodes: 0,
+                    file_count: 0,
+                    symbol_count: 0,
+                }
+            }
+        };
+        dropped_files += dropped;
 
         deployments.push(PodDeployment {
             id: pod.id,
@@ -92,10 +112,14 @@ pub fn generate_pod_manifest(
         });
     }
 
-    // Build inter-pod edges, annotating cuts where applicable.
-    let mut cut_lookup: HashMap<(usize, usize), &CutAnnotation> = HashMap::new();
+    // Build inter-pod edges, annotating cuts where applicable. A pod pair can
+    // carry more than one cut, so the annotations merge into a list.
+    let mut cut_lookup: HashMap<(usize, usize), Vec<CutAnnotation>> = HashMap::new();
     for cut in cuts {
-        cut_lookup.insert((cut.from_pod, cut.to_pod), &cut.annotation);
+        cut_lookup
+            .entry((cut.from_pod, cut.to_pod))
+            .or_default()
+            .push(cut.annotation.clone());
     }
 
     let mut edges: Vec<ManifestEdge> = partition
@@ -108,16 +132,17 @@ pub fn generate_pod_manifest(
                 crate::graph::EdgeKind::Ownership => "ownership".to_string(),
                 crate::graph::EdgeKind::Flow => "flow".to_string(),
             };
-            let annotation = cut_lookup
+            let annotations = cut_lookup
                 .get(&(ip.from_pod, ip.to_pod))
-                .map(|a| (*a).clone());
+                .cloned()
+                .unwrap_or_default();
             ManifestEdge {
                 from_pod: ip.from_pod,
                 to_pod: ip.to_pod,
                 kind,
                 confidence: ip.confidence,
                 is_cross_language: ip.is_cross_language,
-                cut_annotation: annotation,
+                cut_annotations: annotations,
             }
         })
         .collect();
@@ -129,51 +154,51 @@ pub fn generate_pod_manifest(
         .map(|ip| (ip.from_pod, ip.to_pod))
         .collect();
 
-    for cut in cuts {
-        // Every cut must surface as a `rpc_stub` edge (ADR 0003: a forced
-        // split is only safe if the call boundary is explicitly represented).
-        // This holds even when an `import` edge for the same pod pair already
-        // exists - the import edge keeps its annotation, and a distinct
-        // `rpc_stub` edge records the split boundary.
-        edges.push(ManifestEdge {
-            from_pod: cut.from_pod,
-            to_pod: cut.to_pod,
-            kind: "rpc_stub".to_string(),
-            confidence: cut.annotation.original_confidence,
-            is_cross_language: matches!(
-                cut.annotation.cut_reason,
-                crate::deploy::cut::CutReason::CrossLanguageScc
-            ),
-            cut_annotation: Some(cut.annotation.clone()),
-        });
-
-        // Also annotate the matching import/reference edge so the existing
-        // cross-language link carries the cut reason.
-        if inter_pod_pairs.contains(&(cut.from_pod, cut.to_pod)) {
-            for edge in &mut edges {
-                if edge.from_pod == cut.from_pod
-                    && edge.to_pod == cut.to_pod
-                    && edge.cut_annotation.is_none()
-                {
-                    edge.cut_annotation = Some(cut.annotation.clone());
-                }
-            }
+    // Every cut pair must surface as one `rpc_stub` edge (ADR 0003: a forced
+    // split is only safe if the call boundary is explicitly represented). The
+    // pair carries every annotation, and a repeated pair does not add a stub.
+    for (pair, annotations) in &cut_lookup {
+        if edges
+            .iter()
+            .any(|edge| edge.kind == "rpc_stub" && edge.from_pod == pair.0 && edge.to_pod == pair.1)
+        {
+            continue;
         }
+        let confidence = annotations
+            .iter()
+            .map(|annotation| annotation.original_confidence)
+            .fold(f32::INFINITY, f32::min);
+        edges.push(ManifestEdge {
+            from_pod: pair.0,
+            to_pod: pair.1,
+            kind: "rpc_stub".to_string(),
+            confidence,
+            is_cross_language: annotations.iter().any(|annotation| {
+                matches!(
+                    annotation.cut_reason,
+                    crate::deploy::cut::CutReason::CrossLanguageScc
+                )
+            }),
+            cut_annotations: annotations.clone(),
+        });
     }
 
     edges.sort_by(|a, b| (a.from_pod, a.to_pod, &a.kind).cmp(&(b.from_pod, b.to_pod, &b.kind)));
-    let total_ast_nodes = pod_metrics.iter().map(|m| m.total_ast_nodes).sum();
+    let total_ast_nodes = pod_metrics.iter().fold(0usize, |total, metrics| {
+        total.saturating_add(metrics.total_ast_nodes)
+    });
     let cross_language_edges = edges.iter().filter(|e| e.is_cross_language).count();
     let total_pods = deployments.len();
 
     PodManifest {
-        version: "1.0".to_string(),
+        version: "1.1".to_string(),
         deployments,
         edges,
         metrics: GlobalMetrics {
             total_pods,
             cross_language_edges,
             total_ast_nodes,
+            dropped_files,
         },
     }
 }

--- a/src/deploy/mesh.rs
+++ b/src/deploy/mesh.rs
@@ -306,9 +306,8 @@ pub fn generate_mesh_annotation(
 
     // Canonical order: a caller reads the same document for the same tree.
     for unit in &mut deployment_units {
-        unit.symbols.sort_by(|a, b| {
-            (&a.file, &a.name, &a.kind).cmp(&(&b.file, &b.name, &b.kind))
-        });
+        unit.symbols
+            .sort_by(|a, b| (&a.file, &a.name, &a.kind).cmp(&(&b.file, &b.name, &b.kind)));
     }
     cross_language_edges.sort_by(|a, b| {
         (a.from_unit, a.to_unit, &a.from_language, &a.to_language).cmp(&(

--- a/src/deploy/mesh.rs
+++ b/src/deploy/mesh.rs
@@ -37,7 +37,7 @@ pub struct CrossLanguageEdge {
     pub from_language: String,
     pub to_language: String,
     pub call_site: Option<String>,
-    pub confidence: f64,
+    pub confidence: f32,
 }
 
 #[derive(Serialize, Default)]
@@ -298,11 +298,26 @@ pub fn generate_mesh_annotation(
                     from_language: u_lang.to_string(),
                     to_language: v_lang.to_string(),
                     call_site: call_site_file,
-                    confidence: weight.confidence as f64,
+                    confidence: weight.confidence,
                 });
             }
         }
     }
+
+    // Canonical order: a caller reads the same document for the same tree.
+    for unit in &mut deployment_units {
+        unit.symbols.sort_by(|a, b| {
+            (&a.file, &a.name, &a.kind).cmp(&(&b.file, &b.name, &b.kind))
+        });
+    }
+    cross_language_edges.sort_by(|a, b| {
+        (a.from_unit, a.to_unit, &a.from_language, &a.to_language).cmp(&(
+            b.from_unit,
+            b.to_unit,
+            &b.from_language,
+            &b.to_language,
+        ))
+    });
 
     let total_units = deployment_units.len();
     let mut language_list: Vec<String> = languages.into_iter().collect();

--- a/src/deploy/metrics.rs
+++ b/src/deploy/metrics.rs
@@ -72,11 +72,17 @@ pub fn compute_pod_metrics(
         let mut symbol_count = 0usize;
 
         for &fid in &pod.files {
-            if let Some(path) = fid_to_path.get(&fid)
-                && let Some(fm) = file_metrics.get(path)
+            match fid_to_path
+                .get(&fid)
+                .and_then(|path| file_metrics.get(path))
             {
-                total_ast_nodes += fm.ast_node_count;
-                symbol_count += fm.symbol_count;
+                Some(metrics) => {
+                    total_ast_nodes = total_ast_nodes.saturating_add(metrics.ast_node_count);
+                    symbol_count = symbol_count.saturating_add(metrics.symbol_count);
+                }
+                None => {
+                    tracing::warn!(pod = pod.id, file = fid.to_raw(), "pod file has no metrics")
+                }
             }
         }
 

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -226,14 +226,18 @@ pub fn run_deploy(config: DeployConfig) -> anyhow::Result<()> {
     if !config.check {
         std::fs::create_dir_all(&config.out)?;
 
-        let manifest_json = serde_json::to_string_pretty(&pod_manifest)?;
+        let extension = config.format.extension();
+        let manifest_text = config.format.serialize(&pod_manifest)?;
         crate::output::write_atomic(
-            &config.out.join("metacall.pods.json"),
-            manifest_json.as_bytes(),
+            &config.out.join(format!("metacall.pods.{extension}")),
+            manifest_text.as_bytes(),
         )?;
 
-        let mesh_json = serde_json::to_string_pretty(&mesh)?;
-        crate::output::write_atomic(&config.out.join("metacall.mesh.json"), mesh_json.as_bytes())?;
+        let mesh_text = config.format.serialize(&mesh)?;
+        crate::output::write_atomic(
+            &config.out.join(format!("metacall.mesh.{extension}")),
+            mesh_text.as_bytes(),
+        )?;
 
         tracing::info!(
             "Generated pod manifest with {} deployments and {} inter-pod edges.",

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -121,6 +121,7 @@ pub fn run_deploy(config: DeployConfig) -> anyhow::Result<()> {
             add_metacall_edge(
                 &base,
                 from_idx,
+                CallSiteVariant::LoadFromConfiguration,
                 target_lang,
                 script,
                 site.confidence,
@@ -142,12 +143,31 @@ pub fn run_deploy(config: DeployConfig) -> anyhow::Result<()> {
             continue;
         };
         let Some(target_lang) = crate::deploy::tags::from_metacall_tag(target_lang_tag) else {
+            diagnostics.push(Diagnostic {
+                path: site.source_file.clone(),
+                severity: Severity::Warning,
+                message: format!("unknown MetaCall load tag '{target_lang_tag}'"),
+                source_range: site.source_range.clone(),
+            });
             continue;
         };
+        if !crate::deploy::tags::has_loader(target_lang) {
+            diagnostics.push(Diagnostic {
+                path: site.source_file.clone(),
+                severity: Severity::Warning,
+                message: format!(
+                    "no MetaCall loader for language '{}', the tag '{}' is a meta-ast tag",
+                    target_lang.as_ref(),
+                    target_lang_tag
+                ),
+                source_range: site.source_range.clone(),
+            });
+        }
         for script in &site.scripts {
             add_metacall_edge(
                 &config.root,
                 from_idx,
+                site.variant.clone(),
                 target_lang,
                 script,
                 site.confidence,
@@ -202,8 +222,28 @@ pub fn run_deploy(config: DeployConfig) -> anyhow::Result<()> {
 
     // 10. Rebalance oversized pods
     for pod in &partition.pods {
-        if let Some(cut) = cut::find_oversized_pod_cut(pod, &analysis.graph, config.max_pod_size) {
-            all_cuts.push(cut);
+        match cut::find_oversized_pod_cut(pod, &analysis.graph, config.max_pod_size) {
+            Some(cut) => all_cuts.push(cut),
+            None if pod.files.len() > config.max_pod_size => {
+                let path = pod
+                    .files
+                    .first()
+                    .and_then(|fid| analysis.graph.file_node(*fid))
+                    .map(|file| file.path.clone())
+                    .unwrap_or_else(|| config.root.clone());
+                diagnostics.push(Diagnostic {
+                    path,
+                    severity: Severity::Warning,
+                    message: format!(
+                        "pod {} holds {} files above the limit {} and has no internal edge to cut",
+                        pod.id,
+                        pod.files.len(),
+                        config.max_pod_size
+                    ),
+                    source_range: None,
+                });
+            }
+            None => {}
         }
     }
 
@@ -319,6 +359,7 @@ fn orphaned_config_diagnostics(root: &Path, call_sites: &[CallSite]) -> Vec<Diag
 fn add_metacall_edge(
     base: &std::path::Path,
     from_idx: petgraph::graph::NodeIndex,
+    variant: CallSiteVariant,
     target_lang: crate::language::LangId,
     script: &str,
     confidence: f32,
@@ -331,14 +372,26 @@ fn add_metacall_edge(
         crate::graph::node::NodeData::File(f) => f.path.clone(),
         _ => return,
     };
-    if let Some(to_idx) =
-        client_call::resolve_script_to_file(base, script, &source_file, path_to_idx)
-    {
+
+    // A memory load carries inline code and a package load carries a package
+    // name, so neither may resolve to a project file.
+    let resolved = match variant {
+        CallSiteVariant::LoadFromMemory | CallSiteVariant::LoadFromPackage => None,
+        _ => client_call::resolve_script_to_file(base, script, &source_file, path_to_idx),
+    };
+    if let Some(to_idx) = resolved {
         graph.add_edge_normalized(from_idx, to_idx, EdgeKind::Import, confidence);
         return;
     }
 
     // No match: create or reuse ExternalNode (keeps external_index consistent).
-    let to_idx = graph.get_or_create_external_node(script.to_string(), target_lang);
+    // The code text of a memory load is not a name.
+    let name = match variant {
+        CallSiteVariant::LoadFromMemory => {
+            format!("<memory:{}>", crate::deploy::tags::metacall_tag(target_lang))
+        }
+        _ => script.to_string(),
+    };
+    let to_idx = graph.get_or_create_external_node(name, target_lang);
     graph.add_edge_normalized(from_idx, to_idx, EdgeKind::Import, confidence);
 }

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -221,31 +221,14 @@ pub fn run_deploy(config: DeployConfig) -> anyhow::Result<()> {
         cut::find_cross_language_cuts(&analysis.scc, &analysis.graph, &lang_map, &partition);
 
     // 10. Rebalance oversized pods
-    for pod in &partition.pods {
-        match cut::find_oversized_pod_cut(pod, &analysis.graph, config.max_pod_size) {
-            Some(cut) => all_cuts.push(cut),
-            None if pod.files.len() > config.max_pod_size => {
-                let path = pod
-                    .files
-                    .first()
-                    .and_then(|fid| analysis.graph.file_node(*fid))
-                    .map(|file| file.path.clone())
-                    .unwrap_or_else(|| config.root.clone());
-                diagnostics.push(Diagnostic {
-                    path,
-                    severity: Severity::Warning,
-                    message: format!(
-                        "pod {} holds {} files above the limit {} and has no internal edge to cut",
-                        pod.id,
-                        pod.files.len(),
-                        config.max_pod_size
-                    ),
-                    source_range: None,
-                });
-            }
-            None => {}
-        }
-    }
+    rebalance_oversized_pods(
+        &partition,
+        &analysis.graph,
+        config.max_pod_size,
+        &config.root,
+        &mut all_cuts,
+        &mut diagnostics,
+    );
 
     // 11. Resolve external dependencies and scope per pod
     let dependencies = dependency::resolve_dependencies(&analysis.graph, &partition, &config.root);
@@ -356,6 +339,46 @@ fn orphaned_config_diagnostics(root: &Path, call_sites: &[CallSite]) -> Vec<Diag
 /// Edges and external nodes are added through `CodeGraph` helpers so injected
 /// edges obey the same dedup/confidence invariant as builder-constructed ones
 /// and `external_index` stays consistent across repeated loads.
+/// Cut every oversized pod, and report the pods that cannot be cut.
+///
+/// A pod can exceed the limit with no internal edge to cut, for example when a
+/// hand-built partition disagrees with the graph. Staying silent would hide a
+/// deployment unit that the limit was meant to bound.
+fn rebalance_oversized_pods(
+    partition: &crate::deploy::pod::PodPartition,
+    graph: &crate::graph::CodeGraph,
+    max_pod_size: usize,
+    root: &std::path::Path,
+    cuts: &mut Vec<cut::CutEdge>,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    for pod in &partition.pods {
+        match cut::find_oversized_pod_cut(pod, graph, max_pod_size) {
+            Some(cut) => cuts.push(cut),
+            None if pod.files.len() > max_pod_size => {
+                let path = pod
+                    .files
+                    .first()
+                    .and_then(|fid| graph.file_node(*fid))
+                    .map(|file| file.path.clone())
+                    .unwrap_or_else(|| root.to_path_buf());
+                diagnostics.push(Diagnostic {
+                    path,
+                    severity: Severity::Warning,
+                    message: format!(
+                        "pod {} holds {} files above the limit {} and has no internal edge to cut",
+                        pod.id,
+                        pod.files.len(),
+                        max_pod_size
+                    ),
+                    source_range: None,
+                });
+            }
+            None => {}
+        }
+    }
+}
+
 fn add_metacall_edge(
     base: &std::path::Path,
     from_idx: petgraph::graph::NodeIndex,
@@ -388,10 +411,113 @@ fn add_metacall_edge(
     // The code text of a memory load is not a name.
     let name = match variant {
         CallSiteVariant::LoadFromMemory => {
-            format!("<memory:{}>", crate::deploy::tags::metacall_tag(target_lang))
+            format!(
+                "<memory:{}>",
+                crate::deploy::tags::metacall_tag(target_lang)
+            )
         }
         _ => script.to_string(),
     };
     let to_idx = graph.get_or_create_external_node(name, target_lang);
     graph.add_edge_normalized(from_idx, to_idx, EdgeKind::Import, confidence);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::deploy::pod::{Pod, PodPartition};
+    use crate::graph::node::{FileNode, NodeData};
+    use crate::language::LangId;
+    use crate::model::{FileId, SnapshotId};
+
+    #[test]
+    fn unsplittable_oversized_pod_is_reported() {
+        let mut graph = crate::graph::CodeGraph::new(SnapshotId::new(1).unwrap());
+        let mut files = Vec::new();
+        for id in 1..=4 {
+            let fid = FileId::new(id).unwrap();
+            let idx = graph.add_node(NodeData::File(FileNode::new(
+                fid,
+                std::path::PathBuf::from(format!("f{id}.py")),
+                LangId::Python,
+                SnapshotId::new(1).unwrap(),
+            )));
+            graph.file_to_index.insert(fid, idx);
+            files.push(fid);
+        }
+        // One pod over the limit, with no dependency edge inside it.
+        let partition = PodPartition {
+            pods: vec![Pod {
+                id: 0,
+                files,
+                language: LangId::Python,
+            }],
+            inter_pod_edges: Vec::new(),
+            file_languages: HashMap::new(),
+        };
+
+        let mut cuts = Vec::new();
+        let mut diagnostics = Vec::new();
+        rebalance_oversized_pods(
+            &partition,
+            &graph,
+            2,
+            std::path::Path::new("."),
+            &mut cuts,
+            &mut diagnostics,
+        );
+
+        assert!(cuts.is_empty());
+        assert_eq!(diagnostics.len(), 1, "{diagnostics:?}");
+        assert_eq!(diagnostics[0].severity, Severity::Warning);
+        assert!(
+            diagnostics[0].message.contains("no internal edge to cut"),
+            "{}",
+            diagnostics[0].message
+        );
+    }
+
+    #[test]
+    fn oversized_pod_with_an_internal_edge_is_cut() {
+        let mut graph = crate::graph::CodeGraph::new(SnapshotId::new(1).unwrap());
+        let mut files = Vec::new();
+        let mut indices = Vec::new();
+        for id in 1..=3 {
+            let fid = FileId::new(id).unwrap();
+            let idx = graph.add_node(NodeData::File(FileNode::new(
+                fid,
+                std::path::PathBuf::from(format!("f{id}.py")),
+                LangId::Python,
+                SnapshotId::new(1).unwrap(),
+            )));
+            graph.file_to_index.insert(fid, idx);
+            files.push(fid);
+            indices.push(idx);
+        }
+        graph.add_edge_normalized(indices[0], indices[1], EdgeKind::Import, 0.5);
+
+        let partition = PodPartition {
+            pods: vec![Pod {
+                id: 0,
+                files,
+                language: LangId::Python,
+            }],
+            inter_pod_edges: Vec::new(),
+            file_languages: HashMap::new(),
+        };
+
+        let mut cuts = Vec::new();
+        let mut diagnostics = Vec::new();
+        rebalance_oversized_pods(
+            &partition,
+            &graph,
+            2,
+            std::path::Path::new("."),
+            &mut cuts,
+            &mut diagnostics,
+        );
+
+        assert_eq!(cuts.len(), 1, "the internal edge must be cut");
+        assert!(diagnostics.is_empty(), "{diagnostics:?}");
+    }
 }

--- a/src/deploy/pod.rs
+++ b/src/deploy/pod.rs
@@ -121,9 +121,15 @@ pub fn partition_into_pods(graph: &CodeGraph) -> PodPartition {
 
         // Only union files in the same language.
         if src_lang == dst_lang && src_lang.is_some() {
-            let i = file_idx[&src_fid] as u32;
-            let j = file_idx[&dst_fid] as u32;
-            uf.union(i, j);
+            let (Some(&i), Some(&j)) = (file_idx.get(&src_fid), file_idx.get(&dst_fid)) else {
+                tracing::warn!(
+                    from = src_fid.to_raw(),
+                    to = dst_fid.to_raw(),
+                    "partition skipped an edge with a stale file id"
+                );
+                continue;
+            };
+            uf.union(i as u32, j as u32);
         }
     }
 
@@ -179,8 +185,17 @@ pub fn partition_into_pods(graph: &CodeGraph) -> PodPartition {
             continue;
         };
 
-        let src_rep = labeling[file_idx[&src_fid]];
-        let dst_rep = labeling[file_idx[&dst_fid]];
+        let (Some(&src_pos), Some(&dst_pos)) = (file_idx.get(&src_fid), file_idx.get(&dst_fid))
+        else {
+            tracing::warn!(
+                from = src_fid.to_raw(),
+                to = dst_fid.to_raw(),
+                "inter-pod pass skipped an edge with a stale file id"
+            );
+            continue;
+        };
+        let src_rep = labeling[src_pos];
+        let dst_rep = labeling[dst_pos];
         if src_rep == dst_rep {
             continue; // intra-pod edge, not inter-pod.
         }

--- a/src/deploy/scanner.rs
+++ b/src/deploy/scanner.rs
@@ -38,10 +38,6 @@ pub struct CallSite {
     pub confidence: f32,
 }
 
-/// Load entry point suffixes: `metacall_load_from_<suffix>` in the script
-/// ports, `<Suffix>` after `LoadFrom` in Go, and `from_<suffix>` in the Rust port.
-const LOAD_SUFFIXES: [&str; 5] = ["file", "single_file", "memory", "package", "configuration"];
-
 /// Exact client call names across the ports.
 const CLIENT_NAMES: [&str; 20] = [
     "metacall",

--- a/src/deploy/scanner.rs
+++ b/src/deploy/scanner.rs
@@ -38,50 +38,82 @@ pub struct CallSite {
     pub confidence: f32,
 }
 
+/// Load entry point suffixes: `metacall_load_from_<suffix>` in the script
+/// ports, `<Suffix>` after `LoadFrom` in Go, and `from_<suffix>` in the Rust port.
+const LOAD_SUFFIXES: [&str; 5] = ["file", "single_file", "memory", "package", "configuration"];
+
+/// Exact client call names across the ports.
+const CLIENT_NAMES: [&str; 20] = [
+    "metacall",
+    "metacall_await",
+    "metacall_await_s",
+    "metacall_no_arg",
+    "metacall_untyped",
+    "metacall_untyped_no_arg",
+    "metacallfms",
+    "metacallfms_await",
+    "metacallv",
+    "metacallv_s",
+    "metacallt",
+    "metacallt_s",
+    "metacall_function",
+    "Call",
+    "CallUnsafe",
+    "Await",
+    "AwaitUnsafe",
+    "LoadFromFile",
+    "LoadFromMemory",
+    "LoadFromPackage",
+];
+
+/// The one alternation every query predicate and `from_str` share.
+static FUNCTION_NAME_PATTERN: LazyLock<String> = LazyLock::new(|| {
+    let mut alternatives: Vec<String> = CLIENT_NAMES
+        .iter()
+        .map(|name| (*name).to_string())
+        .collect();
+    alternatives.push("metacall_load_from_.*".to_string());
+    alternatives.push("load_from_.*".to_string());
+    alternatives.push("from_(file|single_file|memory|package|configuration)".to_string());
+    alternatives.push("LoadFrom(File|Memory|Package|Configuration)".to_string());
+    format!("^({})$", alternatives.join("|"))
+});
+
+/// Fill the shared function name predicate into a query template.
+fn deploy_source(template: &str) -> String {
+    template.replace("@FN@", &FUNCTION_NAME_PATTERN)
+}
+
+fn load_variant(suffix: &str) -> Option<CallSiteVariant> {
+    match suffix {
+        "file" | "single_file" => Some(CallSiteVariant::LoadFromFile),
+        "memory" => Some(CallSiteVariant::LoadFromMemory),
+        "package" => Some(CallSiteVariant::LoadFromPackage),
+        "configuration" => Some(CallSiteVariant::LoadFromConfiguration),
+        _ => None,
+    }
+}
+
 impl CallSiteVariant {
     fn from_str(s: &str) -> Option<Self> {
-        if s.contains("load_from_file") || s.contains("LoadFromFile") {
-            Some(Self::LoadFromFile)
-        } else if s.contains("load_from_memory") || s.contains("LoadFromMemory") {
-            Some(Self::LoadFromMemory)
-        } else if s.contains("load_from_package") || s.contains("LoadFromPackage") {
-            Some(Self::LoadFromPackage)
-        } else if s.contains("load_from_configuration") || s.contains("LoadFromConfiguration") {
-            Some(Self::LoadFromConfiguration)
-        } else if s.contains("from_file") || s.contains("from_single_file") {
-            Some(Self::LoadFromFile)
-        } else if s.contains("from_memory") {
-            Some(Self::LoadFromMemory)
-        } else if s.contains("from_package") {
-            Some(Self::LoadFromPackage)
-        } else if s.contains("from_configuration") {
-            Some(Self::LoadFromConfiguration)
-        } else if matches!(
-            s,
-            "metacall"
-                | "metacall_await"
-                | "metacall_await_s"
-                | "metacall_no_arg"
-                | "metacall_untyped"
-                | "metacall_untyped_no_arg"
-                | "metacallfms"
-                | "metacallfms_await"
-                | "metacallv"
-                | "metacallv_s"
-                | "metacallt"
-                | "metacallt_s"
-                | "metacall_function"
-                | "Call"
-                | "CallUnsafe"
-                | "Await"
-                | "AwaitUnsafe"
-        ) {
-            // metacall_handle excluded: its argument layout differs per port
-            // (tag first in C/Node, handle first in Rust).
-            Some(Self::ClientCall)
-        } else {
-            None
+        if let Some(suffix) = s.strip_prefix("metacall_load_from_") {
+            return load_variant(suffix);
         }
+        if let Some(suffix) = s.strip_prefix("from_") {
+            return load_variant(suffix);
+        }
+        if let Some(suffix) = s.strip_prefix("load_from_") {
+            return load_variant(suffix);
+        }
+        if let Some(suffix) = s.strip_prefix("LoadFrom") {
+            return load_variant(&suffix.to_lowercase());
+        }
+        // metacall_handle excluded: its argument layout differs per port
+        // (tag first in C/Node, handle first in Rust).
+        if CLIENT_NAMES.contains(&s) {
+            return Some(Self::ClientCall);
+        }
+        None
     }
 }
 
@@ -131,12 +163,14 @@ fn collect_strings_recursive(node: Node, source: &[u8], scripts: &mut Vec<String
 static PYTHON_QUERY: LazyLock<Query> = LazyLock::new(|| {
     crate::language::common::compile_query(
         &tree_sitter_python::LANGUAGE.into(),
-        r#"
+        &deploy_source(
+            r#"
 (call
   function: (identifier) @fn_name
   arguments: (argument_list) @args
-  (#match? @fn_name "^(metacall_load_from_.*|metacall|metacall_await|metacallfms)$"))
+  (#match? @fn_name "@FN@"))
 "#,
+        ),
         "Python deploy",
     )
 });
@@ -144,12 +178,14 @@ static PYTHON_QUERY: LazyLock<Query> = LazyLock::new(|| {
 static JS_QUERY: LazyLock<Query> = LazyLock::new(|| {
     crate::language::common::compile_query(
         &tree_sitter_javascript::LANGUAGE.into(),
-        r#"
+        &deploy_source(
+            r#"
 (call_expression
   function: (identifier) @fn_name
   arguments: (arguments) @args
-  (#match? @fn_name "^(metacall_load_from_.*|metacall|metacall_await|metacallfms)$"))
+  (#match? @fn_name "@FN@"))
 "#,
+        ),
         "JS deploy",
     )
 });
@@ -157,12 +193,14 @@ static JS_QUERY: LazyLock<Query> = LazyLock::new(|| {
 static TS_QUERY: LazyLock<Query> = LazyLock::new(|| {
     crate::language::common::compile_query(
         &tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
-        r#"
+        &deploy_source(
+            r#"
 (call_expression
   function: (identifier) @fn_name
   arguments: (arguments) @args
-  (#match? @fn_name "^(metacall_load_from_.*|metacall|metacall_await|metacallfms)$"))
+  (#match? @fn_name "@FN@"))
 "#,
+        ),
         "TS deploy",
     )
 });
@@ -170,12 +208,14 @@ static TS_QUERY: LazyLock<Query> = LazyLock::new(|| {
 static TSX_QUERY: LazyLock<Query> = LazyLock::new(|| {
     crate::language::common::compile_query(
         &tree_sitter_typescript::LANGUAGE_TSX.into(),
-        r#"
+        &deploy_source(
+            r#"
 (call_expression
   function: (identifier) @fn_name
   arguments: (arguments) @args
-  (#match? @fn_name "^(metacall_load_from_.*|metacall|metacall_await|metacallfms)$"))
+  (#match? @fn_name "@FN@"))
 "#,
+        ),
         "TSX deploy",
     )
 });
@@ -183,12 +223,14 @@ static TSX_QUERY: LazyLock<Query> = LazyLock::new(|| {
 static C_QUERY: LazyLock<Query> = LazyLock::new(|| {
     crate::language::common::compile_query(
         &tree_sitter_c::LANGUAGE.into(),
-        r#"
+        &deploy_source(
+            r#"
 (call_expression
   function: (identifier) @fn_name
   arguments: (argument_list) @args
-  (#match? @fn_name "^(metacall_load_from_.*|metacall|metacall_await|metacall_await_s|metacallfms|metacallfms_await|metacallv|metacallv_s|metacallt|metacallt_s|metacall_function)$"))
+  (#match? @fn_name "@FN@"))
 "#,
+        ),
         "C deploy",
     )
 });
@@ -196,12 +238,14 @@ static C_QUERY: LazyLock<Query> = LazyLock::new(|| {
 static CPP_QUERY: LazyLock<Query> = LazyLock::new(|| {
     crate::language::common::compile_query(
         &tree_sitter_cpp::LANGUAGE.into(),
-        r#"
+        &deploy_source(
+            r#"
 (call_expression
   function: (identifier) @fn_name
   arguments: (argument_list) @args
-  (#match? @fn_name "^(metacall_load_from_.*|metacall|metacall_await|metacall_await_s|metacallfms|metacallfms_await|metacallv|metacallv_s|metacallt|metacallt_s|metacall_function)$"))
+  (#match? @fn_name "@FN@"))
 "#,
+        ),
         "CPP deploy",
     )
 });
@@ -209,7 +253,8 @@ static CPP_QUERY: LazyLock<Query> = LazyLock::new(|| {
 static RUST_QUERY: LazyLock<Query> = LazyLock::new(|| {
     crate::language::common::compile_query(
         &tree_sitter_rust::LANGUAGE.into(),
-        r#"
+        &deploy_source(
+            r#"
 (call_expression
   function: [
     (scoped_identifier
@@ -220,8 +265,10 @@ static RUST_QUERY: LazyLock<Query> = LazyLock::new(|| {
         name: (identifier) @fn_name)
     (identifier) @fn_name
   ]
-  arguments: (arguments) @args)
+  arguments: (arguments) @args
+  (#match? @fn_name "@FN@"))
 "#,
+        ),
         "Rust deploy",
     )
 });
@@ -229,15 +276,26 @@ static RUST_QUERY: LazyLock<Query> = LazyLock::new(|| {
 static GO_QUERY: LazyLock<Query> = LazyLock::new(|| {
     crate::language::common::compile_query(
         &tree_sitter_go::LANGUAGE.into(),
-        r#"
+        &deploy_source(
+            r#"
 (call_expression
   function: (selector_expression
     operand: (identifier) @pkg_name
     field: (field_identifier) @fn_name)
   arguments: (argument_list) @args
-  (#match? @pkg_name "metacall")
-  (#match? @fn_name "^(LoadFrom.*|Call|CallUnsafe|Await|AwaitUnsafe)$"))
+  (#match? @pkg_name "^metacall$")
+  (#match? @fn_name "@FN@"))
+
+; A one argument call parses as a type conversion in this grammar.
+(type_conversion_expression
+  (qualified_type
+    (package_identifier) @pkg_name
+    (type_identifier) @fn_name)
+  operand: (_) @args
+  (#match? @pkg_name "^metacall$")
+  (#match? @fn_name "@FN@"))
 "#,
+        ),
         "Go deploy",
     )
 });
@@ -245,12 +303,14 @@ static GO_QUERY: LazyLock<Query> = LazyLock::new(|| {
 static RUBY_QUERY: LazyLock<Query> = LazyLock::new(|| {
     crate::language::common::compile_query(
         &tree_sitter_ruby::LANGUAGE.into(),
-        r#"
+        &deploy_source(
+            r#"
 (call
   method: (identifier) @fn_name
   arguments: (argument_list) @args
-  (#match? @fn_name "^(metacall_load_from_.*|metacall|metacall_await|metacallfms)$"))
+  (#match? @fn_name "@FN@"))
 "#,
+        ),
         "Ruby deploy",
     )
 });
@@ -799,6 +859,17 @@ metacall_await_s("x", 1)
     ///
     /// Two arguments are required: with one argument tree-sitter-go parses
     /// `pkg.Fn(x)` as a type conversion, not a call.
+    #[test]
+    fn test_scan_go_single_argument_call_is_detected() {
+        // This grammar parses a one argument call as a type conversion.
+        let source = b"package main\nfunc main() { metacall.Call(handler) }";
+        let tree = parse(LangId::Go, source);
+        let sites = scan_file(LangId::Go, &tree, source, Path::new("main.go"));
+        assert_eq!(sites.len(), 1);
+        assert_eq!(sites[0].variant, CallSiteVariant::ClientCall);
+        assert_eq!(sites[0].function_name.as_deref(), Some("handler"));
+    }
+
     #[test]
     fn test_scan_go_rejects_a_lookalike_package() {
         let source = b"metacallmock.Call(\"x\", 1)";

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -51,6 +51,14 @@ impl OutputFormat {
             Self::Yaml => Ok(yaml_serde::to_string(value)?),
         }
     }
+
+    /// File extension for this format, without the dot.
+    pub fn extension(&self) -> &'static str {
+        match self {
+            Self::Json => "json",
+            Self::Yaml => "yaml",
+        }
+    }
 }
 
 #[cfg(test)]

--- a/tests/integration/deploy_client_call_test.rs
+++ b/tests/integration/deploy_client_call_test.rs
@@ -52,7 +52,7 @@ mod deploy_client_call_tests {
     fn test_client_call_mesh_pod_manifest() {
         let (_out_dir, manifest) = run_deploy_on_fixture();
 
-        assert_eq!(manifest["version"].as_str().unwrap(), "1.0");
+        assert_eq!(manifest["version"].as_str().unwrap(), "1.1");
 
         let deployments = manifest["deployments"].as_array().unwrap();
         assert_eq!(

--- a/tests/integration/deploy_mixed_test.rs
+++ b/tests/integration/deploy_mixed_test.rs
@@ -502,8 +502,13 @@ mod deploy_mixed_tests {
             "express (LoadFromPackage) must be classified, got {dep_names:?}"
         );
         assert!(
-            dep_names.iter().any(|n| n.contains("INLINE")),
-            "inline memory load must be classified as external, got {dep_names:?}"
+            dep_names.iter().any(|n| n == "<memory:ts>"),
+            "an inline memory load must be classified for its language, not named \
+             after its code, got {dep_names:?}"
+        );
+        assert!(
+            !dep_names.iter().any(|n| n.contains("INLINE")),
+            "the inline code text must never become a dependency name, got {dep_names:?}"
         );
 
         // The Node validation pod imports the builtin "crypto"; the classifier

--- a/tests/integration/deploy_mixed_test.rs
+++ b/tests/integration/deploy_mixed_test.rs
@@ -145,7 +145,7 @@ mod deploy_mixed_tests {
     #[test]
     fn test_cross_language_manifest_version() {
         let (_out_dir, manifest) = run_deploy_on_fixture("three_lang_math");
-        assert_eq!(manifest["version"].as_str().unwrap(), "1.0");
+        assert_eq!(manifest["version"].as_str().unwrap(), "1.1");
     }
 
     #[test]
@@ -251,9 +251,12 @@ mod deploy_mixed_tests {
             cross_lang >= 4,
             "expected >= 4 cross-language edges (loads + cycle), got {cross_lang}"
         );
-        let has_scc_cut = edges
-            .iter()
-            .any(|e| e["cut_annotation"]["cut_reason"].as_str() == Some("CrossLanguageScc"));
+        let has_scc_cut = edges.iter().any(|e| {
+            e["cut_annotations"].as_array().is_some_and(|cuts| {
+                cuts.iter()
+                    .any(|cut| cut["cut_reason"].as_str() == Some("CrossLanguageScc"))
+            })
+        });
         assert!(
             has_scc_cut,
             "expected a CrossLanguageScc cut, edges: {edges:?}"
@@ -383,18 +386,21 @@ mod deploy_mixed_tests {
 
         // The cross-language cut must fire for the py<->go metacall cycle.
         let edges = manifest["edges"].as_array().unwrap();
-        let has_scc_cut = edges
-            .iter()
-            .any(|e| e["cut_annotation"]["cut_reason"].as_str() == Some("CrossLanguageScc"));
+        let has_scc_cut = edges.iter().any(|e| {
+            e["cut_annotations"].as_array().is_some_and(|cuts| {
+                cuts.iter()
+                    .any(|cut| cut["cut_reason"].as_str() == Some("CrossLanguageScc"))
+            })
+        });
         assert!(
             has_scc_cut,
             "expected a CrossLanguageScc cut, edges: {edges:?}"
         );
 
-        // Every cut edge must carry an rpc_stub-style cut_annotation and a
+        // Every cut edge must carry rpc_stub-style cut annotations and a
         // counterpart pod pair (fairness invariant from ADR 0003).
         for e in edges {
-            if let Some(cut) = e["cut_annotation"].as_object() {
+            for cut in e["cut_annotations"].as_array().into_iter().flatten() {
                 assert!(
                     cut.get("cut_reason").is_some(),
                     "cut edge missing cut_reason: {e:?}"

--- a/tests/integration/deploy_test.rs
+++ b/tests/integration/deploy_test.rs
@@ -30,7 +30,7 @@ mod deploy_tests {
         // Verify pod manifest content
         let pod_content = fs::read_to_string(out_path.join("metacall.pods.json")).unwrap();
         let pod_json: serde_json::Value = serde_json::from_str(&pod_content).unwrap();
-        assert_eq!(pod_json["version"], "1.0");
+        assert_eq!(pod_json["version"], "1.1");
         assert!(!pod_json["deployments"].as_array().unwrap().is_empty());
         // python_calls_js has both Python and JS files
         let languages: Vec<&str> = pod_json["deployments"]
@@ -120,9 +120,10 @@ mod deploy_tests {
             .iter()
             .filter(|e| e["kind"].as_str() == Some("rpc_stub"))
             .filter(|e| {
-                e["cut_annotation"]["cut_reason"]
-                    .get("OversizedPod")
-                    .is_some()
+                e["cut_annotations"].as_array().is_some_and(|cuts| {
+                    cuts.iter()
+                        .any(|cut| cut["cut_reason"].get("OversizedPod").is_some())
+                })
             })
             .collect();
         assert!(
@@ -138,9 +139,10 @@ mod deploy_tests {
             .iter()
             .filter(|e| e["kind"].as_str() == Some("rpc_stub"))
             .filter(|e| {
-                e["cut_annotation"]["cut_reason"]
-                    .get("OversizedPod")
-                    .is_some()
+                e["cut_annotations"].as_array().is_some_and(|cuts| {
+                    cuts.iter()
+                        .any(|cut| cut["cut_reason"].get("OversizedPod").is_some())
+                })
             })
             .collect();
         assert!(


### PR DESCRIPTION
## Summary

Deploy contract. Fixes D1 to D15 and N-D1 to N-D4.

- `-f yaml` is honoured: both artifacts go through the output format and take its extension. The deploy doc records that core reads JSON only.
- One exact name table drives every scanner query predicate and the classifier, so `read_from_file` is no longer a MetaCall load and `metacallv`, `metacallt`, `metacall_no_arg` and the untyped variants are no longer invisible. The Go package predicate is anchored.
- An unknown load tag and a language without a loader report a warning with the call-site range.
- Cut annotations carry portable paths, merge per pod pair as `cut_annotations`, and emit exactly one rpc_stub per pair; the pod manifest version moves to 1.1.
- Lockfile entries match an exact token, the version window is bounded by the entry block, `source` follows the parse result, `go.sum` needs the exact module path and `go.mod` require lines yield versions.
- A memory load never resolves to a project file and is named for its language; a package load never resolves to a file.
- Mesh output is canonically sorted with a single confidence width; a stale symbol file id skips instead of panicking; totals saturate; an unsplittable pod and a partition or graph disagreement are reported.

## Type of change

- [x] `fix` - bug fix

## Affected area

- [x] `deploy` (feature)
- [x] `docs` / `tests`
