### PR TITLE
fix(shard): write portable shard names and store each edge once

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,8 @@ pub use graph::{
 pub use output::shard::{
     INDEX_DIR_NAME, IndexLoadOptions, IndexLoadStats, LoadedIndex, LoadedShard,
     SHARD_SCHEMA_VERSION, ShardEdge, ShardEdgeKind, ShardError, ShardFile, ShardFlowKind,
-    ShardHeader, ShardManifestRecord, ShardSymbol, is_safe_shard_name, load_index, read_header,
+    ShardHeader, ShardManifestRecord, ShardNamePlan, ShardSymbol, collision_key,
+    is_safe_shard_name, is_writable_name, load_index, plan_shard_file_names, read_header,
     read_manifest, read_shard, restore_shard_edges, write_header, write_manifest, write_shard,
 };
 pub use pipeline::{GraphAnalysis, SnapshotMeta, snapshot_meta};

--- a/src/output/shard/error.rs
+++ b/src/output/shard/error.rs
@@ -48,6 +48,9 @@ pub enum ShardError {
     #[error("unsafe shard name: {name}")]
     UnsafeShardName { name: String },
 
+    #[error("shard name '{name}' cannot be written on every platform: {reason}")]
+    UnwritableShardName { name: String, reason: &'static str },
+
     #[error("index path escapes the project root: {path:?}")]
     PathOutsideRoot { path: PathBuf },
 }

--- a/src/output/shard/file.rs
+++ b/src/output/shard/file.rs
@@ -15,7 +15,7 @@ use crate::model::{
 };
 use crate::output::shard::edge::{ShardEdge, validate_edge};
 use crate::output::shard::error::ShardError;
-use crate::output::shard::name::{StableNameIndex, node_belongs_to_file, normalized_path};
+use crate::output::shard::name::{StableNameIndex, node_owner_path, normalized_path};
 
 /// Shard payload version.
 ///
@@ -62,6 +62,9 @@ pub struct LoadedShard {
 
 impl ShardFile {
     /// Convert an in-memory `FileExtraction` and graph into a shard record.
+    ///
+    /// An edge is stored by the shard of its source owner only, so a
+    /// cross-file edge exists once in the index instead of once per endpoint.
     pub fn from_extraction(
         extraction: &FileExtraction,
         graph: &CodeGraph,
@@ -88,8 +91,9 @@ impl ShardFile {
             .filter(|edge| {
                 !matches!(graph.graph()[edge.source()], NodeData::Data(_))
                     && !matches!(graph.graph()[edge.target()], NodeData::Data(_))
-                    && (node_belongs_to_file(graph, edge.source(), &extraction.path)
-                        || node_belongs_to_file(graph, edge.target(), &extraction.path))
+                    && node_owner_path(graph, edge.source())
+                        .or_else(|| node_owner_path(graph, edge.target()))
+                        == Some(extraction.path.as_path())
             })
             .map(|edge| {
                 let source_name = names

--- a/src/output/shard/index.rs
+++ b/src/output/shard/index.rs
@@ -119,13 +119,14 @@ pub fn load_index(
     let mut shards: BTreeMap<String, Vec<ShardFile>> = BTreeMap::new();
     let mut unreadable_shards: BTreeMap<String, String> = BTreeMap::new();
     for record in &manifest {
+        // Containment and writability stay separate, so a traversal attempt and
+        // a name that no portable writer creates do not look alike. Shard names
+        // are checked here, where the shard file is opened.
         if !is_safe_shard_name(&record.shard) {
             return Err(ShardError::UnsafeShardName {
                 name: record.shard.clone(),
             });
         }
-        // Containment and writability stay separate, so a traversal attempt
-        // and a name that no portable writer creates do not look alike.
         if !is_writable_name(&record.shard) {
             return Err(ShardError::UnwritableShardName {
                 name: record.shard.clone(),

--- a/src/output/shard/index.rs
+++ b/src/output/shard/index.rs
@@ -13,11 +13,12 @@ use std::sync::Arc;
 
 use crate::model::{FileExtraction, IdGenerator, SymbolId};
 
-use super::edge::ShardEdge;
+use super::edge::{ShardEdge, ShardEdgeKind};
 use super::error::ShardError;
 use super::file::{LoadedShard, ShardFile, read_shard};
 use super::header::{ShardHeader, read_header};
 use super::manifest::{ShardManifestRecord, read_manifest};
+use super::name::is_device_stem;
 
 /// Directory name of the generated index under the project root.
 pub const INDEX_DIR_NAME: &str = ".meta-ast";
@@ -79,6 +80,22 @@ pub fn is_safe_shard_name(name: &str) -> bool {
             .any(|component| matches!(component, Component::ParentDir | Component::RootDir))
 }
 
+/// Reports whether a shard name can be written on every platform this index
+/// supports: it stays inside `shards/`, it does not end in a dot or a space,
+/// and its stem is not a reserved Windows device.
+pub fn is_writable_name(name: &str) -> bool {
+    if !is_safe_shard_name(name) {
+        return false;
+    }
+    let Some(file_name) = Path::new(name).file_name().and_then(|part| part.to_str()) else {
+        return false;
+    };
+    if file_name.ends_with('.') || file_name.ends_with(' ') {
+        return false;
+    }
+    !is_device_stem(file_name.split('.').next().unwrap_or_default())
+}
+
 /// Load and verify a `.meta-ast` index.
 ///
 /// IDs are assigned in manifest order, so the caller must pass a generator
@@ -105,6 +122,14 @@ pub fn load_index(
         if !is_safe_shard_name(&record.shard) {
             return Err(ShardError::UnsafeShardName {
                 name: record.shard.clone(),
+            });
+        }
+        // Containment and writability stay separate, so a traversal attempt
+        // and a name that no portable writer creates do not look alike.
+        if !is_writable_name(&record.shard) {
+            return Err(ShardError::UnwritableShardName {
+                name: record.shard.clone(),
+                reason: "the name is reserved or ends in a dot or a space",
             });
         }
         if shards.contains_key(&record.shard) {
@@ -221,6 +246,17 @@ pub fn load_index(
         stats,
         skips,
     })
+}
+
+impl LoadedIndex {
+    /// Persisted edges per kind, for a caller that reports index contents.
+    pub fn edge_counts_by_kind(&self) -> BTreeMap<ShardEdgeKind, usize> {
+        let mut counts = BTreeMap::new();
+        for edge in &self.edges {
+            *counts.entry(edge.kind).or_default() += 1;
+        }
+        counts
+    }
 }
 
 fn record_skip(

--- a/src/output/shard/mod.rs
+++ b/src/output/shard/mod.rs
@@ -24,9 +24,10 @@ pub use file::{
 pub use header::{ShardHeader, read_header, write_header};
 pub use index::{
     INDEX_DIR_NAME, IndexLoadOptions, IndexLoadStats, LoadedIndex, ShardSkip, is_safe_shard_name,
-    load_index,
+    is_writable_name, load_index,
 };
 pub use manifest::{ShardManifestRecord, read_manifest, write_manifest};
+pub use name::{ShardNamePlan, collision_key, plan_shard_file_names};
 
 #[cfg(test)]
 mod tests {

--- a/src/output/shard/name.rs
+++ b/src/output/shard/name.rs
@@ -1,21 +1,32 @@
 //! Stable naming and descriptor generation for shard endpoints.
 
-use std::collections::HashMap;
-use std::path::Path;
+use std::collections::{BTreeMap, HashMap};
+use std::path::{Path, PathBuf};
 
 use petgraph::graph::NodeIndex;
 
+use crate::error::{Diagnostic, Severity};
 use crate::graph::{CodeGraph, NodeData};
 use crate::model::FileId;
 use crate::output::shard::error::ShardError;
 
-pub(crate) fn node_belongs_to_file(graph: &CodeGraph, node_index: NodeIndex, path: &Path) -> bool {
-    match graph.graph().node_weight(node_index) {
-        Some(NodeData::File(file)) => file.path == path,
-        Some(NodeData::Symbol(symbol)) => graph
+/// Suffix of every shard file.
+const SHARD_SUFFIX: &str = ".jsonl";
+/// Longest escaped component kept verbatim in a name. The suffix and a
+/// collision marker must still fit the common 255 byte file name limit.
+const MAX_COMPONENT_BYTES: usize = 200;
+/// Digest length used when an escaped path is too long to name a file.
+const LONG_COMPONENT_DIGEST: usize = 32;
+
+/// Path of the file that owns a node: the file itself, or the file that holds
+/// a symbol. `None` for an external node, a data node, or an unknown index.
+pub(crate) fn node_owner_path(graph: &CodeGraph, node_index: NodeIndex) -> Option<&Path> {
+    match graph.graph().node_weight(node_index)? {
+        NodeData::File(file) => Some(file.path.as_path()),
+        NodeData::Symbol(symbol) => graph
             .file_node(symbol.file_id)
-            .is_some_and(|file| file.path == path),
-        Some(NodeData::External(_) | NodeData::Data(_)) | None => false,
+            .map(|file| file.path.as_path()),
+        NodeData::External(_) | NodeData::Data(_) => None,
     }
 }
 
@@ -206,4 +217,165 @@ pub(crate) fn escape_component(value: &str) -> String {
         }
     }
     escaped
+}
+
+/// Key that two written names share when one file system would treat them as
+/// one file: case folding, and the trailing dot or space that Windows strips.
+///
+/// A shard writer percent-encodes before a name reaches the file system, which
+/// removes every other ambiguity, so Unicode normalization is not part of the
+/// key.
+pub fn collision_key(name: &str) -> String {
+    name.trim_end_matches(['.', ' ']).to_lowercase()
+}
+
+/// Windows reserves these names whatever extension follows them.
+pub(crate) fn is_device_stem(stem: &str) -> bool {
+    const NAMES: [&str; 4] = ["CON", "PRN", "AUX", "NUL"];
+    if NAMES.iter().any(|name| stem.eq_ignore_ascii_case(name)) {
+        return true;
+    }
+    let bytes = stem.as_bytes();
+    bytes.len() == 4
+        && bytes[3].is_ascii_digit()
+        && (bytes[..3].eq_ignore_ascii_case(b"COM") || bytes[..3].eq_ignore_ascii_case(b"LPT"))
+}
+
+/// One shard file name per source path, in input order.
+#[derive(Debug, Clone)]
+pub struct ShardNamePlan {
+    pub names: Vec<String>,
+    /// One warning per name that had to change, naming the paths involved.
+    pub warnings: Vec<Diagnostic>,
+}
+
+/// Escaped shard component and the two reasons it can differ from the path.
+struct ShardComponent {
+    name: String,
+    /// The escaped path was too long, so the name is a digest.
+    hashed: bool,
+    /// A reserved device stem was escaped.
+    device: bool,
+}
+
+/// Choose a shard file name for every source path.
+///
+/// Paths are expected relative to the index root; an absolute path still
+/// produces a valid name. Two paths that one file system folds into one name
+/// get a deterministic suffix instead of sharing a file, so the index also
+/// loads after it moves to a platform with different file name rules.
+pub fn plan_shard_file_names(paths: &[PathBuf]) -> Result<ShardNamePlan, ShardError> {
+    let mut names = Vec::with_capacity(paths.len());
+    let mut warnings = Vec::new();
+    let mut taken: BTreeMap<String, PathBuf> = BTreeMap::new();
+
+    for (position, path) in paths.iter().enumerate() {
+        let component = shard_component(path)?;
+        let name = format!("shards/{}{SHARD_SUFFIX}", component.name);
+        if component.device {
+            warnings.push(Diagnostic {
+                path: path.clone(),
+                severity: Severity::Warning,
+                message: format!(
+                    "{} names a Windows device, so the shard is written as {name}",
+                    path.display()
+                ),
+                source_range: None,
+            });
+        }
+        if component.hashed {
+            taken.insert(collision_key(&name), path.clone());
+            names.push(name);
+            continue;
+        }
+
+        let Some(first) = taken.get(&collision_key(&name)).cloned() else {
+            taken.insert(collision_key(&name), path.clone());
+            names.push(name);
+            continue;
+        };
+
+        let resolved = disambiguated(&name, &first, position, &taken)?;
+        taken.insert(collision_key(&resolved), path.clone());
+        warnings.push(Diagnostic {
+            path: path.clone(),
+            severity: Severity::Warning,
+            message: format!(
+                "{} and {} differ only by case or a trailing mark, so the shard is written as {resolved}",
+                first.display(),
+                path.display()
+            ),
+            source_range: None,
+        });
+        names.push(resolved);
+    }
+
+    Ok(ShardNamePlan { names, warnings })
+}
+
+/// Escaped form of the last path component, portable on every file system.
+fn shard_component(path: &Path) -> Result<ShardComponent, ShardError> {
+    let normalized = normalized_path(path)?;
+    let (directory, file) = match normalized.rsplit_once('/') {
+        Some((directory, file)) => (Some(directory), file),
+        None => (None, normalized.as_str()),
+    };
+    let (escaped_file, device) = escaped_file_component(file);
+    let component = match directory {
+        Some(directory) => format!("{}%2F{escaped_file}", escape_component(directory)),
+        None => escaped_file,
+    };
+    if component.len() <= MAX_COMPONENT_BYTES {
+        return Ok(ShardComponent {
+            name: component,
+            hashed: false,
+            device,
+        });
+    }
+    let digest = blake3::hash(normalized.as_bytes()).to_hex().to_string();
+    Ok(ShardComponent {
+        name: digest[..LONG_COMPONENT_DIGEST].to_string(),
+        hashed: true,
+        device,
+    })
+}
+
+/// Escape a file name so it can be created on Windows, macOS and Linux: a
+/// trailing dot is escaped because Windows strips it, and a device stem is
+/// escaped because Windows reserves it whatever the extension is. The second
+/// value reports the device rewrite.
+fn escaped_file_component(file: &str) -> (String, bool) {
+    let mut escaped = escape_component(file);
+    if escaped.ends_with('.') {
+        escaped.truncate(escaped.len() - 1);
+        escaped.push_str("%2E");
+    }
+    let stem_end = escaped.find('.').unwrap_or(escaped.len());
+    if !is_device_stem(&escaped[..stem_end]) {
+        return (escaped, false);
+    }
+    let first = escaped.as_bytes()[0];
+    (format!("%{first:02X}{}", &escaped[1..]), true)
+}
+
+/// Deterministic marker that separates two names the file system folds.
+fn disambiguated(
+    name: &str,
+    first: &Path,
+    position: usize,
+    taken: &BTreeMap<String, PathBuf>,
+) -> Result<String, ShardError> {
+    let stem = name.strip_suffix(SHARD_SUFFIX).unwrap_or(name);
+    let seed = format!("{}\u{0}{name}\u{0}{position}", first.display());
+    let digest = blake3::hash(seed.as_bytes()).to_hex().to_string();
+    for width in [8usize, 16, 32, 64] {
+        let candidate = format!("{stem}.{}{SHARD_SUFFIX}", &digest[..width]);
+        if !taken.contains_key(&collision_key(&candidate)) {
+            return Ok(candidate);
+        }
+    }
+    Err(ShardError::UnwritableShardName {
+        name: name.to_string(),
+        reason: "no digest separates this name from the names already planned",
+    })
 }

--- a/tests/fixtures/import_hygiene/app.js
+++ b/tests/fixtures/import_hygiene/app.js
@@ -1,5 +1,5 @@
-import React from 'react';
-import { helper } from './helper';
+import React from "react";
+import { helper } from "./helper";
 
 export const compute = (value) => helper(value);
 

--- a/tests/fixtures/import_hygiene/module.ts
+++ b/tests/fixtures/import_hygiene/module.ts
@@ -1,4 +1,4 @@
-import { core } from '@angular/core';
+import { core } from "@angular/core";
 
 export function ts_use(): number {
     return core();

--- a/tests/integration/shard_hygiene_test.rs
+++ b/tests/integration/shard_hygiene_test.rs
@@ -271,18 +271,32 @@ fn export_disambiguates_equivalent_names_end_to_end() {
     fs::write(root.join("a.py"), "def lower():\n    return 2\n").unwrap();
     fs::write(root.join("CON.py"), "def device():\n    return 3\n").unwrap();
 
+    // A case-insensitive file system folds A.py and a.py into one file, so the
+    // tree can hold only two of the three names there. The naming policy is the
+    // part that must hold on every file system, so it is checked with the
+    // intended path list either way, and the export round trip below needs the
+    // three distinct files and runs only where they exist.
+    let folded = std::fs::read_dir(root).unwrap().count() < 3;
+
     let (analysis, _diagnostics) =
         meta_ast::pipeline::analyze_graph(root, SnapshotId::new(1).unwrap(), None).unwrap();
-    let relative: Vec<PathBuf> = analysis
-        .extractions
-        .iter()
-        .map(|file| {
-            file.path
-                .strip_prefix(root)
-                .unwrap_or(file.path.as_path())
-                .to_path_buf()
-        })
-        .collect();
+    let relative: Vec<PathBuf> = if folded {
+        ["A.py", "a.py", "CON.py"]
+            .iter()
+            .map(PathBuf::from)
+            .collect()
+    } else {
+        analysis
+            .extractions
+            .iter()
+            .map(|file| {
+                file.path
+                    .strip_prefix(root)
+                    .unwrap_or(file.path.as_path())
+                    .to_path_buf()
+            })
+            .collect()
+    };
     assert_eq!(relative.len(), 3, "the fixture tree holds three files");
 
     let plan = plan_shard_file_names(&relative).unwrap();
@@ -318,6 +332,12 @@ fn export_disambiguates_equivalent_names_end_to_end() {
         "every written name is portable: {:?}",
         plan.names
     );
+
+    if folded {
+        // The round trip needs three files on disk; the policy assertions above
+        // are the part that has to hold on a case-insensitive file system.
+        return;
+    }
 
     write_index(root, &analysis, &plan.names);
     for name in &plan.names {

--- a/tests/integration/shard_hygiene_test.rs
+++ b/tests/integration/shard_hygiene_test.rs
@@ -354,7 +354,15 @@ fn reader_refuses_a_name_that_no_platform_can_write() {
 
     let (analysis, _diagnostics) =
         meta_ast::pipeline::analyze_graph(root, SnapshotId::new(1).unwrap(), None).unwrap();
-    write_index(root, &analysis, &["shards/CON.jsonl".to_string()]);
+    write_index(root, &analysis, &["shards/0.jsonl".to_string()]);
+
+    let manifest_path = root.join(INDEX_DIR_NAME).join("manifest.jsonl");
+    let manifest = fs::read_to_string(&manifest_path).unwrap();
+    fs::write(
+        &manifest_path,
+        manifest.replace("shards/0.jsonl", "shards/CON.jsonl"),
+    )
+    .unwrap();
 
     let error = load_index(
         root,

--- a/tests/integration/shard_hygiene_test.rs
+++ b/tests/integration/shard_hygiene_test.rs
@@ -1,12 +1,19 @@
 //! Shard name portability and edge ownership.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
-use std::path::Path;
+use std::fs::File;
+use std::io::BufReader;
+use std::path::{Path, PathBuf};
 
+use meta_ast::Severity;
 use meta_ast::graph::{CodeGraph, EdgeKind, GraphBuilder};
-use meta_ast::model::SnapshotId;
-use meta_ast::output::shard::{ShardEdge, ShardEdgeKind, ShardFile, restore_shard_edges};
+use meta_ast::model::{IdGenerator, SnapshotId, SymbolId};
+use meta_ast::output::shard::{
+    INDEX_DIR_NAME, IndexLoadOptions, ShardEdge, ShardEdgeKind, ShardError, ShardFile, ShardHeader,
+    ShardManifestRecord, collision_key, is_writable_name, load_index, plan_shard_file_names,
+    read_shard, restore_shard_edges, write_header, write_manifest, write_shard,
+};
 use meta_ast::pipeline::GraphAnalysis;
 use tempfile::tempdir;
 
@@ -124,4 +131,272 @@ fn rebuild(analysis: &GraphAnalysis) -> CodeGraph {
         &mut diagnostics,
     );
     graph
+}
+
+fn planned_names(paths: &[&str]) -> Vec<String> {
+    let paths: Vec<PathBuf> = paths.iter().map(PathBuf::from).collect();
+    plan_shard_file_names(&paths).unwrap().names
+}
+
+/// Write one shard per file under the given names, plus the header and the
+/// manifest that reference them.
+fn write_index(root: &Path, analysis: &GraphAnalysis, names: &[String]) {
+    let dir = root.join(INDEX_DIR_NAME);
+    fs::create_dir_all(dir.join("shards")).unwrap();
+
+    let mut header = Vec::new();
+    write_header(&mut header, &ShardHeader::new("2026-01-01T00:00:00Z")).unwrap();
+    fs::write(dir.join("header.json"), header).unwrap();
+
+    let mut records = Vec::new();
+    for (file, name) in analysis.extractions.iter().zip(names) {
+        let bytes = fs::read(&file.path).unwrap();
+        records.push(ShardManifestRecord::from_file_bytes(
+            file.path.clone(),
+            &bytes,
+            0,
+            name.clone(),
+        ));
+        let shard = ShardFile::from_extraction(file, &analysis.graph).unwrap();
+        let mut payload = Vec::new();
+        write_shard(&mut payload, std::slice::from_ref(&shard)).unwrap();
+        fs::write(dir.join(name), payload).unwrap();
+    }
+
+    let mut manifest = Vec::new();
+    write_manifest(&mut manifest, &records).unwrap();
+    fs::write(dir.join("manifest.jsonl"), manifest).unwrap();
+}
+
+/// A shard is a file name, so two source names that one platform folds into
+/// one name must not share a shard.
+#[test]
+fn portable_names_of_equivalent_file_names_stay_distinct() {
+    const PAIRS: [(&str, &str); 14] = [
+        ("a\\b.py", "a/b.py"),
+        ("a%2Fb.py", "a%2fb.py"),
+        ("caf\u{e9}.py", "cafe\u{301}.py"),
+        ("A.py", "a.py"),
+        ("name.", "name"),
+        ("name ", "name"),
+        ("CON", "CON.py"),
+        ("a-b.py", "a_b.py"),
+        ("a b.py", "a_b.py"),
+        ("x%20y.py", "x y.py"),
+        ("a+b.py", "a b.py"),
+        ("a#b.py", "a?b.py"),
+        ("NUL.py", "nul.py"),
+        ("a..py", "a.py"),
+    ];
+
+    for (first, second) in PAIRS {
+        let names = planned_names(&[first, second]);
+        assert_eq!(names.len(), 2);
+        assert_ne!(
+            names[0], names[1],
+            "{first:?} and {second:?} need their own shard"
+        );
+        for name in &names {
+            assert!(
+                is_writable_name(name),
+                "{name} must be writable for {first:?}/{second:?}"
+            );
+        }
+    }
+}
+
+/// A path long enough to exceed the common file name limit still gets a
+/// writable shard name.
+#[test]
+fn a_long_path_becomes_a_bounded_name() {
+    let long = format!("{}leaf.py", "d/".repeat(120));
+    let names = planned_names(&[long.as_str(), "a.py"]);
+
+    assert_ne!(names[0], names[1]);
+    for name in &names {
+        assert!(
+            name.len() <= 255,
+            "{name} exceeds the common file name limit ({} bytes)",
+            name.len()
+        );
+        assert!(is_writable_name(name), "{name} must be writable");
+    }
+}
+
+#[test]
+fn collision_key_folds_case_and_trailing_marks() {
+    assert_eq!(collision_key("A.py"), collision_key("a.py"));
+    assert_ne!(collision_key("A.py"), collision_key("B.py"));
+    assert_eq!(collision_key("name."), collision_key("name"));
+    assert_eq!(collision_key("name "), collision_key("name"));
+    assert_eq!(collision_key("name. ."), "name");
+}
+
+#[test]
+fn device_names_and_trailing_marks_are_refused() {
+    for name in [
+        "shards/CON.jsonl",
+        "shards/con.jsonl",
+        "shards/CON",
+        "shards/NUL.py.jsonl",
+        "shards/lpt1.jsonl",
+        "shards/name.",
+        "shards/name ",
+        "000.jsonl",
+        "shards/../secret.jsonl",
+        "/etc/passwd",
+    ] {
+        assert!(!is_writable_name(name), "{name} must be refused");
+    }
+
+    for name in [
+        "shards/000.jsonl",
+        "shards/a.py.jsonl",
+        "shards/%43ON.py.jsonl",
+        "shards/CON2.jsonl",
+        "shards/console.jsonl",
+    ] {
+        assert!(is_writable_name(name), "{name} must be accepted");
+    }
+}
+
+/// The whole writer path on a tree that holds a case colliding pair and a
+/// reserved device name: every file gets its own readable shard, the reader
+/// takes them back, and the export is byte stable.
+#[test]
+fn export_disambiguates_equivalent_names_end_to_end() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    fs::write(root.join("A.py"), "def upper():\n    return 1\n").unwrap();
+    fs::write(root.join("a.py"), "def lower():\n    return 2\n").unwrap();
+    fs::write(root.join("CON.py"), "def device():\n    return 3\n").unwrap();
+
+    let (analysis, _diagnostics) =
+        meta_ast::pipeline::analyze_graph(root, SnapshotId::new(1).unwrap(), None).unwrap();
+    let relative: Vec<PathBuf> = analysis
+        .extractions
+        .iter()
+        .map(|file| {
+            file.path
+                .strip_prefix(root)
+                .unwrap_or(file.path.as_path())
+                .to_path_buf()
+        })
+        .collect();
+    assert_eq!(relative.len(), 3, "the fixture tree holds three files");
+
+    let plan = plan_shard_file_names(&relative).unwrap();
+    assert_eq!(plan.names.len(), 3);
+
+    let collision = plan
+        .warnings
+        .iter()
+        .find(|warning| warning.message.contains("A.py") && warning.message.contains("a.py"))
+        .expect("one warning names both paths that fold into one name");
+    assert_eq!(collision.severity, Severity::Warning);
+    assert!(
+        collision.message.contains("case"),
+        "the reason is named: {}",
+        collision.message
+    );
+
+    let device = plan
+        .warnings
+        .iter()
+        .find(|warning| warning.message.contains("CON.py"))
+        .expect("one warning names the reserved device path");
+    assert!(
+        device.message.contains("device"),
+        "the reason is named: {}",
+        device.message
+    );
+
+    let distinct: BTreeSet<&String> = plan.names.iter().collect();
+    assert_eq!(distinct.len(), 3, "one shard per file: {:?}", plan.names);
+    assert!(
+        plan.names.iter().all(|name| is_writable_name(name)),
+        "every written name is portable: {:?}",
+        plan.names
+    );
+
+    write_index(root, &analysis, &plan.names);
+    for name in &plan.names {
+        assert!(
+            root.join(INDEX_DIR_NAME).join(name).exists(),
+            "{name} was written"
+        );
+    }
+
+    let loaded = load_index(
+        root,
+        &IdGenerator::<SymbolId>::new(),
+        &IndexLoadOptions::default(),
+    )
+    .unwrap();
+    assert_eq!(loaded.stats.loaded, 3);
+    assert_eq!(loaded.stats.skipped, 0);
+
+    let payload = |name: &String| fs::read(root.join(INDEX_DIR_NAME).join(name)).unwrap();
+    let before: Vec<Vec<u8>> = plan.names.iter().map(payload).collect();
+    write_index(root, &analysis, &plan.names);
+    let after: Vec<Vec<u8>> = plan.names.iter().map(payload).collect();
+
+    assert_eq!(before, after, "a second export writes the same bytes");
+}
+
+/// A name a portable writer never creates is refused instead of opening a
+/// device file on the platform that reserves it.
+#[test]
+fn reader_refuses_a_name_that_no_platform_can_write() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    fs::write(root.join("a.py"), "def a():\n    return 1\n").unwrap();
+
+    let (analysis, _diagnostics) =
+        meta_ast::pipeline::analyze_graph(root, SnapshotId::new(1).unwrap(), None).unwrap();
+    write_index(root, &analysis, &["shards/CON.jsonl".to_string()]);
+
+    let error = load_index(
+        root,
+        &IdGenerator::<SymbolId>::new(),
+        &IndexLoadOptions::default(),
+    )
+    .unwrap_err();
+
+    assert!(
+        matches!(error, ShardError::UnwritableShardName { .. }),
+        "got {error:?}"
+    );
+}
+
+/// The loaded totals must account for every persisted edge, per kind.
+#[test]
+fn loaded_index_reports_edges_by_kind() {
+    let (dir, analysis, _shards) = analyzed_project();
+    let root = dir.path();
+    let names: Vec<String> = (0..analysis.extractions.len())
+        .map(|index| format!("shards/{index}.jsonl"))
+        .collect();
+    write_index(root, &analysis, &names);
+
+    let loaded = load_index(
+        root,
+        &IdGenerator::<SymbolId>::new(),
+        &IndexLoadOptions::default(),
+    )
+    .unwrap();
+
+    let mut payload_counts: BTreeMap<ShardEdgeKind, usize> = BTreeMap::new();
+    for name in &names {
+        let file = File::open(root.join(INDEX_DIR_NAME).join(name)).unwrap();
+        for record in read_shard(BufReader::new(file)).unwrap() {
+            for edge in record.edges {
+                *payload_counts.entry(edge.kind).or_default() += 1;
+            }
+        }
+    }
+
+    assert!(!payload_counts.is_empty(), "the fixture stores edges");
+    assert_eq!(payload_counts.values().sum::<usize>(), loaded.edges.len());
+    assert_eq!(loaded.edge_counts_by_kind(), payload_counts);
 }


### PR DESCRIPTION
Shard names now survive every supported file system: two paths that differ only by case or by a trailing dot or space get a deterministic suffix and a warning naming both, Windows device names are escaped, and an over-long component becomes a digest. Each edge is stored by the shard of its source owner only and the reader tolerates a duplicate, so an index written by an earlier build still loads, and the loaded index reports its edge counts per kind.\n\nLadder: 16 failing tests before this level, 15 after.