### PR TITLE
fix(language): store bare import specifiers and report undecodable text

### DIFF
--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -295,8 +295,8 @@ fn extract_source(
         })
         .collect();
 
-    let (imports, references) = if opts.skip_imports_and_refs {
-        (Vec::new(), Vec::new())
+    let (imports, references, text_diagnostics) = if opts.skip_imports_and_refs {
+        (Vec::new(), Vec::new(), Vec::new())
     } else {
         crate::language::extract_imports_and_references_for(lang, &tree, source, path)
     };
@@ -313,6 +313,7 @@ fn extract_source(
     out.imports = imports;
     out.references = references;
     out.diagnostics = diags;
+    out.diagnostics.extend(text_diagnostics);
     out.ast_node_count = metrics.node_count;
     #[cfg(feature = "metacall-deploy")]
     {

--- a/src/language/common.rs
+++ b/src/language/common.rs
@@ -367,24 +367,64 @@ fn resolve_import_path_from_symbol_node<'a>(
     }
 }
 
+/// Byte span of the specifier inside an import node.
+///
+/// Import statements wrap the specifier in a string literal or, for C and C++
+/// system headers, in angle brackets. Consumers want the bare form, so the wrap
+/// characters are trimmed here, at the single place the value is produced. A
+/// leading quote implies a string literal and always closes the span; angle
+/// brackets only count when they wrap the whole specifier, because a qualified
+/// Rust path can start with `<`.
+fn bare_span(source: &[u8], (start, end): (usize, usize)) -> (usize, usize) {
+    let Some(&first) = source.get(start) else {
+        return (start, end);
+    };
+    match first {
+        b'\'' | b'"' => {
+            let end = if end > start && source[end - 1] == first {
+                end - 1
+            } else {
+                end
+            };
+            (start + 1, end)
+        }
+        b'<' if end > start + 1 && source[end - 1] == b'>' => (start + 1, end - 1),
+        _ => (start, end),
+    }
+}
+
+/// One warning for a text range that is not valid UTF-8.
+///
+/// The range travels as a diagnostic instead of a placeholder string, so a
+/// consumer can point at the defect instead of parsing a sentinel.
+fn undecodable(path: &std::path::Path, range: SourceRange, what: &str) -> crate::error::Diagnostic {
+    crate::error::Diagnostic {
+        path: path.to_path_buf(),
+        severity: crate::error::Severity::Warning,
+        message: format!("{what} is not valid UTF-8"),
+        source_range: Some(range),
+    }
+}
+
 pub(crate) fn extract_imports_and_references_with_spec<'a>(
     tree: &'a tree_sitter::Tree,
     source: &'a [u8],
     spec: &LanguageSpec,
-    _file_path: &std::path::Path,
+    file_path: &std::path::Path,
 ) -> (
     Vec<crate::model::UnresolvedImport>,
     Vec<crate::model::UnresolvedReference>,
+    Vec<crate::error::Diagnostic>,
 ) {
     let query = (spec.import_ref_query_fn)();
     let Some(path_idx) = query.capture_index_for_name("import.path") else {
-        return (Vec::new(), Vec::new());
+        return (Vec::new(), Vec::new(), Vec::new());
     };
     let alias_idx = query.capture_index_for_name("import.alias");
     let symbol_idx = query.capture_index_for_name("import.symbol");
     let star_idx = query.capture_index_for_name("import.star");
     let Some(ref_idx) = query.capture_index_for_name("reference.name") else {
-        return (Vec::new(), Vec::new());
+        return (Vec::new(), Vec::new(), Vec::new());
     };
 
     let mut query_cursor = tree_sitter::QueryCursor::new();
@@ -460,21 +500,22 @@ pub(crate) fn extract_imports_and_references_with_spec<'a>(
         }
     }
 
