### PR TITLE
fix(language): stop treating a plain line comment as documentation

### DIFF
--- a/src/language/c.rs
+++ b/src/language/c.rs
@@ -146,6 +146,24 @@ mod tests {
     }
 
     #[test]
+    fn c_plain_line_comment_is_not_a_docstring() {
+        let note = b"// note for readers\nint noted(void) { return 0; }";
+        let tree = parse(note);
+        let symbols = extract_symbols_for(LangId::C, &tree, note);
+        let func = symbols.iter().find(|s| s.name == "noted").unwrap();
+        assert!(
+            func.docstring.is_none(),
+            "a plain line comment must stay a comment"
+        );
+
+        let documented = b"/// line doc\nint lined(void) { return 0; }";
+        let tree = parse(documented);
+        let symbols = extract_symbols_for(LangId::C, &tree, documented);
+        let func = symbols.iter().find(|s| s.name == "lined").unwrap();
+        assert_eq!(func.docstring.as_deref(), Some("line doc"));
+    }
+
+    #[test]
     fn c_docstring_extraction() {
         let src = b"/** Doxygen comment. */\nint documented() {}";
         let tree = parse(src);

--- a/src/language/javascript.rs
+++ b/src/language/javascript.rs
@@ -359,6 +359,28 @@ mod tests {
     }
 
     #[test]
+    fn js_plain_line_comment_is_not_a_docstring() {
+        let note = b"// note for readers\nfunction noted() {}";
+        let tree = parse(note);
+        let symbols = extract_symbols_for(LangId::JavaScript, &tree, note);
+        let func = symbols.iter().find(|s| s.name == "noted").unwrap();
+        assert!(
+            func.docstring.is_none(),
+            "a plain line comment must stay a comment"
+        );
+
+        let documented = b"/// line doc\nfunction lined() {}";
+        let tree = parse(documented);
+        let symbols = extract_symbols_for(LangId::JavaScript, &tree, documented);
+        let func = symbols.iter().find(|s| s.name == "lined").unwrap();
+        assert_eq!(
+            func.docstring.as_deref(),
+            Some("line doc"),
+            "the documenting line form is ///"
+        );
+    }
+
+    #[test]
     fn js_docstring_extraction() {
         let src = b"/** JSDoc comment. */\nfunction documented() {}";
         let tree = parse(src);

--- a/src/language/mod.rs
+++ b/src/language/mod.rs
@@ -54,8 +54,13 @@ pub enum DefaultVisibility {
 /// Shared JSDoc/C-style doc comment config.
 ///
 /// Used by JS, TS, TSX, C, C++ specs. Only Rust, Go, Ruby, Python differ.
+///
+/// A plain `//` line is a note, not documentation: it stays a comment and never
+/// becomes a symbol docstring. The documenting line forms are `///` and `//!`,
+/// and the block form is `/** */`. Go and Ruby keep their own convention, where
+/// a plain `//` or `#` line does document the symbol below it.
 pub const C_LIKE_DOC_COMMENT: DocCommentConfig = DocCommentConfig {
-    line_prefixes: &["//"],
+    line_prefixes: &["///", "//!"],
     block_open: Some("/**"),
     block_close: "*/",
     strip_continuation_marker: true,


### PR DESCRIPTION
## Summary

Fixes L3 from the audit: a plain `//` line above a JS, TS, TSX, C or C++ declaration was treated as its documentation, so every ordinary note became a symbol docstring.

- `C_LIKE_DOC_COMMENT.line_prefixes` is now `["///", "//!"]`. A plain `//` line stays a comment; the documenting line forms and the `/** */` block form still attach, which is what JSDoc and Doxygen define.
- Go keeps its own convention (a plain `//` line does document the symbol below it) and Ruby keeps `#`; Rust already required `///` or `//!`. Python has no comment based docstrings.
- Tests: `js_plain_line_comment_is_not_a_docstring` and `c_plain_line_comment_is_not_a_docstring` pin both halves, one for a script language and one for the C family, whose config is the shared constant.

No snapshot needed refreshing. The insta snapshots read fixtures that only ever used `/** */`, so nothing pinned the old behavior; the two unit tests pin the new one instead. Adding a plain `//` line to a fixture was tried and reverted: the repository's JavaScript linter then flags every declaration in that fixture as unused, which a declaration fixture cannot satisfy.

## Type of change

- [x] `fix` - bug fix

## Affected area

- [x] `language` (extraction)
- [x] `docs` / `tests`

## Notes

The change is user visible: symbols in JS, TS, TSX, C and C++ that previously carried a docstring copied from a plain `//` note now report no docstring. Docstrings from `///`, `//!` and `/** */` are unchanged.
