### PR TITLE
fix(cli): define the diagnostic policy and the exit status

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,11 @@ view of their structure without executing any user code. Its objectives:
   its dependencies across a polyglot repo to understand structure quickly.
   Run `meta-ast inspect` on a checkout and read the JSON/YAML, or open the
   interactive dashboard from `meta-ast graph --html`.
-- **Cyclic dependency guard.** Run `meta-ast graph` in CI to fail builds that
-  introduce accidental import cycles (Tarjan SCC flags cyclic clusters).
+- **CI gate.** `meta-ast graph` exits 1 when the run reports an error
+  diagnostic, 2 for a usage or configuration problem, and 0 otherwise. Pass
+  `--fail-on warning` to fail on warnings as well, or `--fail-on never` to
+  always exit 0. Import cycles surface as cyclic clusters in the output and in
+  the deployability hints, and they are not errors by themselves.
 - **Dependency-graph diffing & refactors.** Before splitting a module or
   deleting a package, generate the graph and confirm what actually depends on
   it across languages - catch hidden cross-language coupling a grep would miss.
@@ -216,7 +219,7 @@ All docs are also published as an [mdbook site](https://metacall.github.io/meta-
 
 ## Roadmap
 
-The core GSoC 2026 milestones (Phases 1-7) are complete with release `v0.5.0`. Full details and post-v1 initiatives are tracked in [docs/src/ROADMAP.md](docs/src/ROADMAP.md).
+The core GSoC 2026 milestones (Phases 1-7) are complete with release `v0.7.0`. Full details and post-v1 initiatives are tracked in [docs/src/ROADMAP.md](docs/src/ROADMAP.md).
 
 ### Post-v1 Active Roadmap
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,11 @@ meta-ast graph <path> --html                    # interactive Cytoscape.js dashb
 meta-ast graph <path> --datagraph               # export detailed datagraph.json (requires --features dataflow)
 meta-ast graph <path> --datagraph --datagraph-output dg.json   # choose the datagraph path
 meta-ast graph <path> --watch                   # watch mode: continuous re-analysis on file changes (requires --features watch)
+
+`--datagraph`, `--datagraph-output`, `--watch`, `--watch-debounce` and the `deploy`
+subcommand are compiled in only when their feature is enabled. A build without the
+feature rejects the flag at argument parsing with exit status 2, so the CLI surface
+depends on the feature set of the installed binary.
 meta-ast graph <path> --watch --watch-debounce 100 --html -o graph.html
 ```
 

--- a/docs/src/ARCHITECTURE.md
+++ b/docs/src/ARCHITECTURE.md
@@ -72,7 +72,7 @@ Detailed graph contract is defined in `specs/graph-model.md`.
 **Current status:** Baseline incremental analysis is implemented behind the `watch`
 feature flag (`--features watch`). The `watch` module (`src/watch/mod.rs`) provides:
 
-- `incremental_reanalyze()` - pure, deterministic, testable re-analysis step.
+- `incremental_reanalyze()` - testable re-analysis step. It reads the filesystem, and it is deterministic for identical input: files are numbered in path order.
 - `run_watch()` - debounced OS-level watcher loop (via `notify` + `notify-debouncer-mini`).
 - BLAKE3 cryptographic content-hash fingerprinting (`Fingerprint([u8; 32])`) for change detection.
 - Cached `Arc<FileExtraction>` per file: zero-allocation pointer sharing for unchanged files; graph rebuilt from scratch each tick (graph + SCC rebuild is sub-ms).

--- a/docs/src/FINAL_REPORT.md
+++ b/docs/src/FINAL_REPORT.md
@@ -4,7 +4,7 @@
 - **Organization**: [MetaCall](https://github.com/metacall)
 - **Project**: `meta-ast` - Standalone Polyglot Static Analysis Engine
 - **Program**: Google Summer of Code (GSoC) 2026
-- **Status**: Completed, v0.5.0
+- **Status**: Completed, v0.5.0; the crate has moved on to 0.7.0 (see Cargo.toml)
 
 ---
 
@@ -15,6 +15,7 @@
 ### Original Problem Statement
 
 MetaCall supports polyglot architectures where functions written in different languages call each other seamlessly. However, developers lacked a fast, unified static analysis tool to:
+
 1. Map cross-language dependencies without running arbitrary user code.
 2. Detect cyclic imports that block deployment decomposition.
 3. Automatically partition polyglot applications into optimal, language-specific deployment pods.
@@ -37,24 +38,28 @@ MetaCall supports polyglot architectures where functions written in different la
 The project executed across seven planned phases. All milestones were delivered, tested, and released.
 
 ### Phase 1: Unified Parser Lifecycle and Symbol Extraction
+
 - Built thread-local tree-sitter parser pools for zero-overhead multi-threaded parsing.
 - Implemented uniform AST query packs across Python, JavaScript, TypeScript, TSX, C, C++, Rust, and Go.
 - Normalized declarations into the [`Symbol`](https://github.com/metacall/meta-ast/blob/main/src/model/mod.rs) IR with visibility, signature, and docstring metadata.
 - Implemented robust error recovery: malformed source files emit structured [`Diagnostic`](https://github.com/metacall/meta-ast/blob/main/src/error.rs) records without stopping the pipeline.
 
 ### Phase 2: Dependency Graph and Tarjan SCC
+
 - Implemented the [`CodeGraph`](https://github.com/metacall/meta-ast/blob/main/src/graph/mod.rs) directed graph model over petgraph.
 - Implemented cross-file import and symbol resolution with confidence scoring (1.0 for own file / direct import, 0.8 for transitive import, 0.6 for cross-language).
 - Integrated Tarjan Strongly Connected Components (SCC) algorithm with `EdgeFiltered` views to isolate cyclic clusters while excluding ownership and flow edges.
 - Classified graph components into independent deployment units vs. co-deployment clusters.
 
 ### Phase 3: Datagraph and Dataflow Sinks
+
 - Extended the IR with intra-procedural def-use dataflow nodes ([`DataNode`](https://github.com/metacall/meta-ast/blob/main/src/model/mod.rs), [`FlowEdge`](https://github.com/metacall/meta-ast/blob/main/src/model/mod.rs), [`DataScope`](https://github.com/metacall/meta-ast/blob/main/src/model/mod.rs)).
 - Implemented def-use extraction for parameter bindings and variable declarations.
 - Defined a schema-versioned export format (schema version 1) and the [`GraphSink`](https://github.com/metacall/meta-ast/blob/main/src/sink/mod.rs) pluggable adapter trait.
 - Added the `--datagraph` CLI flag for dataflow export.
 
 ### Phase 4: CLI Polish, Visualization, and Incremental Watch Mode
+
 - Added structured output formats (`--format json|yaml`) across all subcommands.
 - Implemented an interactive Cytoscape.js HTML visualization dashboard (`--html`).
 - Built incremental watch mode (`--watch`):
@@ -64,6 +69,7 @@ The project executed across seven planned phases. All milestones were delivered,
   - Collision-free ID generation using [`IdGenerator::with_start`](https://github.com/metacall/meta-ast/blob/main/src/model/ids.rs).
 
 ### Phase 5: MetaCall Deployment Manifest Generator (`metacall-deploy`)
+
 - Implemented AST scanners for MetaCall call sites (`metacall_load_from_file`, `metacall_load_from_memory`, `metacall_load_from_package`, `metacall_load_from_configuration`, and `metacall()` client calls per RFC 0011).
 - Implemented same-language pod partitioning using Union-Find over resolved dependency edges.
 - Added external package dependency resolution from lockfiles (`package-lock.json`, `Cargo.lock`, `go.sum`, `requirements.txt`, `Gemfile.lock`) for exact version pinning.
@@ -73,10 +79,12 @@ The project executed across seven planned phases. All milestones were delivered,
 - Added `--check` mode: verifies cut fairness (every cut edge across pods has a corresponding RPC stub entry, fulfilling ADR 0003).
 
 ### Phase 6: Language Expansion (Ruby)
+
 - Implemented full Ruby support: tree-sitter grammar integration, symbol query pack, `require`/`require_relative` import resolver, reference detection, and lockfile resolution (`Gemfile.lock`).
 - Evaluated C# and Java; concluded Ruby provided the highest immediate utility for MetaCall Function Mesh targets.
 
 ### Phase 7: Validation, CI/CD, Benchmarking, and Delivery
+
 - Hardened CI matrix across 4 operating systems (Linux glibc/musl, macOS x86_64/ARM64, Windows x86_64/ARM64) on stable and nightly Rust toolchains.
 - Added automated linting, formatting, cargo-deny license/vulnerability audits, and cargo-nextest execution.
 - Configured Criterion benchmark suite tracking pipeline, graph, and incremental performance.
@@ -119,7 +127,9 @@ All work was developed in pull requests, reviewed, and merged into the main bran
 | [#53](https://github.com/metacall/meta-ast/pull/53) | CLI & graph hardening | `--language` filtering, `--max-pod-size`, O(1) edge normalization. |
 
 ### Notes
+
 - there was multiple commits unlinked with issues or PRs "Mostly optimizations".
+
 ---
 
 ## 4. Key Metrics and Project Numbers
@@ -141,22 +151,27 @@ All work was developed in pull requests, reviewed, and merged into the main bran
 ## 5. Technical Challenges and Engineering Insights
 
 ### A. Polyglot Semantic Gap and Import Resolution
+
 **Challenge**: Each programming language uses different module and symbol resolution semantics. C/C++ relies on header inclusion; Python uses runtime `sys.path` and relative imports; JavaScript/TypeScript uses ESM, CommonJS, and `tsconfig.json` path mappings; Rust uses hierarchical crate paths; Ruby uses `require` and `require_relative`.
 **Solution**: Designed the [`ImportResolver`](https://github.com/metacall/meta-ast/blob/main/src/language/import_resolver.rs) abstraction. Each language provides a stateful resolver that caches directory hierarchies and configuration files. Unresolved imports are recorded with confidence penalties (0.6 cross-language vs 1.0 same-file) and surface as non-fatal diagnostics.
 
 ### B. Collision-Free Incremental State in Watch Mode
+
 **Challenge**: When re-analyzing modified files in watch mode, creating new symbol IDs could collide with cached IDs from unchanged files or force expensive whole-graph re-allocations.
 **Solution**: Implemented an explicit ID generation seam using [`IdGenerator::with_start(max_cached_id + 1)`](https://github.com/metacall/meta-ast/blob/main/src/model/ids.rs). Unchanged files retain their existing [`Arc<FileExtraction>`](https://github.com/metacall/meta-ast/blob/main/src/model/mod.rs) references with zero allocations (verified via `Arc::ptr_eq`), while newly extracted files receive strictly monotonic, non-overlapping IDs.
 
 ### C. Deployment Cut Fairness and Invariant Verification
+
 **Challenge**: Partitioning polyglot applications into separate deployment pods can sever dependencies. If an edge across pods lacks an RPC stub, the deployed application fails at runtime.
 **Solution**: Implemented the cut fairness validation algorithm (ADR 0003). In `--check` mode, the analyzer constructs a bijection between inter-pod cut edges and declared RPC stubs. Any missing stub produces an immediate diagnostic error with the exact source location of the call site.
 
 ### D. Graph Assembly Performance at Scale
+
 **Challenge**: Initial graph construction used repeated edge scans to deduplicate multi-language references, causing quadratic slowdowns on large graphs.
 **Solution**: Replaced linear scans with an indexed `(src, dst, kind)` lookup map in [`CodeGraph`](https://github.com/metacall/meta-ast/blob/main/src/graph/mod.rs), delivering O(1) edge deduplication and max-confidence fusion. This reduced graph construction time for 10,000 duplicate edges to 486 microseconds.
 
 ### E. Cross-Platform Path Normalization
+
 **Challenge**: File paths and snapshots differed across Linux, macOS, and Windows due to backslashes and case sensitivity.
 **Solution**: Enforced universal forward-slash path normalization across all internal data structures, JSON serializers, and snapshot tests, ensuring deterministic CI verification across all four operating systems.
 
@@ -165,9 +180,11 @@ All work was developed in pull requests, reviewed, and merged into the main bran
 ## 6. How to Build, Test, and Verify
 
 ### Prerequisites
+
 - Rust 1.94.0 or newer ([rustup.rs](https://rustup.rs))
 
 ### Build from Source
+
 ```bash
 git clone https://github.com/metacall/meta-ast.git
 cd meta-ast
@@ -180,6 +197,7 @@ cargo build --release --features metacall-deploy --features watch --features dat
 ```
 
 ### Run Test Suite
+
 ```bash
 # Run all tests across all feature flags
 cargo test --all-features
@@ -190,11 +208,13 @@ cargo fmt --check
 ```
 
 ### Run Benchmarks
+
 ```bash
 cargo bench --features watch
 ```
 
 ### Run CLI Commands
+
 ```bash
 # Inspect declarations in a project
 ./target/release/meta-ast inspect ./tests/fixtures/python/ -f json
@@ -211,13 +231,15 @@ cargo bench --features watch
 ## 7. Current State and Future Work
 
 ### Current State
-`meta-ast` is feature-complete for its GSoC 2026 milestones and project goals. The engine is released as v0.5.0 on [crates.io](https://crates.io/crates/meta-ast) and GitHub Releases, with documentation published at [metacall.github.io/meta-ast](https://metacall.github.io/meta-ast/).
+
+`meta-ast` is feature-complete for its GSoC 2026 milestones and project goals. The 0.5.0 milestone is released on [crates.io](https://crates.io/crates/meta-ast) and GitHub Releases, with documentation published at [metacall.github.io/meta-ast](https://metacall.github.io/meta-ast/).
 
 ### Future Work (Post-GSoC Roadmap)
+
 - **C ABI and Header Generation**: Implement automatic C header generation for exported polyglot functions (RFC 0011).
 - **Deeper Intra-Procedural Dataflow**: Expand dataflow node extraction from Rust to JavaScript, TypeScript, Python, and Go.
 - **Additional Language Packs**: Add grammars for PHP, Java, and C# based on user demand.
-- **Polyglot SAST Integration**: Integrate static application security testing rules and machine learning assisted anomaly detection (RFC 0029).
+- **Polyglot SAST Integration**: Integrate static application security testing rules and machine learning assisted anomaly detection (no RFC yet; see docs/src/rfcs/ for the numbered records).
 
 ---
 

--- a/docs/src/ROADMAP.md
+++ b/docs/src/ROADMAP.md
@@ -35,7 +35,7 @@ Goals:
 
 - Extend model with optional data/flow nodes (DataNode, FlowEdge, DataScope, FlowKind).
 - Implement intra-procedural def-use extraction for Rust (let bindings, parameters).
-- Provide portable graph export contract with schema versioning (v1).
+- Provide portable graph export contract with schema versioning. The graph document carries `SCHEMA_VERSION` and the shard format carries `SHARD_SCHEMA_VERSION` (4 as of this release).
 - Pluggable sink adapters (GraphSink trait + JsonSink).
 - CLI integration: `--datagraph` flag on graph subcommand.
 - Unified GraphOutput serialization (replaces separate datagraph module).
@@ -222,8 +222,8 @@ Goals:
 - Extract statement nodes, binary operations, control flow branches, and expression terms across
   all 9 supported languages.
 - Maintain a layered representation:
-  - *Layer 1 (Default)*: Fast, lightweight symbol & reference graph.
-  - *Layer 2 (Opt-in)*: Full expression-level AST with lexical scopes and operator nodes.
+  - _Layer 1 (Default)_: Fast, lightweight symbol & reference graph.
+  - _Layer 2 (Opt-in)_: Full expression-level AST with lexical scopes and operator nodes.
 - Generate intra-procedural CFGs for abstract interpretation, dead branch elimination, and
   fine-grained taint propagation.
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -53,6 +53,9 @@ pub enum Error {
     #[error("identifier space exhausted")]
     IdExhausted,
 
+    #[error("analysis reported {errors} error(s) and {warnings} warning(s)")]
+    Diagnostics { errors: usize, warnings: usize },
+
     #[error("invalid source URI '{uri}': {message}")]
     InvalidSourceUri { uri: String, message: String },
 

--- a/src/interface/args.rs
+++ b/src/interface/args.rs
@@ -67,6 +67,10 @@ pub struct InspectArgs {
     /// Output format for the extracted symbols
     #[arg(short = 'f', long, default_value = "json", value_parser = parse_format)]
     pub format: crate::output::OutputFormat,
+
+    /// Diagnostic severity that makes the run exit with status 1
+    #[arg(long, value_enum, default_value_t = crate::interface::report::FailOn::Error)]
+    pub fail_on: crate::interface::report::FailOn,
 }
 
 #[derive(Parser)]
@@ -85,6 +89,10 @@ pub struct GraphArgs {
     /// Output serialization format for the graph structure
     #[arg(short = 'f', long, default_value = "json", value_parser = parse_format)]
     pub format: crate::output::OutputFormat,
+
+    /// Diagnostic severity that makes the run exit with status 1
+    #[arg(long, value_enum, default_value_t = crate::interface::report::FailOn::Error)]
+    pub fail_on: crate::interface::report::FailOn,
 
     /// Generate an interactive HTML dashboard with graph visualization
     #[arg(long)]

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -1,2 +1,3 @@
 pub mod args;
 pub mod banner;
+pub mod report;

--- a/src/interface/report.rs
+++ b/src/interface/report.rs
@@ -1,0 +1,115 @@
+//! Diagnostic reporting and the exit policy.
+//!
+//! An analysis run reports every diagnostic it collected and then decides the
+//! process status from the requested policy. The reporting is separate from the
+//! serialization, so `--fail-on` never changes the emitted document.
+
+use crate::error::{Diagnostic, Error, Severity};
+
+/// How many diagnostics make a run fail.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, clap::ValueEnum)]
+#[value(rename_all = "lower")]
+pub enum FailOn {
+    /// Never fail on diagnostics.
+    Never,
+    /// Fail when the run reports an error diagnostic.
+    #[default]
+    Error,
+    /// Fail when the run reports an error or a warning diagnostic.
+    Warning,
+}
+
+impl FailOn {
+    /// True when the collected diagnostics trip the policy.
+    pub fn tripped(self, errors: usize, warnings: usize) -> bool {
+        match self {
+            FailOn::Never => false,
+            FailOn::Error => errors > 0,
+            FailOn::Warning => errors > 0 || warnings > 0,
+        }
+    }
+}
+
+/// Log every diagnostic and apply the policy.
+///
+/// Returns [`Error::Diagnostics`] when the policy is tripped, so the caller can
+/// map it to the analysis exit code.
+pub fn report_diagnostics(diagnostics: &[Diagnostic], fail_on: FailOn) -> Result<(), Error> {
+    let mut errors = 0usize;
+    let mut warnings = 0usize;
+
+    for diagnostic in diagnostics {
+        let path = diagnostic.path.display().to_string();
+        let range = diagnostic
+            .source_range
+            .as_ref()
+            .map(|range| range.start.line + 1);
+        match diagnostic.severity {
+            Severity::Error => {
+                errors += 1;
+                tracing::error!(path = %path, line = ?range, "{}", diagnostic.message);
+            }
+            Severity::Warning => {
+                warnings += 1;
+                tracing::warn!(path = %path, line = ?range, "{}", diagnostic.message);
+            }
+        }
+    }
+
+    if fail_on.tripped(errors, warnings) {
+        return Err(Error::Diagnostics { errors, warnings });
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn diagnostic(severity: Severity) -> Diagnostic {
+        Diagnostic {
+            path: PathBuf::from("a.py"),
+            severity,
+            message: "problem".into(),
+            source_range: None,
+        }
+    }
+
+    #[test]
+    fn never_accepts_errors() {
+        let diagnostics = [diagnostic(Severity::Error)];
+        assert!(report_diagnostics(&diagnostics, FailOn::Never).is_ok());
+    }
+
+    #[test]
+    fn error_policy_ignores_warnings() {
+        let diagnostics = [diagnostic(Severity::Warning)];
+        assert!(report_diagnostics(&diagnostics, FailOn::Error).is_ok());
+    }
+
+    #[test]
+    fn error_policy_fails_on_an_error() {
+        let diagnostics = [diagnostic(Severity::Warning), diagnostic(Severity::Error)];
+        let error = report_diagnostics(&diagnostics, FailOn::Error).unwrap_err();
+        assert!(matches!(
+            error,
+            Error::Diagnostics {
+                errors: 1,
+                warnings: 1
+            }
+        ));
+    }
+
+    #[test]
+    fn warning_policy_fails_on_a_warning() {
+        let diagnostics = [diagnostic(Severity::Warning)];
+        assert!(report_diagnostics(&diagnostics, FailOn::Warning).is_err());
+    }
+
+    #[test]
+    fn clean_run_never_fails() {
+        assert!(report_diagnostics(&[], FailOn::Warning).is_ok());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,20 +1,42 @@
+use std::process::ExitCode;
+
 use clap::Parser;
 use meta_ast::interface::args::Cli;
+use meta_ast::interface::report::report_diagnostics;
 use meta_ast::model::SnapshotId;
 
 #[cfg(feature = "watch")]
 use meta_ast::watch::{WatchConfig, run_watch};
 
-fn main() -> anyhow::Result<()> {
-    meta_ast::interface::banner::print_banner();
+fn main() -> ExitCode {
+    match run() {
+        Ok(status) => status,
+        Err(error) => {
+            eprintln!("error: {error:#}");
+            ExitCode::from(exit_status(&error))
+        }
+    }
+}
 
-    meta_ast::language::validate_queries();
+/// Usage and configuration problems exit with 2, every other failure with 1.
+fn exit_status(error: &anyhow::Error) -> u8 {
+    match error.downcast_ref::<meta_ast::Error>() {
+        Some(meta_ast::Error::Config(_)) => 2,
+        _ => 1,
+    }
+}
+
+/// Parse first, so help and version stay clean, then install the subscriber
+/// before anything can log or panic.
+fn run() -> anyhow::Result<ExitCode> {
+    let cli = Cli::parse();
 
     tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .init();
 
-    let cli = Cli::parse();
+    meta_ast::interface::banner::print_banner();
+    meta_ast::language::validate_queries();
 
     match cli {
         Cli::Inspect(args) => {
@@ -31,20 +53,14 @@ fn main() -> anyhow::Result<()> {
                 },
             );
 
-            let mut symbols: Vec<_> = result
-                .files
-                .into_iter()
-                .flat_map(|f| {
-                    for diag in &f.diagnostics {
-                        tracing::warn!(
-                            path = %diag.path.display(),
-                            severity = ?diag.severity,
-                            "{}", diag.message
-                        );
-                    }
-                    f.symbols
-                })
-                .collect();
+            let mut diagnostics = Vec::new();
+            let mut symbols = Vec::new();
+            for file in result.files {
+                diagnostics.extend(file.diagnostics.iter().cloned());
+                symbols.extend(file.symbols);
+            }
+
+            report_diagnostics(&diagnostics, args.fail_on)?;
 
             let config = meta_ast::output::emitter::EmitConfig {
                 output: args.output,
@@ -55,7 +71,7 @@ fn main() -> anyhow::Result<()> {
 
             meta_ast::output::emitter::emit_inspect(&mut symbols, &config)?;
 
-            Ok(())
+            Ok(ExitCode::SUCCESS)
         }
 
         Cli::Graph(args) => {
@@ -73,6 +89,7 @@ fn main() -> anyhow::Result<()> {
                 let output = args.output.clone();
                 let html = args.html;
                 let format = args.format;
+                let fail_on = args.fail_on;
 
                 return run_watch(args.path, watch_config, move |analysis, change_set| {
                     let emit_config = meta_ast::output::emitter::EmitConfig {
@@ -106,11 +123,14 @@ fn main() -> anyhow::Result<()> {
                         "Re-analyzed",
                     );
 
+                    let _ = fail_on;
+
                     Ok(())
-                });
+                })
+                .map(|()| ExitCode::SUCCESS);
             }
 
-            let snapshot_id = SnapshotId::new(1).unwrap();
+            let snapshot_id = SnapshotId::from(std::num::NonZeroU32::MIN);
             let languages = args.language.map(|l| [l]);
             let (analysis, diags) = meta_ast::pipeline::analyze_graph(
                 &args.path,
@@ -118,13 +138,7 @@ fn main() -> anyhow::Result<()> {
                 languages.as_ref().map(|a| a.as_slice()),
             )?;
 
-            for diag in &diags {
-                tracing::warn!(
-                    path = %diag.path.display(),
-                    severity = ?diag.severity,
-                    "{}", diag.message
-                );
-            }
+            report_diagnostics(&diags, args.fail_on)?;
 
             let default_html_output = if args.html && args.output.is_none() {
                 let name = args
@@ -180,7 +194,7 @@ fn main() -> anyhow::Result<()> {
                 sink.emit(&export)?;
             }
 
-            Ok(())
+            Ok(ExitCode::SUCCESS)
         }
 
         #[cfg(feature = "metacall-deploy")]
@@ -192,7 +206,8 @@ fn main() -> anyhow::Result<()> {
                 check: args.check,
                 max_pod_size: args.max_pod_size,
             };
-            meta_ast::deploy::run_deploy(config)
+            meta_ast::deploy::run_deploy(config)?;
+            Ok(ExitCode::SUCCESS)
         }
     }
 }


### PR DESCRIPTION
## Summary

CLI and error policy. Fixes X1 to X4, plus the documentation rows the code invalidates.

- `inspect` and `graph` accept `--fail-on never|error|warning`, default `error`, and exit 1 when the policy trips, 2 for a usage or configuration problem, 0 otherwise. The README claim about a CI gate now matches the tool.
- The arguments parse before the banner, so `--help` and `--version` stay clean, and the query validation runs after the tracing subscriber is installed.
- Diagnostics report through one helper that keeps the path, the line and the severity.
- Doc truth: the crate version, both schema versions, the missing RFC reference, the deterministic wording, and the feature-gated CLI surface.

## Type of change

- [x] `fix` - bug fix

## Affected area

- [x] `interface` (CLI)
- [x] `docs` / `tests`