-    let slice = |(s, e): (usize, usize)| -> String {
-        let s = &source[s..e];
-        std::str::from_utf8(s)
-            .unwrap_or("<invalid-utf8>")
-            .to_string()
-    };
+    let text =
+        |(s, e): (usize, usize)| -> Option<&'a str> { std::str::from_utf8(&source[s..e]).ok() };
+    let mut diagnostics: Vec<crate::error::Diagnostic> = Vec::new();
     let mut imports: Vec<crate::model::UnresolvedImport> = Vec::with_capacity(raw_imports.len());
     for r in raw_imports {
+        let Some(ns) = r.namespace else {
+            continue;
+        };
+        let Some(specifier) = text(bare_span(source, ns)) else {
+            diagnostics.push(undecodable(file_path, r.range, "the import specifier"));
+            continue;
+        };
         imports.push(crate::model::UnresolvedImport {
-            import_specifier: match r.namespace {
-                Some(ns) => slice(ns),
-                None => continue,
-            },
-            alias: r.alias.map(slice),
-            symbol: r.symbol.map(slice),
+            import_specifier: specifier.to_string(),
+            alias: r.alias.and_then(text).map(str::to_string),
+            symbol: r.symbol.and_then(text).map(str::to_string),
             star: r.star,
             range: r.range,
         });
@@ -483,16 +524,19 @@ pub(crate) fn extract_imports_and_references_with_spec<'a>(
     let mut references: Vec<crate::model::UnresolvedReference> =
         Vec::with_capacity(ref_ranges.len());
     for range in ref_ranges {
-        let name = std::str::from_utf8(&source[range.byte_start..range.byte_end])
-            .unwrap_or("<invalid-utf8>")
-            .to_string();
-        references.push(crate::model::UnresolvedReference { name, range });
+        match std::str::from_utf8(&source[range.byte_start..range.byte_end]) {
+            Ok(name) => references.push(crate::model::UnresolvedReference {
+                name: name.to_string(),
+                range,
+            }),
+            Err(_) => diagnostics.push(undecodable(file_path, range, "the reference name")),
+        }
     }
 
     imports.sort_by_key(|i| i.range.byte_start);
     references.sort_by_key(|r| r.range.byte_start);
 
-    (imports, references)
+    (imports, references, diagnostics)
 }
 
 /// JS-family AST node kinds that introduce a new intra-procedural scope.
