### PR TITLE
fix(output): derive the default path once and vendor the dashboard bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,9 @@ view of their structure without executing any user code. Its objectives:
   co-deployment vs. independent-function decisions. Requires the feature-enabled
   install (`cargo install meta-ast --features metacall-deploy`).
 - **Documentation & visualization.** Emit an interactive Cytoscape.js dashboard
-  (`--html`, loaded from a CDN and cached by the browser) to explore ownership,
-  references, and deployment units visually.
+  (`--html`, self-contained: the vendored bundle travels inside the document, so
+  it renders offline) to explore ownership, references, and deployment units
+  visually.
 - **Library integration.** Consume `meta-ast` as a crate: `analyze_graph`
   returns a `GraphAnalysis` (`CodeGraph` + `SccAnalysis`) for custom tooling,
   linters, or report generators.
@@ -157,7 +158,8 @@ Builds the cross-file dependency graph, resolves imports, and runs Tarjan SCC to
 
 ```bash
 meta-ast graph <path> [-l language] [-f json|yaml] [-o graph.json]
-meta-ast graph <path> --html                    # interactive Cytoscape.js dashboard (CDN, browser-cached)
+meta-ast graph <path> --html                    # interactive Cytoscape.js dashboard (self-contained, <path>.html)
+meta-ast graph <path> --html --open             # write the dashboard and open it in the browser
 meta-ast graph <path> --datagraph               # export detailed datagraph.json (requires --features dataflow)
 meta-ast graph <path> --datagraph --datagraph-output dg.json   # choose the datagraph path
 meta-ast graph <path> --watch                   # watch mode: continuous re-analysis on file changes (requires --features watch)

--- a/src/interface/args.rs
+++ b/src/interface/args.rs
@@ -78,7 +78,7 @@ pub struct GraphArgs {
     /// Root directory to analyze
     pub path: std::path::PathBuf,
 
-    /// Output file path (prints to stdout if omitted)
+    /// Output file path (defaults to stdout, or `<path>.html` with --html)
     #[arg(short, long)]
     pub output: Option<std::path::PathBuf>,
 
@@ -97,6 +97,10 @@ pub struct GraphArgs {
     /// Generate an interactive HTML dashboard with graph visualization
     #[arg(long)]
     pub html: bool,
+
+    /// Open the written dashboard in the default browser (needs --html)
+    #[arg(long, requires = "html")]
+    pub open: bool,
 
     /// Also emit a portable datagraph export (requires --features dataflow)
     #[cfg(feature = "dataflow")]
@@ -185,5 +189,23 @@ mod tests {
     #[test]
     fn parse_language_empty_returns_err() {
         assert!(parse_language("").is_err());
+    }
+
+    #[test]
+    fn opening_the_dashboard_is_an_opt_in() {
+        let parsed = Cli::try_parse_from(["meta-ast", "graph", "demo", "--html", "--open"]);
+        assert!(
+            parsed.is_ok(),
+            "graph --html --open parses: {:?}",
+            parsed.as_ref().err()
+        );
+        assert!(
+            matches!(parsed, Ok(Cli::Graph(ref args)) if args.open),
+            "the flag reaches the parsed arguments"
+        );
+        assert!(
+            Cli::try_parse_from(["meta-ast", "graph", "demo", "--open"]).is_err(),
+            "--open without --html is a usage error"
+        );
     }
 }

--- a/src/output/dashboard.rs
+++ b/src/output/dashboard.rs
@@ -2,10 +2,23 @@ use crate::graph::CodeGraph;
 use crate::graph::scc::SccAnalysis;
 use crate::output::graph::GraphOutput;
 
+/// The Cytoscape.js bundle every dashboard carries.
+///
+/// The file is the cdnjs artifact for cytoscape 3.30.4, whose published SRI is
+/// `sha384-H3uzGzTfGHUAumB8+s4GEdfFwzAceN9wCCndN8AXubWKFIPuBSWKKtWDx7RhSf/z`.
+/// It holds no `</script` sequence, so the document can inline it as it is, and
+/// the `.js.txt` name keeps editors and formatters away from the bytes.
+const CYTOSCAPE_BUNDLE: &str = include_str!("../../assets/cytoscape-3.30.4.min.js.txt");
+
+/// BLAKE3 of [`CYTOSCAPE_BUNDLE`]. A replacement asset must update this pin.
+#[cfg(test)]
+const CYTOSCAPE_BUNDLE_BLAKE3: &str =
+    "7a81eefc9202b3f3596583a6207800f8ccc308b3b34564308ccc9a1acbfa40ee";
+
 /// Generate an interactive HTML dashboard from graph analysis data.
 ///
-/// Cytoscape.js is always loaded from a CDN so the library is never shipped
-/// in the binary; the browser caches it after the first fetch.
+/// The document is self-contained: the vendored Cytoscape.js bundle travels
+/// inside it, so it renders offline and needs no integrity attribute.
 pub fn to_graph_html(
     graph: &CodeGraph,
     scc_analysis: &SccAnalysis,
@@ -15,7 +28,7 @@ pub fn to_graph_html(
     let json_data = escape_script_payload(&serde_json::to_string(&graph_output)?);
 
     let html = HTML_TEMPLATE
-        .replacen("__CDN_SCRIPT__", &cdn_script(), 1)
+        .replacen("__CYTOSCAPE_BUNDLE__", CYTOSCAPE_BUNDLE, 1)
         .replacen("__DATA__", &json_data, 1);
     Ok(html)
 }
@@ -40,10 +53,6 @@ fn escape_script_payload(json: &str) -> String {
         }
     }
     escaped
-}
-
-fn cdn_script() -> String {
-    r#"<script src="https://cdnjs.cloudflare.com/ajax/libs/cytoscape/3.30.4/cytoscape.min.js"></script>"#.to_string()
 }
 
 const HTML_TEMPLATE: &str = r##"<!DOCTYPE html>
@@ -121,6 +130,9 @@ body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen,Ubunt
 </div>
 </div>
 </div>
+<script>
+__CYTOSCAPE_BUNDLE__
+</script>
 <script>
 var DATA=__DATA__;
 window.addEventListener("DOMContentLoaded",function(){
@@ -260,6 +272,21 @@ var png=cy.png({full:true,scale:2});
 var a=document.createElement("a");a.href=png;a.download="meta-ast-graph.png";a.click();
 }
 </script>
-__CDN_SCRIPT__
 </body>
 </html>"##;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_vendored_bundle_matches_the_pinned_hash() {
+        let hash = blake3::hash(CYTOSCAPE_BUNDLE.as_bytes())
+            .to_hex()
+            .to_string();
+        assert_eq!(
+            hash, CYTOSCAPE_BUNDLE_BLAKE3,
+            "update the pin when the vendored bundle changes"
+        );
+    }
+}

--- a/src/output/emitter.rs
+++ b/src/output/emitter.rs
@@ -30,12 +30,11 @@ pub fn emit_inspect(symbols: &mut Vec<Symbol>, config: &EmitConfig) -> anyhow::R
 
 /// Serialize and emit the dependency graph analysis results.
 ///
-/// If `config.html` is true, generates an interactive HTML dashboard and writes it
-/// to `config.output` (defaulting to "project.metast"). If `config.open_browser` is true,
-/// opens the HTML file in the default browser.
-///
-/// Otherwise, serializes the graph into the requested text format (JSON/YAML) and
-/// writes to `config.output` or prints to stdout.
+/// If `config.html` is true, generates the interactive HTML dashboard. It is
+/// written to `config.output`, or printed to stdout when no path is given, in
+/// which case there is nothing for `config.open_browser` to open. Otherwise,
+/// the graph is serialized into the requested text format (JSON/YAML) and
+/// written to `config.output`, or printed to stdout.
 pub fn emit_graph(analysis: &GraphAnalysis, config: &EmitConfig) -> anyhow::Result<()> {
     if config.html {
         let html = crate::output::dashboard::to_graph_html(
@@ -43,30 +42,14 @@ pub fn emit_graph(analysis: &GraphAnalysis, config: &EmitConfig) -> anyhow::Resu
             &analysis.scc,
             analysis.snapshot_id.to_raw() as u64,
         )?;
-        let path = config
-            .output
-            .clone()
-            .unwrap_or_else(|| PathBuf::from("project.metast"));
-        crate::output::write_atomic(&path, html.as_bytes())?;
-        if config.open_browser {
-            // A file URL keeps a non-UTF-8 path intact. `to_string_lossy` would
-            // replace the unencodable bytes, and the OS handler expects a URL.
-            let absolute = if path.is_absolute() {
-                path.clone()
-            } else {
-                std::env::current_dir()?.join(&path)
-            };
-            match url::Url::from_file_path(&absolute) {
-                Ok(url) => {
-                    if let Err(e) = webbrowser::open(url.as_str()) {
-                        tracing::warn!(error = %e, "could not open browser");
-                    }
+        match &config.output {
+            Some(path) => {
+                crate::output::write_atomic(path, html.as_bytes())?;
+                if config.open_browser {
+                    open_in_browser(path)?;
                 }
-                Err(()) => tracing::warn!(
-                    path = %absolute.display(),
-                    "cannot open the dashboard in a browser"
-                ),
             }
+            None => println!("{html}"),
         }
     } else {
         let content = crate::output::graph::serialize_graph(
@@ -83,6 +66,29 @@ pub fn emit_graph(analysis: &GraphAnalysis, config: &EmitConfig) -> anyhow::Resu
                 println!("{content}");
             }
         }
+    }
+    Ok(())
+}
+
+/// Hand the written dashboard to the operating system's default browser.
+fn open_in_browser(path: &std::path::Path) -> anyhow::Result<()> {
+    // A file URL keeps a non-UTF-8 path intact. `to_string_lossy` would
+    // replace the unencodable bytes, and the OS handler expects a URL.
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()?.join(path)
+    };
+    match url::Url::from_file_path(&absolute) {
+        Ok(url) => {
+            if let Err(e) = webbrowser::open(url.as_str()) {
+                tracing::warn!(error = %e, "could not open browser");
+            }
+        }
+        Err(()) => tracing::warn!(
+            path = %absolute.display(),
+            "cannot open the dashboard in a browser"
+        ),
     }
     Ok(())
 }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -6,7 +6,7 @@ pub mod shard;
 
 use serde::Serialize;
 use std::io::Write;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// Write `bytes` to `path` by renaming a temporary file beside it.
 ///
@@ -61,6 +61,32 @@ impl OutputFormat {
     }
 }
 
+/// The document a command writes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum OutputKind {
+    /// The interactive dashboard.
+    Html,
+    /// The serialized graph or symbol list.
+    Text,
+}
+
+/// Resolve where a command writes its document.
+///
+/// An explicit path always wins. The dashboard then lands beside the analyzed
+/// path as `<stem>.html`, and serialized text goes to stdout.
+pub fn default_output_path(
+    kind: OutputKind,
+    output: Option<PathBuf>,
+    root: &Path,
+) -> Option<PathBuf> {
+    match (kind, output) {
+        (_, Some(path)) => Some(path),
+        (OutputKind::Html, None) => Some(root.with_extension("html")),
+        (OutputKind::Text, None) => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -72,6 +98,35 @@ mod tests {
             .map(|entry| entry.file_name().to_string_lossy().to_string())
             .filter(|name| name.contains(".tmp."))
             .collect()
+    }
+
+    #[test]
+    fn explicit_output_wins_over_the_default() {
+        let given = PathBuf::from("reports/graph.html");
+        assert_eq!(
+            default_output_path(OutputKind::Html, Some(given.clone()), Path::new("demo")),
+            Some(given)
+        );
+    }
+
+    #[test]
+    fn html_defaults_beside_the_analyzed_path() {
+        assert_eq!(
+            default_output_path(OutputKind::Html, None, Path::new("demo")),
+            Some(PathBuf::from("demo.html"))
+        );
+        assert_eq!(
+            default_output_path(OutputKind::Html, None, Path::new("demo/src/main.py")),
+            Some(PathBuf::from("demo/src/main.html"))
+        );
+    }
+
+    #[test]
+    fn text_without_a_path_goes_to_stdout() {
+        assert_eq!(
+            default_output_path(OutputKind::Text, None, Path::new("demo")),
+            None
+        );
     }
 
     #[test]

--- a/src/watch/config.rs
+++ b/src/watch/config.rs
@@ -35,7 +35,7 @@ impl WatchConfig {
             format: OutputFormat::Json,
             output: None,
             html: false,
-            open_browser: true,
+            open_browser: false,
             languages: None,
         }
     }
@@ -64,7 +64,7 @@ mod tests {
         assert_eq!(cfg.format, OutputFormat::Json);
         assert!(cfg.output.is_none());
         assert!(!cfg.html);
-        assert!(cfg.open_browser);
+        assert!(!cfg.open_browser);
         assert!(cfg.languages.is_none());
     }
 

--- a/tests/integration/dashboard_test.rs
+++ b/tests/integration/dashboard_test.rs
@@ -69,8 +69,8 @@ fn to_graph_html_data_placeholder_replaced() {
     let html = meta_ast::output::dashboard::to_graph_html(&graph, &scc, 1).unwrap();
     assert!(!html.contains("__DATA__"), "__DATA__ should be substituted");
     assert!(
-        !html.contains("__CDN_SCRIPT__"),
-        "__CDN_SCRIPT__ should be substituted"
+        !html.contains("__CYTOSCAPE_BUNDLE__"),
+        "__CYTOSCAPE_BUNDLE__ should be substituted"
     );
 }
 
@@ -93,12 +93,12 @@ fn to_graph_html_json_data_valid() {
 }
 
 #[test]
-fn to_graph_html_cdn_link() {
+fn to_graph_html_embeds_the_vendored_bundle() {
     let (graph, scc) = build_sample_graph();
     let html = meta_ast::output::dashboard::to_graph_html(&graph, &scc, 1).unwrap();
     assert!(
-        html.contains("cdnjs.cloudflare.com/ajax/libs/cytoscape"),
-        "should contain CDN link"
+        html.contains("kc.version=\"3.30.4\""),
+        "should embed the pinned Cytoscape.js build"
     );
 }
 


### PR DESCRIPTION
The emitters write to stdout when no path is given instead of a default file, the HTML dashboard uses the `.html` extension and opens a browser only with `--open`, and the Cytoscape bundle travels inside the document with its integrity pinned by a test, so the dashboard renders without network access.\n\nLadder: 15 failing tests before this level, 11 after.