@@ -659,7 +703,7 @@ mod tests {
 
     use crate::language::LangId;
 
-    use super::{clean_docstring, field_text, source_range_from_node};
+    use super::{bare_span, clean_docstring, field_text, source_range_from_node};
 
     #[test]
     fn source_range_tracks_node_positions() {
@@ -692,6 +736,29 @@ mod tests {
 
         let name = field_text(&function, "name", source).unwrap();
         assert_eq!(name, "hello");
+    }
+
+    #[test]
+    fn bare_span_strips_only_the_wrapping_delimiters() {
+        let quoted = b"'react'";
+        assert_eq!(bare_span(quoted, (0, quoted.len())), (1, 6));
+
+        let system_header = b"<stdio.h>";
+        assert_eq!(bare_span(system_header, (0, system_header.len())), (1, 8));
+
+        let bare = b"json";
+        assert_eq!(bare_span(bare, (0, bare.len())), (0, 4));
+
+        // An unterminated literal still loses its opening quote.
+        let unterminated = b"'foo";
+        assert_eq!(bare_span(unterminated, (0, unterminated.len())), (1, 4));
+
+        // A qualified path that starts with an angle bracket is not a wrap.
+        let qualified = b"<T as Trait>::x";
+        assert_eq!(
+            bare_span(qualified, (0, qualified.len())),
+            (0, qualified.len())
+        );
     }
 
     #[test]

--- a/src/language/go.rs
+++ b/src/language/go.rs
@@ -179,7 +179,7 @@ mod tests {
         use crate::language::extract_imports_and_references_for;
         let src = b"package main\n\nimport \"fmt\"\n";
         let tree = parse(src);
-        let (imports, _) = extract_imports_and_references_for(
+        let (imports, _, _) = extract_imports_and_references_for(
             LangId::Go,
             &tree,
             src,
@@ -190,7 +190,7 @@ mod tests {
             1,
             "expected 1 import record for non-aliased import"
         );
-        assert_eq!(imports[0].import_specifier, "\"fmt\"");
+        assert_eq!(imports[0].import_specifier, "fmt");
         assert!(imports[0].alias.is_none());
     }
 
@@ -199,7 +199,7 @@ mod tests {
         use crate::language::extract_imports_and_references_for;
         let src = b"package main\n\nimport alias \"fmt\"\n";
         let tree = parse(src);
-        let (imports, _) = extract_imports_and_references_for(
+        let (imports, _, _) = extract_imports_and_references_for(
             LangId::Go,
             &tree,
             src,
@@ -210,7 +210,7 @@ mod tests {
             1,
             "expected 1 import record, not 2 (CR-03 regression check)"
         );
-        assert_eq!(imports[0].import_specifier, "\"fmt\"");
+        assert_eq!(imports[0].import_specifier, "fmt");
         assert_eq!(imports[0].alias.as_deref(), Some("alias"));
     }
 
@@ -219,15 +219,15 @@ mod tests {
         use crate::language::extract_imports_and_references_for;
         let src = b"package main\n\nimport (\n\t\"fmt\"\n\t\"os\"\n)\n";
         let tree = parse(src);
-        let (imports, _) = extract_imports_and_references_for(
+        let (imports, _, _) = extract_imports_and_references_for(
             LangId::Go,
             &tree,
             src,
             &std::path::PathBuf::from("test.go"),
         );
         assert_eq!(imports.len(), 2, "expected 2 import records for fmt and os");
-        assert_eq!(imports[0].import_specifier, "\"fmt\"");
-        assert_eq!(imports[1].import_specifier, "\"os\"");
+        assert_eq!(imports[0].import_specifier, "fmt");
+        assert_eq!(imports[1].import_specifier, "os");
     }
 
     #[test]

--- a/src/language/javascript.rs
+++ b/src/language/javascript.rs
@@ -306,7 +306,7 @@ mod tests {
         use crate::language::extract_imports_and_references_for;
         let src = b"import { foo, bar } from 'utils';";
         let tree = parse(src);
-        let (imports, _) = extract_imports_and_references_for(
+        let (imports, _, _) = extract_imports_and_references_for(
             LangId::JavaScript,
             &tree,
             src,
@@ -319,7 +319,7 @@ mod tests {
             "expected 2 named import records for foo and bar"
         );
         for imp in &named {
-            assert_eq!(imp.import_specifier, "'utils'");
+            assert_eq!(imp.import_specifier, "utils");
         }
         assert_eq!(named[0].symbol.as_deref(), Some("foo"));
         assert_eq!(named[1].symbol.as_deref(), Some("bar"));
@@ -330,7 +330,7 @@ mod tests {
         use crate::language::extract_imports_and_references_for;
         let src = b"import React from 'react';";
         let tree = parse(src);
-        let (imports, _) = extract_imports_and_references_for(
+        let (imports, _, _) = extract_imports_and_references_for(
             LangId::JavaScript,
             &tree,
             src,
@@ -338,7 +338,7 @@ mod tests {
         );
         let named: Vec<_> = imports.iter().filter(|i| i.symbol.is_some()).collect();
         assert_eq!(named.len(), 1);
-        assert_eq!(named[0].import_specifier, "'react'");
+        assert_eq!(named[0].import_specifier, "react");
         assert_eq!(named[0].symbol.as_deref(), Some("React"));
     }
 
@@ -347,14 +347,14 @@ mod tests {
         use crate::language::extract_imports_and_references_for;
         let src = b"import 'styles.css';";
         let tree = parse(src);
-        let (imports, _) = extract_imports_and_references_for(
+        let (imports, _, _) = extract_imports_and_references_for(
             LangId::JavaScript,
             &tree,
             src,
             &std::path::PathBuf::from("test.js"),
         );
         assert_eq!(imports.len(), 1);
-        assert_eq!(imports[0].import_specifier, "'styles.css'");
+        assert_eq!(imports[0].import_specifier, "styles.css");
         assert!(imports[0].symbol.is_none());
     }
 

--- a/src/language/mod.rs
+++ b/src/language/mod.rs
@@ -193,6 +193,7 @@ pub fn extract_imports_and_references_for<'a>(
 ) -> (
     Vec<crate::model::UnresolvedImport>,
     Vec<crate::model::UnresolvedReference>,
+    Vec<crate::error::Diagnostic>,
 ) {
     common::extract_imports_and_references_with_spec(tree, source, spec_for(id), file_path)
 }

--- a/src/language/python.rs
+++ b/src/language/python.rs
@@ -392,7 +392,7 @@ mod tests {
         use crate::language::extract_imports_and_references_for;
         let src = b"from . import util\n";
         let tree = parse(src);
-        let (imports, _) = extract_imports_and_references_for(
+        let (imports, _, _) = extract_imports_and_references_for(
             LangId::Python,
             &tree,
             src,
@@ -408,7 +408,7 @@ mod tests {
         use crate::language::extract_imports_and_references_for;
         let src = b"from .util import helper\n";
         let tree = parse(src);
-        let (imports, _) = extract_imports_and_references_for(
+        let (imports, _, _) = extract_imports_and_references_for(
             LangId::Python,
             &tree,
             src,
@@ -424,7 +424,7 @@ mod tests {
         use crate::language::extract_imports_and_references_for;
         let src = b"from ..pkg.mod import baz\n";
         let tree = parse(src);
-        let (imports, _) = extract_imports_and_references_for(
+        let (imports, _, _) = extract_imports_and_references_for(
             LangId::Python,
             &tree,
             src,
@@ -439,7 +439,7 @@ mod tests {
         use crate::language::extract_imports_and_references_for;
         let src = b"from a.b import c as d\n";
         let tree = parse(src);
-        let (imports, _) = extract_imports_and_references_for(
+        let (imports, _, _) = extract_imports_and_references_for(
             LangId::Python,
             &tree,
             src,

--- a/src/language/ruby.rs
+++ b/src/language/ruby.rs
@@ -226,10 +226,10 @@ mod tests {
     fn extract_require_import() {
         let src = b"require 'json'";
         let tree = parse(src);
-        let (imports, _) =
+        let (imports, _, _) =
             extract_imports_and_references_for(LangId::Ruby, &tree, src, &PathBuf::from("test.rb"));
         assert_eq!(imports.len(), 1);
-        assert_eq!(imports[0].import_specifier, "'json'");
+        assert_eq!(imports[0].import_specifier, "json");
         assert!(imports[0].symbol.is_none());
     }
 
@@ -237,17 +237,17 @@ mod tests {
     fn extract_require_relative_import() {
         let src = b"require_relative './helper'";
         let tree = parse(src);
-        let (imports, _) =
+        let (imports, _, _) =
             extract_imports_and_references_for(LangId::Ruby, &tree, src, &PathBuf::from("test.rb"));
         assert_eq!(imports.len(), 1);
-        assert_eq!(imports[0].import_specifier, "'./helper'");
+        assert_eq!(imports[0].import_specifier, "./helper");
     }
 
     #[test]
     fn require_calls_do_not_leak_as_references() {
         let src = b"require 'json'\nputs 'hi'";
         let tree = parse(src);
-        let (imports, references) =
+        let (imports, references, _) =
             extract_imports_and_references_for(LangId::Ruby, &tree, src, &PathBuf::from("test.rb"));
         assert_eq!(imports.len(), 1);
         assert!(references.iter().any(|r| r.name == "puts"));
@@ -258,7 +258,7 @@ mod tests {
     fn extract_bare_call_reference() {
         let src = b"calc_total(items)";
         let tree = parse(src);
-        let (_, references) =
+        let (_, references, _) =
             extract_imports_and_references_for(LangId::Ruby, &tree, src, &PathBuf::from("test.rb"));
         assert!(references.iter().any(|r| r.name == "calc_total"));
     }
@@ -267,7 +267,7 @@ mod tests {
     fn extract_constant_receiver_reference() {
         let src = b"Math.sqrt(4)";
         let tree = parse(src);
-        let (_, references) =
+        let (_, references, _) =
             extract_imports_and_references_for(LangId::Ruby, &tree, src, &PathBuf::from("test.rb"));
         assert!(references.iter().any(|r| r.name == "Math"));
         assert!(references.iter().any(|r| r.name == "sqrt"));

--- a/src/language/typescript.rs
+++ b/src/language/typescript.rs
@@ -237,7 +237,7 @@ mod tests {
         use crate::language::extract_imports_and_references_for;
         let src = b"import { Component, OnInit } from '@angular/core';";
         let tree = parse(src);
-        let (imports, _) = extract_imports_and_references_for(
+        let (imports, _, _) = extract_imports_and_references_for(
             LangId::TypeScript,
             &tree,
             src,
@@ -246,7 +246,7 @@ mod tests {
         let named: Vec<_> = imports.iter().filter(|i| i.symbol.is_some()).collect();
         assert_eq!(named.len(), 2);
         for imp in &named {
-            assert_eq!(imp.import_specifier, "'@angular/core'");
+            assert_eq!(imp.import_specifier, "@angular/core");
         }
         assert_eq!(named[0].symbol.as_deref(), Some("Component"));
         assert_eq!(named[1].symbol.as_deref(), Some("OnInit"));
@@ -257,7 +257,7 @@ mod tests {
         use crate::language::extract_imports_and_references_for;
         let src = b"import React from 'react';";
         let tree = parse(src);
-        let (imports, _) = extract_imports_and_references_for(
+        let (imports, _, _) = extract_imports_and_references_for(
             LangId::TypeScript,
             &tree,
             src,
@@ -265,7 +265,7 @@ mod tests {
         );
         let named: Vec<_> = imports.iter().filter(|i| i.symbol.is_some()).collect();
         assert_eq!(named.len(), 1);
-        assert_eq!(named[0].import_specifier, "'react'");
+        assert_eq!(named[0].import_specifier, "react");
         assert_eq!(named[0].symbol.as_deref(), Some("React"));
     }
 

--- a/src/output/shard/file.rs
+++ b/src/output/shard/file.rs
@@ -19,9 +19,10 @@ use crate::output::shard::name::{StableNameIndex, node_owner_path, normalized_pa
 
 /// Shard payload version.
 ///
-/// Version 4 spells symbol kinds and visibility in lowercase, so version 3
-/// records no longer parse. Regenerate the index after an upgrade.
-pub const SHARD_SCHEMA_VERSION: u32 = 4;
+/// Version 5 stores the import specifier without its surrounding quotes and
+/// drops a specifier that is not valid UTF-8, so version 4 records no longer
+/// parse. Regenerate the index after an upgrade.
+pub const SHARD_SCHEMA_VERSION: u32 = 5;
 
 /// A per-file shard record stored in `.meta-ast/shards/<n>.jsonl`.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/tests/integration/pipeline_test.rs
+++ b/tests/integration/pipeline_test.rs
@@ -1013,7 +1013,7 @@ fn extract_js_multiline_import() {
         imports.len()
     );
     for imp in imports {
-        assert_eq!(imp.import_specifier, "'./module'");
+        assert_eq!(imp.import_specifier, "./module");
     }
 
     std::fs::remove_dir_all(&tmp).unwrap();


### PR DESCRIPTION
The persisted import specifier loses its surrounding quotes and a C or C++ system header its angle brackets, at the single place the value is produced. An undecodable specifier or reference name becomes a warning carrying the file and a range instead of a placeholder string. The shard payload version moves to 5 because the persisted value changed shape.\n\nLadder: 11 failing tests before this level, 8 after.