### PR TITLE
refactor(language): one language pack macro and table driven dependency resolution

### DIFF
--- a/src/deploy/dependency.rs
+++ b/src/deploy/dependency.rs
@@ -19,25 +19,6 @@ pub struct DependencyEntry {
     pub source: DependencySource,
 }
 
-/// Classify a single external dependency using language-specific strategies.
-///
-/// Dispatches by `external.language` via exhaustive match, following the
-/// repo's enum-static-dispatch convention. Lockfiles are tried first;
-/// if missing or unparseable, falls back to the manifest file. If that
-/// also fails, returns `Unresolved` (never blocks).
-pub fn classify_external(external: &ExternalNode, project_root: &Path) -> ExternalClassification {
-    match external.language {
-        LangId::Python => classify_python(external, project_root),
-        LangId::JavaScript | LangId::TypeScript | LangId::Tsx => {
-            classify_node_ecosystem(external, project_root)
-        }
-        LangId::Rust => classify_rust(external, project_root),
-        LangId::Go => classify_go(external, project_root),
-        LangId::Ruby => classify_ruby(external, project_root),
-        LangId::C | LangId::Cpp => classify_c_cpp_best_effort(external, project_root),
-    }
-}
-
 /// Resolve all external nodes in a graph and return per-pod dependency lists.
 ///
 /// Walks Import edges from each pod's files to ExternalNode targets,
@@ -111,56 +92,210 @@ pub fn resolve_dependencies(
     deps
 }
 
-// ── Per-language resolvers ─────────────────────────────────────────
+// ── Dependency sources ─────────────────────────────────────────────
 
-fn classify_python(external: &ExternalNode, root: &Path) -> ExternalClassification {
-    let lockfiles = [
-        root.join("uv.lock"),
-        root.join("poetry.lock"),
-        root.join("Pipfile.lock"),
-    ];
-    for lf in &lockfiles {
-        if !lf.exists() {
-            continue;
-        }
-        if let Some(version) = parse_version_from_lockfile(lf, &external.raw_path) {
-            return ExternalClassification::Classified {
-                package_name: external.raw_path.clone(),
-                version: Some(version),
-                language: LangId::Python,
-                source: DependencySource::Lockfile,
-            };
+/// How a file states the version of one entry.
+#[derive(Debug, Clone, Copy)]
+enum EntryFormat {
+    /// `name = "x"` with a `version = "..."` in the same entry, `name==1.2.3`,
+    /// or yarn's `version "1.2.3"` line inside the entry.
+    EntryValue,
+    /// `[[package]]` blocks that carry `name` and `version`.
+    TomlPackageArray,
+    /// A JSON object whose dependency sections map a name to a version.
+    JsonDependencyMap,
+    /// `<name> (<version>)`, as Gemfile.lock writes it.
+    ParenthesizedName,
+    /// `<name> <version> <hash>`, matched on the exact first token.
+    ExactToken,
+    /// A `require` line, single or block form, carrying a `v` prefix.
+    GoRequire,
+    /// The file proves the ecosystem is in use and carries no version.
+    Presence,
+}
+
+/// One file that can answer a dependency question.
+struct SourceSpec {
+    file: &'static str,
+    format: EntryFormat,
+    kind: DependencySource,
+    /// A lockfile that does not carry the entry is skipped rather than used as
+    /// the source. Python, Node and Go do that; Rust and Ruby keep the lockfile.
+    needs_entry: bool,
+    at_root: bool,
+    in_subdirectory: bool,
+}
+
+const fn lockfile(
+    file: &'static str,
+    format: EntryFormat,
+    needs_entry: bool,
+    at_root: bool,
+    in_subdirectory: bool,
+) -> SourceSpec {
+    SourceSpec {
+        file,
+        format,
+        kind: DependencySource::Lockfile,
+        needs_entry,
+        at_root,
+        in_subdirectory,
+    }
+}
+
+const fn manifest(
+    file: &'static str,
+    format: EntryFormat,
+    at_root: bool,
+    in_subdirectory: bool,
+) -> SourceSpec {
+    SourceSpec {
+        file,
+        format,
+        kind: DependencySource::Manifest,
+        needs_entry: false,
+        at_root,
+        in_subdirectory,
+    }
+}
+
+static PYTHON_SOURCES: [SourceSpec; 5] = [
+    lockfile("uv.lock", EntryFormat::EntryValue, true, true, false),
+    lockfile("poetry.lock", EntryFormat::EntryValue, true, true, false),
+    lockfile("Pipfile.lock", EntryFormat::EntryValue, true, true, false),
+    manifest("pyproject.toml", EntryFormat::Presence, true, true),
+    manifest("requirements.txt", EntryFormat::Presence, true, true),
+];
+
+static NODE_SOURCES: [SourceSpec; 5] = [
+    lockfile(
+        "package-lock.json",
+        EntryFormat::EntryValue,
+        true,
+        true,
+        false,
+    ),
+    lockfile("yarn.lock", EntryFormat::EntryValue, true, true, false),
+    lockfile("pnpm-lock.yaml", EntryFormat::EntryValue, true, true, false),
+    lockfile(
+        "package-lock.json",
+        EntryFormat::EntryValue,
+        true,
+        false,
+        true,
+    ),
+    manifest("package.json", EntryFormat::JsonDependencyMap, true, true),
+];
+
+static RUST_SOURCES: [SourceSpec; 2] = [
+    lockfile(
+        "Cargo.lock",
+        EntryFormat::TomlPackageArray,
+        false,
+        true,
+        false,
+    ),
+    manifest("Cargo.toml", EntryFormat::Presence, true, false),
+];
+
+static GO_SOURCES: [SourceSpec; 2] = [
+    lockfile("go.sum", EntryFormat::ExactToken, true, true, false),
+    manifest("go.mod", EntryFormat::GoRequire, true, false),
+];
+
+static RUBY_SOURCES: [SourceSpec; 2] = [
+    lockfile(
+        "Gemfile.lock",
+        EntryFormat::ParenthesizedName,
+        false,
+        true,
+        false,
+    ),
+    manifest("Gemfile", EntryFormat::Presence, true, false),
+];
+
+static C_SOURCES: [SourceSpec; 2] = [
+    manifest("conanfile.txt", EntryFormat::Presence, true, false),
+    manifest("vcpkg.json", EntryFormat::Presence, true, false),
+];
+
+/// The files one ecosystem answers dependency questions from, in the order
+/// they are tried, plus the reason reported when none of them answers.
+struct EcosystemSpec {
+    sources: &'static [SourceSpec],
+    unresolved: &'static str,
+}
+
+static PYTHON: EcosystemSpec = EcosystemSpec {
+    sources: &PYTHON_SOURCES,
+    unresolved: "no Python lockfile or manifest found",
+};
+static NODE: EcosystemSpec = EcosystemSpec {
+    sources: &NODE_SOURCES,
+    unresolved: "no Node.js lockfile or package.json found",
+};
+static RUST: EcosystemSpec = EcosystemSpec {
+    sources: &RUST_SOURCES,
+    unresolved: "no Cargo.lock or Cargo.toml found",
+};
+static GO: EcosystemSpec = EcosystemSpec {
+    sources: &GO_SOURCES,
+    unresolved: "no go.sum or go.mod found",
+};
+static RUBY: EcosystemSpec = EcosystemSpec {
+    sources: &RUBY_SOURCES,
+    unresolved: "no Gemfile.lock or Gemfile found",
+};
+static C_FAMILY: EcosystemSpec = EcosystemSpec {
+    sources: &C_SOURCES,
+    unresolved: "no C/C++ manifest convention found (conanfile.txt, vcpkg.json)",
+};
+
+fn ecosystem_spec(lang: LangId) -> &'static EcosystemSpec {
+    match lang {
+        LangId::Python => &PYTHON,
+        LangId::JavaScript | LangId::TypeScript | LangId::Tsx => &NODE,
+        LangId::Rust => &RUST,
+        LangId::Go => &GO,
+        LangId::Ruby => &RUBY,
+        LangId::C | LangId::Cpp => &C_FAMILY,
+    }
+}
+
+/// Classify a single external dependency from the ecosystem's source table.
+///
+/// Root sources are tried first, then the sources that may live in an
+/// immediate subdirectory, so a monorepo layout answers without a project-wide
+/// search. An ecosystem that declares no subdirectory source never reads the
+/// directory listing.
+pub fn classify_external(external: &ExternalNode, project_root: &Path) -> ExternalClassification {
+    let spec = ecosystem_spec(external.language);
+
+    for source in spec.sources.iter().filter(|source| source.at_root) {
+        if let Some(classification) =
+            classify_source(external, &project_root.join(source.file), source)
+        {
+            return classification;
         }
     }
 
-    let manifests = [root.join("pyproject.toml"), root.join("requirements.txt")];
-    for mf in &manifests {
-        if mf.exists() {
-            return ExternalClassification::Classified {
-                package_name: external.raw_path.clone(),
-                version: None,
-                language: LangId::Python,
-                source: DependencySource::Manifest,
-            };
-        }
-    }
-
-    // Check immediate subdirectories (monorepo layout).
-    if let Ok(entries) = std::fs::read_dir(root) {
-        for entry in entries.flatten() {
-            let subdir = entry.path();
-            if !subdir.is_dir() {
-                continue;
-            }
-            for mf in &manifests {
-                let p = subdir.join(mf.file_name().unwrap_or_default());
-                if p.exists() {
-                    return ExternalClassification::Classified {
-                        package_name: external.raw_path.clone(),
-                        version: None,
-                        language: LangId::Python,
-                        source: DependencySource::Manifest,
-                    };
+    if spec.sources.iter().any(|source| source.in_subdirectory)
+        && let Ok(entries) = std::fs::read_dir(project_root)
+    {
+        // Sorted, so two subdirectories offering the same file name do not
+        // depend on the order the file system hands them out.
+        let mut directories: Vec<std::path::PathBuf> = entries
+            .flatten()
+            .map(|entry| entry.path())
+            .filter(|path| path.is_dir())
+            .collect();
+        directories.sort();
+        for directory in directories {
+            for source in spec.sources.iter().filter(|source| source.in_subdirectory) {
+                if let Some(classification) =
+                    classify_source(external, &directory.join(source.file), source)
+                {
+                    return classification;
                 }
             }
         }
@@ -168,184 +303,41 @@ fn classify_python(external: &ExternalNode, root: &Path) -> ExternalClassificati
 
     ExternalClassification::Unresolved {
         raw_path: external.raw_path.clone(),
-        reason: "no Python lockfile or manifest found".into(),
+        reason: spec.unresolved.to_string(),
     }
 }
 
-fn classify_node_ecosystem(external: &ExternalNode, root: &Path) -> ExternalClassification {
-    // Check root-level lockfiles and manifests first.
-    let lockfiles = [
-        root.join("package-lock.json"),
-        root.join("yarn.lock"),
-        root.join("pnpm-lock.yaml"),
-    ];
-    for lf in &lockfiles {
-        if !lf.exists() {
-            continue;
-        }
-        if let Some(version) = parse_version_from_lockfile(lf, &external.raw_path) {
-            return ExternalClassification::Classified {
-                package_name: external.raw_path.clone(),
-                version: Some(version),
-                language: external.language,
-                source: DependencySource::Lockfile,
-            };
-        }
+/// Classify one candidate file, or report that the file does not answer.
+fn classify_source(
+    external: &ExternalNode,
+    path: &Path,
+    source: &SourceSpec,
+) -> Option<ExternalClassification> {
+    if !path.exists() {
+        return None;
     }
-
-    let mf = root.join("package.json");
-    if mf.exists() {
-        return ExternalClassification::Classified {
-            package_name: external.raw_path.clone(),
-            version: parse_version_from_package_json(&mf, &external.raw_path),
-            language: external.language,
-            source: DependencySource::Manifest,
-        };
+    let version = read_version(source.format, path, &external.raw_path);
+    if version.is_none() && source.needs_entry {
+        return None;
     }
-
-    // Search immediate subdirectories for package.json (monorepo layout).
-    if let Ok(entries) = std::fs::read_dir(root) {
-        for entry in entries.flatten() {
-            let subdir = entry.path();
-            if !subdir.is_dir() {
-                continue;
-            }
-            let lock_path = subdir.join("package-lock.json");
-            if lock_path.exists()
-                && let Some(version) = parse_version_from_lockfile(&lock_path, &external.raw_path)
-            {
-                return ExternalClassification::Classified {
-                    package_name: external.raw_path.clone(),
-                    version: Some(version),
-                    language: external.language,
-                    source: DependencySource::Lockfile,
-                };
-            }
-            let pkg_path = subdir.join("package.json");
-            if pkg_path.exists() {
-                return ExternalClassification::Classified {
-                    package_name: external.raw_path.clone(),
-                    version: parse_version_from_package_json(&pkg_path, &external.raw_path),
-                    language: external.language,
-                    source: DependencySource::Manifest,
-                };
-            }
-        }
-    }
-
-    ExternalClassification::Unresolved {
-        raw_path: external.raw_path.clone(),
-        reason: "no Node.js lockfile or package.json found".into(),
-    }
+    Some(ExternalClassification::Classified {
+        package_name: external.raw_path.clone(),
+        version,
+        language: external.language,
+        source: source.kind,
+    })
 }
 
-fn classify_rust(external: &ExternalNode, root: &Path) -> ExternalClassification {
-    let lf = root.join("Cargo.lock");
-    if lf.exists() {
-        return ExternalClassification::Classified {
-            package_name: external.raw_path.clone(),
-            version: parse_version_from_cargo_lock(&lf, &external.raw_path),
-            language: LangId::Rust,
-            source: DependencySource::Lockfile,
-        };
-    }
-
-    let mf = root.join("Cargo.toml");
-    if mf.exists() {
-        return ExternalClassification::Classified {
-            package_name: external.raw_path.clone(),
-            version: None,
-            language: LangId::Rust,
-            source: DependencySource::Manifest,
-        };
-    }
-
-    ExternalClassification::Unresolved {
-        raw_path: external.raw_path.clone(),
-        reason: "no Cargo.lock or Cargo.toml found".into(),
-    }
-}
-
-fn classify_go(external: &ExternalNode, root: &Path) -> ExternalClassification {
-    let lf = root.join("go.sum");
-    if lf.exists()
-        && let Some(version) = parse_version_from_go_sum(&lf, &external.raw_path)
-    {
-        return ExternalClassification::Classified {
-            package_name: external.raw_path.clone(),
-            version: Some(version),
-            language: LangId::Go,
-            source: DependencySource::Lockfile,
-        };
-    }
-
-    let mf = root.join("go.mod");
-    if mf.exists() {
-        return ExternalClassification::Classified {
-            package_name: external.raw_path.clone(),
-            version: parse_version_from_go_mod(&mf, &external.raw_path),
-            language: LangId::Go,
-            source: DependencySource::Manifest,
-        };
-    }
-
-    ExternalClassification::Unresolved {
-        raw_path: external.raw_path.clone(),
-        reason: "no go.sum or go.mod found".into(),
-    }
-}
-
-fn classify_ruby(external: &ExternalNode, root: &Path) -> ExternalClassification {
-    let lf = root.join("Gemfile.lock");
-    if lf.exists() {
-        return ExternalClassification::Classified {
-            package_name: external.raw_path.clone(),
-            version: parse_version_from_gemfile_lock(&lf, &external.raw_path),
-            language: LangId::Ruby,
-            source: DependencySource::Lockfile,
-        };
-    }
-
-    let mf = root.join("Gemfile");
-    if mf.exists() {
-        return ExternalClassification::Classified {
-            package_name: external.raw_path.clone(),
-            version: None,
-            language: LangId::Ruby,
-            source: DependencySource::Manifest,
-        };
-    }
-
-    ExternalClassification::Unresolved {
-        raw_path: external.raw_path.clone(),
-        reason: "no Gemfile.lock or Gemfile found".into(),
-    }
-}
-
-fn classify_c_cpp_best_effort(external: &ExternalNode, root: &Path) -> ExternalClassification {
-    // C/C++ has no universal convention. Try conanfile.txt, then vcpkg.json.
-    // If neither exists, silently fall back to Unresolved.
-    if root.join("conanfile.txt").exists() {
-        return ExternalClassification::Classified {
-            package_name: external.raw_path.clone(),
-            version: None,
-            language: external.language,
-            source: DependencySource::Manifest,
-        };
-    }
-    if root.join("vcpkg.json").exists() {
-        return ExternalClassification::Classified {
-            package_name: external.raw_path.clone(),
-            version: None,
-            language: external.language,
-            source: DependencySource::Manifest,
-        };
-    }
-
-    tracing::trace!(path = %external.raw_path, "C/C++ external dependency unresolved");
-    ExternalClassification::Unresolved {
-        raw_path: external.raw_path.clone(),
-        reason: "no C/C++ manifest convention found (conanfile.txt, vcpkg.json)".into(),
+/// Read the version a file states for a package, in the shape it writes.
+fn read_version(format: EntryFormat, path: &Path, package: &str) -> Option<String> {
+    match format {
+        EntryFormat::EntryValue => entry_value_version(path, package),
+        EntryFormat::TomlPackageArray => toml_package_version(path, package),
+        EntryFormat::JsonDependencyMap => json_dependency_version(path, package),
+        EntryFormat::ParenthesizedName => parenthesized_version(path, package),
+        EntryFormat::ExactToken => exact_token_version(path, package),
+        EntryFormat::GoRequire => go_require_version(path, package),
+        EntryFormat::Presence => None,
     }
 }
 
@@ -390,7 +382,7 @@ fn version_assignment(line: &str) -> Option<String> {
     extract_semver(rest)
 }
 
-fn parse_version_from_lockfile(path: &Path, package: &str) -> Option<String> {
+fn entry_value_version(path: &Path, package: &str) -> Option<String> {
     let content = std::fs::read_to_string(path).ok()?;
     let mut inside_entry = false;
 
@@ -429,7 +421,7 @@ fn parse_version_from_lockfile(path: &Path, package: &str) -> Option<String> {
     None
 }
 
-fn parse_version_from_package_json(path: &Path, package: &str) -> Option<String> {
+fn json_dependency_version(path: &Path, package: &str) -> Option<String> {
     let content = std::fs::read_to_string(path).ok()?;
     let json: serde_json::Value = serde_json::from_str(&content).ok()?;
     // Check dependencies/devDependencies for the package.
@@ -443,7 +435,7 @@ fn parse_version_from_package_json(path: &Path, package: &str) -> Option<String>
     None
 }
 
-fn parse_version_from_cargo_lock(path: &Path, package: &str) -> Option<String> {
+fn toml_package_version(path: &Path, package: &str) -> Option<String> {
     let content = std::fs::read_to_string(path).ok()?;
     // Cargo.lock uses TOML; search for [[package]] sections with name = "..."
     let mut in_package_section = false;
@@ -464,7 +456,7 @@ fn parse_version_from_cargo_lock(path: &Path, package: &str) -> Option<String> {
     None
 }
 
-fn parse_version_from_go_sum(path: &Path, package: &str) -> Option<String> {
+fn exact_token_version(path: &Path, package: &str) -> Option<String> {
     let content = std::fs::read_to_string(path).ok()?;
     // go.sum format: <module> <version> <hash>, one line per module version.
     for line in content.lines() {
@@ -480,7 +472,7 @@ fn parse_version_from_go_sum(path: &Path, package: &str) -> Option<String> {
 }
 
 /// Read a `require` line, in single or block form, and drop the `v` prefix.
-fn parse_version_from_go_mod(path: &Path, module: &str) -> Option<String> {
+fn go_require_version(path: &Path, module: &str) -> Option<String> {
     let content = std::fs::read_to_string(path).ok()?;
     let mut inside_block = false;
 
@@ -512,7 +504,7 @@ fn parse_version_from_go_mod(path: &Path, module: &str) -> Option<String> {
     None
 }
 
-fn parse_version_from_gemfile_lock(path: &Path, name: &str) -> Option<String> {
+fn parenthesized_version(path: &Path, name: &str) -> Option<String> {
     let content = std::fs::read_to_string(path).ok()?;
     // Gemfile.lock lists each gem as "  <name> (<version>)" under a specs
     // section. The name has no quotes; match the indented line exactly.
@@ -601,7 +593,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_version_from_gemfile_lock_extracts_version() {
+    fn parenthesized_version_extracts_version() {
         let dir = test_dir("parse");
         let lf = dir.join("Gemfile.lock");
         std::fs::write(
@@ -611,10 +603,10 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            parse_version_from_gemfile_lock(&lf, "rails"),
+            parenthesized_version(&lf, "rails"),
             Some("7.0.8.4".to_string())
         );
-        assert_eq!(parse_version_from_gemfile_lock(&lf, "missing"), None);
+        assert_eq!(parenthesized_version(&lf, "missing"), None);
         let _ = std::fs::remove_dir_all(&dir);
     }
 
@@ -627,7 +619,7 @@ mod tests {
         )
         .unwrap();
 
-        let classification = classify_ruby(&external_node("rails"), &dir);
+        let classification = classify_external(&external_node("rails"), &dir);
         match classification {
             ExternalClassification::Classified {
                 package_name,
@@ -648,7 +640,7 @@ mod tests {
     #[test]
     fn classify_ruby_unresolved_without_gemfile() {
         let missing = std::env::temp_dir().join("meta_ast_ruby_dep_missing_dir");
-        let classification = classify_ruby(&external_node("rails"), &missing);
+        let classification = classify_external(&external_node("rails"), &missing);
         match classification {
             ExternalClassification::Unresolved { raw_path, reason } => {
                 assert_eq!(raw_path, "rails");
@@ -670,12 +662,12 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            parse_version_from_lockfile(&lf, "requests"),
+            entry_value_version(&lf, "requests"),
             None,
             "requests must not match the requests-toolbelt entry"
         );
         assert_eq!(
-            parse_version_from_lockfile(&lf, "requests-toolbelt").as_deref(),
+            entry_value_version(&lf, "requests-toolbelt").as_deref(),
             Some("4.0.0")
         );
         let _ = std::fs::remove_dir_all(&dir);
@@ -692,7 +684,7 @@ mod tests {
         )
         .unwrap();
 
-        let classification = classify_python(&python_node("requests"), &dir);
+        let classification = classify_external(&python_node("requests"), &dir);
         assert!(
             !matches!(
                 classification,
@@ -714,12 +706,12 @@ mod tests {
         std::fs::write(&lf, "github.com/foo/bar/baz v1.0.0 h1:AAAA=\n").unwrap();
 
         assert_eq!(
-            parse_version_from_go_sum(&lf, "github.com/foo/bar"),
+            exact_token_version(&lf, "github.com/foo/bar"),
             None,
             "a prefix must not match a different module"
         );
         assert_eq!(
-            parse_version_from_go_sum(&lf, "github.com/foo/bar/baz").as_deref(),
+            exact_token_version(&lf, "github.com/foo/bar/baz").as_deref(),
             Some("v1.0.0")
         );
         let _ = std::fs::remove_dir_all(&dir);
@@ -735,7 +727,7 @@ mod tests {
         )
         .unwrap();
 
-        let classification = classify_go(&go_node("github.com/foo/bar"), &dir);
+        let classification = classify_external(&go_node("github.com/foo/bar"), &dir);
         match classification {
             ExternalClassification::Classified {
                 version,

--- a/src/graph/scc.rs
+++ b/src/graph/scc.rs
@@ -13,7 +13,7 @@
 //! preserved as a single deployment unit whenever possible.
 use petgraph::algo::tarjan_scc;
 use petgraph::graph::{DiGraph, NodeIndex};
-use petgraph::visit::{EdgeFiltered, EdgeRef};
+use petgraph::visit::EdgeFiltered;
 use std::collections::HashMap;
 
 use crate::graph::edge::EdgeData;
@@ -91,27 +91,6 @@ impl SccAnalysis {
         let mut node_to_component = HashMap::new();
 
         for (index, nodes) in scc_groups.into_iter().enumerate() {
-            // Self-loop detection must use the dependency subgraph too:
-            // a Flow or Ownership self-loop does not make the component
-            // cyclic because those edges are excluded from SCC analysis.
-            let has_self_loop = nodes.iter().any(|&node| {
-                graph
-                    .edges_directed(node, petgraph::Direction::Outgoing)
-                    .any(|edge| edge.weight().kind.participates_in_scc() && edge.target() == node)
-            });
-
-            let is_cyclic = nodes.len() > 1 || has_self_loop;
-
-            let hint = if nodes.len() > 1 {
-                DeployabilityHint::CyclicCluster
-            } else if has_self_loop {
-                DeployabilityHint::SelfLoop
-            } else if nodes.len() == 1 {
-                DeployabilityHint::AcyclicDependency
-            } else {
-                DeployabilityHint::Independent
-            };
-
             for &node in &nodes {
                 node_to_component.insert(node, index);
             }
@@ -119,62 +98,61 @@ impl SccAnalysis {
             components.push(Scc {
                 index,
                 nodes,
-                is_cyclic,
-                hint,
+                is_cyclic: false,
+                hint: DeployabilityHint::Independent,
             });
         }
 
-        Self::classify_independence(graph, &mut components, &node_to_component);
-
-        Self {
-            components,
-            node_to_component,
-        }
-    }
-
-    /// Classify components as Independent if they have no outgoing dependencies
-    /// to other components.
-    fn classify_independence(
-        graph: &DiGraph<NodeData, EdgeData>,
-        components: &mut [Scc],
-        node_to_component: &HashMap<NodeIndex, usize>,
-    ) {
-        let mut component_deps: HashMap<usize, Vec<usize>> = HashMap::new();
+        // One walk over the dependency edges answers both questions the hints
+        // need: a self-loop makes a single node cyclic, and an edge that leaves
+        // its component makes that component dependent on another one.
+        let mut self_loops = vec![false; components.len()];
+        let mut has_outer_dependency = vec![false; components.len()];
 
         for edge_idx in graph.edge_indices() {
             let Some(weight) = graph.edge_weight(edge_idx) else {
                 continue;
             };
-            // Independence follows the dependency subgraph: Ownership and
-            // Flow edges do not create deployment coupling between units.
             if !weight.kind.participates_in_scc() {
                 continue;
             }
             let Some((source, target)) = graph.edge_endpoints(edge_idx) else {
                 continue;
             };
-            let source_comp = node_to_component.get(&source);
-            let target_comp = node_to_component.get(&target);
+            let (Some(&source_component), Some(&target_component)) = (
+                node_to_component.get(&source),
+                node_to_component.get(&target),
+            ) else {
+                continue;
+            };
 
-            if let (Some(&s), Some(&t)) = (source_comp, target_comp)
-                && s != t
-            {
-                component_deps.entry(s).or_default().push(t);
+            if source_component == target_component {
+                if source == target {
+                    self_loops[source_component] = true;
+                }
+            } else {
+                has_outer_dependency[source_component] = true;
             }
         }
 
-        // Update hints for components with no external dependencies
-        for comp in components.iter_mut() {
-            if comp.hint == DeployabilityHint::AcyclicDependency {
-                let has_external_deps = component_deps
-                    .get(&comp.index)
-                    .map(|deps| !deps.is_empty())
-                    .unwrap_or(false);
+        for component in &mut components {
+            let clustered = component.nodes.len() > 1;
+            let self_loop = self_loops[component.index];
+            component.is_cyclic = clustered || self_loop;
+            component.hint = if clustered {
+                DeployabilityHint::CyclicCluster
+            } else if self_loop {
+                DeployabilityHint::SelfLoop
+            } else if has_outer_dependency[component.index] {
+                DeployabilityHint::AcyclicDependency
+            } else {
+                DeployabilityHint::Independent
+            };
+        }
 
-                if !has_external_deps {
-                    comp.hint = DeployabilityHint::Independent;
-                }
-            }
+        Self {
+            components,
+            node_to_component,
         }
     }
 

--- a/src/language/c.rs
+++ b/src/language/c.rs
@@ -1,15 +1,40 @@
-use crate::language::{DefaultVisibility, LanguageSpec};
+use crate::language::pack::define_language_pack;
+use crate::language::{C_LIKE_DOC_COMMENT, DefaultVisibility};
 use std::path::{Path, PathBuf};
-use std::sync::LazyLock;
 
 fn resolve_c_import(raw: &str, source_dir: &Path, _project_root: &Path) -> Option<PathBuf> {
     crate::language::import_resolver::resolve_c_family_import(raw, source_dir)
 }
 
-static C_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
-    crate::language::common::compile_query(
-        &tree_sitter_c::LANGUAGE.into(),
-        r#"
+pub(crate) const C_FAMILY_IMPORT_QUERY_STR: &str = r#"
+(preproc_include
+  path: (string_literal) @import.path)
+(preproc_include
+    path: (system_lib_string) @import.path)
+"#;
+
+pub(crate) const C_FAMILY_REFERENCE_QUERY_STR: &str = r#"
+(call_expression
+  function: (identifier) @reference.name)
+(call_expression
+  function: (field_expression
+    field: (field_identifier) @reference.name))
+(call_expression
+  function: (field_expression
+    argument: (identifier) @reference.name))
+"#;
+
+define_language_pack!(
+    spec: C_SPEC,
+    label: "C",
+    lang: LangId::C,
+    grammar: tree_sitter_c::LANGUAGE,
+    extensions: ["c", "h"],
+    resolver: resolve_c_import,
+    symbols: {
+        static: C_QUERY,
+        accessor: c_query,
+        query: r#"
         (function_definition
             declarator: [
                 (function_declarator
@@ -45,173 +70,114 @@ static C_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
                         parameters: (parameter_list) @signature))
             ]) @kind.declaration
         "#,
-        "C",
-    )
-});
-
-pub(crate) const C_FAMILY_IMPORT_QUERY_STR: &str = r#"
-(preproc_include
-  path: (string_literal) @import.path)
-(preproc_include
-    path: (system_lib_string) @import.path)
-"#;
-
-pub(crate) const C_FAMILY_REFERENCE_QUERY_STR: &str = r#"
-(call_expression
-  function: (identifier) @reference.name)
-(call_expression
-  function: (field_expression
-    field: (field_identifier) @reference.name))
-(call_expression
-  function: (field_expression
-    argument: (identifier) @reference.name))
-"#;
-
-fn c_query() -> &'static tree_sitter::Query {
-    &C_QUERY
-}
-
-static C_IMPORT_REF_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
-    crate::language::common::compile_query(
-        &tree_sitter_c::LANGUAGE.into(),
-        &format!(
-            "{}\n{}",
-            C_FAMILY_IMPORT_QUERY_STR, C_FAMILY_REFERENCE_QUERY_STR
-        ),
-        "C combined import+ref",
-    )
-});
-
-fn c_import_ref_query() -> &'static tree_sitter::Query {
-    &C_IMPORT_REF_QUERY
-}
-
-pub(crate) const C_SPEC: LanguageSpec = LanguageSpec {
-    extensions: &["c", "h"],
-    grammar_fn: || tree_sitter_c::LANGUAGE.into(),
-    query_fn: c_query,
-    import_path_resolver: resolve_c_import,
-    import_ref_query_fn: c_import_ref_query,
-    class_like_parents: &[],
-    ancestor_visibility_rules: &[],
+    },
+    imports_refs: {
+        static: C_IMPORT_REF_QUERY,
+        accessor: c_import_ref_query,
+        import: C_FAMILY_IMPORT_QUERY_STR,
+        reference: C_FAMILY_REFERENCE_QUERY_STR,
+    },
+    import_statement_kinds: ["preproc_include"],
+    class_like_parents: [],
+    ancestors: [],
     visibility_from_name: None,
-    import_statement_kinds: &["preproc_include"],
     default_visibility: DefaultVisibility::PublicByDefault,
-    doc_comment_config: Some(crate::language::C_LIKE_DOC_COMMENT),
-};
+    doc_comment: Some(C_LIKE_DOC_COMMENT),
+    fixture: "tests/fixtures/c/functions.c",
+    snapshot: c_insta_snapshot,
+    tests {
+        use crate::model::SymbolKind;
 
-#[cfg(test)]
-mod tests {
-    use crate::language::{LangId, extract_symbols_for, grammar_for};
-    use crate::model::SymbolKind;
+        #[test]
+        fn c_grammar_loads() {
+            let _ = grammar_for(LangId::C);
+        }
 
-    fn parse(source: &[u8]) -> tree_sitter::Tree {
-        let mut parser = tree_sitter::Parser::new();
-        parser.set_language(&grammar_for(LangId::C)).unwrap();
-        parser.parse(source, None).unwrap()
-    }
+        #[test]
+        fn extract_function() {
+            let src = b"int add(int a, int b) { return a + b; }";
+            let tree = parse(src);
+            let symbols = extract_symbols_for(LangId::C, &tree, src);
+            assert_eq!(symbols.len(), 1);
+            assert_eq!(symbols[0].name, "add");
+            assert!(matches!(symbols[0].kind, SymbolKind::Function));
+            assert_eq!(symbols[0].signature.as_deref(), Some("(int a, int b)"));
+        }
 
-    #[test]
-    fn c_grammar_loads() {
-        let _ = grammar_for(LangId::C);
-    }
+        #[test]
+        fn extract_struct() {
+            let src = b"struct Point { int x; int y; };";
+            let tree = parse(src);
+            let symbols = extract_symbols_for(LangId::C, &tree, src);
+            let s = symbols.iter().find(|s| s.name == "Point").unwrap();
+            assert!(matches!(s.kind, SymbolKind::Struct));
+        }
 
-    #[test]
-    fn extract_function() {
-        let src = b"int add(int a, int b) { return a + b; }";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::C, &tree, src);
-        assert_eq!(symbols.len(), 1);
-        assert_eq!(symbols[0].name, "add");
-        assert!(matches!(symbols[0].kind, SymbolKind::Function));
-        assert_eq!(symbols[0].signature.as_deref(), Some("(int a, int b)"));
-    }
+        #[test]
+        fn extract_enum() {
+            let src = b"enum Color { RED, GREEN };";
+            let tree = parse(src);
+            let symbols = extract_symbols_for(LangId::C, &tree, src);
+            let s = symbols.iter().find(|s| s.name == "Color").unwrap();
+            assert!(matches!(s.kind, SymbolKind::Enum));
+        }
 
-    #[test]
-    fn extract_struct() {
-        let src = b"struct Point { int x; int y; };";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::C, &tree, src);
-        let s = symbols.iter().find(|s| s.name == "Point").unwrap();
-        assert!(matches!(s.kind, SymbolKind::Struct));
-    }
+        #[test]
+        fn c_docstring_extraction() {
+            let src = b"/** Doxygen comment. */\nint documented() {}";
+            let tree = parse(src);
+            let symbols = extract_symbols_for(LangId::C, &tree, src);
+            let func = symbols.iter().find(|s| s.name == "documented").unwrap();
+            assert!(func.docstring.is_some(), "documented should have docstring");
+            assert!(func.docstring.as_ref().unwrap().contains("Doxygen comment"));
+        }
 
-    #[test]
-    fn extract_enum() {
-        let src = b"enum Color { RED, GREEN };";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::C, &tree, src);
-        let s = symbols.iter().find(|s| s.name == "Color").unwrap();
-        assert!(matches!(s.kind, SymbolKind::Enum));
-    }
+        #[test]
+        fn extract_function_declaration() {
+            let src = b"int add(int a, int b);";
+            let tree = parse(src);
+            let symbols = extract_symbols_for(LangId::C, &tree, src);
+            let found = symbols.iter().find(|s| s.name == "add");
+            assert!(found.is_some(), "missing add: {symbols:?}");
+            let found = found.unwrap();
+            assert_eq!(format!("{:?}", found.kind), "Declaration");
+            assert_eq!(found.signature.as_deref(), Some("(int a, int b)"));
+        }
 
-    #[test]
-    fn c_docstring_extraction() {
-        let src = b"/** Doxygen comment. */\nint documented() {}";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::C, &tree, src);
-        let func = symbols.iter().find(|s| s.name == "documented").unwrap();
-        assert!(func.docstring.is_some(), "documented should have docstring");
-        assert!(func.docstring.as_ref().unwrap().contains("Doxygen comment"));
-    }
+        #[test]
+        fn extract_pointer_returning_function_declaration() {
+            let src = b"int *f(void);";
+            let tree = parse(src);
+            let symbols = extract_symbols_for(LangId::C, &tree, src);
+            let found = symbols.iter().find(|s| s.name == "f");
+            assert!(found.is_some(), "missing f: {symbols:?}");
+            assert_eq!(format!("{:?}", found.unwrap().kind), "Declaration");
+        }
 
-    #[test]
-    fn extract_function_declaration() {
-        let src = b"int add(int a, int b);";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::C, &tree, src);
-        let found = symbols.iter().find(|s| s.name == "add");
-        assert!(found.is_some(), "missing add: {symbols:?}");
-        let found = found.unwrap();
-        assert_eq!(format!("{:?}", found.kind), "Declaration");
-        assert_eq!(found.signature.as_deref(), Some("(int a, int b)"));
-    }
+        #[test]
+        fn extern_variable_declaration_is_not_a_symbol() {
+            let src = b"extern int counter;";
+            let tree = parse(src);
+            let symbols = extract_symbols_for(LangId::C, &tree, src);
+            assert!(!symbols.iter().any(|s| s.name == "counter"));
+        }
 
-    #[test]
-    fn extract_pointer_returning_function_declaration() {
-        let src = b"int *f(void);";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::C, &tree, src);
-        let found = symbols.iter().find(|s| s.name == "f");
-        assert!(found.is_some(), "missing f: {symbols:?}");
-        assert_eq!(format!("{:?}", found.unwrap().kind), "Declaration");
-    }
+        #[test]
+        fn typedef_function_pointer_is_not_a_declaration() {
+            let src = b"typedef int (*cb)(int);";
+            let tree = parse(src);
+            let symbols = extract_symbols_for(LangId::C, &tree, src);
+            assert!(!symbols.iter().any(|s| s.name == "cb"));
+        }
 
-    #[test]
-    fn extern_variable_declaration_is_not_a_symbol() {
-        let src = b"extern int counter;";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::C, &tree, src);
-        assert!(!symbols.iter().any(|s| s.name == "counter"));
-    }
-
-    #[test]
-    fn typedef_function_pointer_is_not_a_declaration() {
-        let src = b"typedef int (*cb)(int);";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::C, &tree, src);
-        assert!(!symbols.iter().any(|s| s.name == "cb"));
-    }
-
-    #[test]
-    fn definition_is_not_marked_as_a_declaration() {
-        let src = b"int add(int a, int b) { return a + b; }";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::C, &tree, src);
-        assert_eq!(symbols.len(), 1, "{symbols:?}");
-        assert_eq!(symbols[0].name, "add");
-        assert_eq!(format!("{:?}", symbols[0].kind), "Function");
-    }
-
-    #[test]
-    fn c_insta_snapshot() {
-        let src = std::fs::read_to_string(
-            std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-                .join("tests/fixtures/c/functions.c"),
-        )
-        .unwrap();
-        let tree = parse(src.as_bytes());
-        let symbols = extract_symbols_for(LangId::C, &tree, src.as_bytes());
-        insta::assert_json_snapshot!(symbols);
-    }
-}
+        #[test]
+        fn definition_is_not_marked_as_a_declaration() {
+            let src = b"int add(int a, int b) { return a + b; }";
+            let tree = parse(src);
+            let symbols = extract_symbols_for(LangId::C, &tree, src);
+            assert_eq!(symbols.len(), 1, "{symbols:?}");
+            assert_eq!(symbols[0].name, "add");
+            assert_eq!(format!("{:?}", symbols[0].kind), "Function");
+        }
+    },
+);

--- a/src/language/common.rs
+++ b/src/language/common.rs
@@ -637,7 +637,13 @@ pub(crate) fn extract_def_use_dataflow(
     }
 
     let mut nodes: Vec<DataNode> = Vec::new();
-    let mut def_ids: Vec<(String, usize, DataNodeId, bool)> = Vec::new();
+    // Definitions grouped by their enclosing scope and name, in source order:
+    // a use looks up its own bucket instead of scanning every definition, and
+    // the nearest preceding definition is the last entry before the use.
+    let mut defs_by_scope: std::collections::HashMap<
+        usize,
+        std::collections::HashMap<String, Vec<(usize, DataNodeId)>>,
+    > = std::collections::HashMap::new();
     for (name, byte_pos, node, is_param) in &defs {
         let scope = if *is_param {
             DataScope::Parameter
@@ -652,29 +658,35 @@ pub(crate) fn extract_def_use_dataflow(
             type_hint: None,
             source_range: source_range_from_node(node),
         };
-        def_ids.push((name.clone(), *byte_pos, dn.id, *is_param));
+        let scope_start = find_enclosing_scope(tree.root_node(), *byte_pos, function_kinds);
+        defs_by_scope
+            .entry(scope_start)
+            .or_default()
+            .entry(name.clone())
+            .or_default()
+            .push((*byte_pos, dn.id));
         nodes.push(dn);
+    }
+    for by_name in defs_by_scope.values_mut() {
+        for candidates in by_name.values_mut() {
+            candidates.sort_by_key(|(byte_pos, _)| *byte_pos);
+        }
     }
 
     let mut edges: Vec<FlowEdge> = Vec::new();
     for (use_name, use_pos, use_node, use_func_start) in &uses {
-        let mut best_def: Option<&(String, usize, DataNodeId, bool)> = None;
-        for def in &def_ids {
-            if def.0 == *use_name
-                && def.1 < *use_pos
-                && find_enclosing_scope(tree.root_node(), def.1, function_kinds) == *use_func_start
-            {
-                match best_def {
-                    None => best_def = Some(def),
-                    Some(best) => {
-                        if def.1 > best.1 {
-                            best_def = Some(def);
-                        }
-                    }
-                }
-            }
-        }
-        if let Some(def) = best_def {
+        let best_def = defs_by_scope
+            .get(use_func_start)
+            .and_then(|by_name| by_name.get(use_name.as_str()))
+            .and_then(|candidates| {
+                let preceding = candidates.partition_point(|(byte_pos, _)| byte_pos < use_pos);
+                preceding
+                    .checked_sub(1)
+                    .and_then(|index| candidates.get(index))
+                    .map(|(_, def_id)| *def_id)
+            });
+
+        if let Some(def_id) = best_def {
             let use_dn = DataNode {
                 id: id_gen.next(),
                 symbol_id: None,
@@ -686,7 +698,7 @@ pub(crate) fn extract_def_use_dataflow(
             let target_id = use_dn.id;
             nodes.push(use_dn);
             edges.push(FlowEdge {
-                source: def.2,
+                source: def_id,
                 target: target_id,
                 kind: FlowKind::DefUse,
                 confidence: CONFIDENCE_DEF_USE,

--- a/src/language/cpp.rs
+++ b/src/language/cpp.rs
@@ -1,16 +1,23 @@
+use crate::language::DefaultVisibility;
 use crate::language::c::{C_FAMILY_IMPORT_QUERY_STR, C_FAMILY_REFERENCE_QUERY_STR};
-use crate::language::{DefaultVisibility, LanguageSpec};
+use crate::language::pack::define_language_pack;
 use std::path::{Path, PathBuf};
-use std::sync::LazyLock;
 
 fn resolve_cpp_import(raw: &str, source_dir: &Path, _project_root: &Path) -> Option<PathBuf> {
     crate::language::import_resolver::resolve_c_family_import(raw, source_dir)
 }
 
-static CPP_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
-    crate::language::common::compile_query(
-        &tree_sitter_cpp::LANGUAGE.into(),
-        r#"
+define_language_pack!(
+    spec: CPP_SPEC,
+    label: "C++",
+    lang: LangId::Cpp,
+    grammar: tree_sitter_cpp::LANGUAGE,
+    extensions: ["cc", "cpp", "cxx", "hpp"],
+    resolver: resolve_cpp_import,
+    symbols: {
+        static: CPP_QUERY,
+        accessor: cpp_query,
+        query: r#"
         (function_definition
           declarator: (function_declarator
             declarator: [
@@ -97,144 +104,104 @@ static CPP_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
         (type_definition
             declarator: (type_identifier) @name) @kind.type_alias
         "#,
-        "C++",
-    )
-});
-
-fn cpp_query() -> &'static tree_sitter::Query {
-    &CPP_QUERY
-}
-
-static CPP_IMPORT_REF_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
-    crate::language::common::compile_query(
-        &tree_sitter_cpp::LANGUAGE.into(),
-        &format!(
-            "{}\n{}",
-            C_FAMILY_IMPORT_QUERY_STR, C_FAMILY_REFERENCE_QUERY_STR
-        ),
-        "C++ combined import+ref",
-    )
-});
-
-fn cpp_import_ref_query() -> &'static tree_sitter::Query {
-    &CPP_IMPORT_REF_QUERY
-}
-
-pub(crate) const CPP_SPEC: LanguageSpec = LanguageSpec {
-    extensions: &["cc", "cpp", "cxx", "hpp"],
-    grammar_fn: || tree_sitter_cpp::LANGUAGE.into(),
-    query_fn: cpp_query,
-    import_path_resolver: resolve_cpp_import,
-    import_ref_query_fn: cpp_import_ref_query,
-    class_like_parents: &["class_specifier", "struct_specifier"],
-    ancestor_visibility_rules: &[],
+    },
+    imports_refs: {
+        static: CPP_IMPORT_REF_QUERY,
+        accessor: cpp_import_ref_query,
+        import: C_FAMILY_IMPORT_QUERY_STR,
+        reference: C_FAMILY_REFERENCE_QUERY_STR,
+    },
+    import_statement_kinds: ["preproc_include"],
+    class_like_parents: ["class_specifier", "struct_specifier"],
+    ancestors: [],
     visibility_from_name: None,
-    import_statement_kinds: &["preproc_include"],
     default_visibility: DefaultVisibility::PrivateByDefault,
-    doc_comment_config: Some(crate::language::C_LIKE_DOC_COMMENT),
-};
+    doc_comment: Some(crate::language::C_LIKE_DOC_COMMENT),
+    fixture: "tests/fixtures/cpp/classes.cpp",
+    snapshot: cpp_insta_snapshot,
+    tests {
+            use crate::model::SymbolKind;
 
-#[cfg(test)]
-mod tests {
-    use crate::language::{LangId, extract_symbols_for, grammar_for};
-    use crate::model::SymbolKind;
 
-    fn parse(source: &[u8]) -> tree_sitter::Tree {
-        let mut parser = tree_sitter::Parser::new();
-        parser.set_language(&grammar_for(LangId::Cpp)).unwrap();
-        parser.parse(source, None).unwrap()
-    }
+            #[test]
+            fn extract_class() {
+                let src = b"class Foo { public: void bar() {} };";
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::Cpp, &tree, src);
+                let foo = symbols.iter().find(|s| s.name == "Foo").unwrap();
+                assert!(matches!(foo.kind, SymbolKind::Class));
+            }
 
-    #[test]
-    fn extract_class() {
-        let src = b"class Foo { public: void bar() {} };";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::Cpp, &tree, src);
-        let foo = symbols.iter().find(|s| s.name == "Foo").unwrap();
-        assert!(matches!(foo.kind, SymbolKind::Class));
-    }
+            #[test]
+            fn extract_method() {
+                let src = b"class Foo { public: void bar() {} };";
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::Cpp, &tree, src);
+                let bar = symbols.iter().find(|s| s.name == "bar").unwrap();
+                assert!(matches!(bar.kind, SymbolKind::Method));
+            }
 
-    #[test]
-    fn extract_method() {
-        let src = b"class Foo { public: void bar() {} };";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::Cpp, &tree, src);
-        let bar = symbols.iter().find(|s| s.name == "bar").unwrap();
-        assert!(matches!(bar.kind, SymbolKind::Method));
-    }
+            #[test]
+            fn extract_namespace() {
+                let src = b"namespace math { int add(int a, int b) { return a + b; } }";
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::Cpp, &tree, src);
+                let ns = symbols.iter().find(|s| s.name == "math").unwrap();
+                assert!(matches!(ns.kind, SymbolKind::Namespace));
+            }
 
-    #[test]
-    fn extract_namespace() {
-        let src = b"namespace math { int add(int a, int b) { return a + b; } }";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::Cpp, &tree, src);
-        let ns = symbols.iter().find(|s| s.name == "math").unwrap();
-        assert!(matches!(ns.kind, SymbolKind::Namespace));
-    }
+            #[test]
+            fn cpp_docstring_extraction() {
+                let src = b"/** C++ doc comment. */\nint documented() {}";
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::Cpp, &tree, src);
+                let func = symbols.iter().find(|s| s.name == "documented").unwrap();
+                assert!(func.docstring.is_some(), "documented should have docstring");
+                assert!(func.docstring.as_ref().unwrap().contains("C++ doc comment"));
+            }
 
-    #[test]
-    fn cpp_docstring_extraction() {
-        let src = b"/** C++ doc comment. */\nint documented() {}";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::Cpp, &tree, src);
-        let func = symbols.iter().find(|s| s.name == "documented").unwrap();
-        assert!(func.docstring.is_some(), "documented should have docstring");
-        assert!(func.docstring.as_ref().unwrap().contains("C++ doc comment"));
-    }
+            #[test]
+            fn extract_class_member_function_declaration() {
+                let src = b"class C { void m(); };";
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::Cpp, &tree, src);
+                let found = symbols.iter().find(|s| s.name == "m");
+                assert!(found.is_some(), "missing m: {symbols:?}");
+                assert_eq!(format!("{:?}", found.unwrap().kind), "Declaration");
+            }
 
-    #[test]
-    fn extract_class_member_function_declaration() {
-        let src = b"class C { void m(); };";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::Cpp, &tree, src);
-        let found = symbols.iter().find(|s| s.name == "m");
-        assert!(found.is_some(), "missing m: {symbols:?}");
-        assert_eq!(format!("{:?}", found.unwrap().kind), "Declaration");
-    }
+            #[test]
+            fn qualified_definition_uses_the_plain_name() {
+                let src = b"void C::m() {}";
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::Cpp, &tree, src);
+                let names: Vec<&str> = symbols.iter().map(|s| s.name.as_ref()).collect();
+                assert!(names.contains(&"m"), "names: {names:?}");
+                assert!(!names.contains(&"C::m"), "names: {names:?}");
+            }
 
-    #[test]
-    fn qualified_definition_uses_the_plain_name() {
-        let src = b"void C::m() {}";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::Cpp, &tree, src);
-        let names: Vec<&str> = symbols.iter().map(|s| s.name.as_ref()).collect();
-        assert!(names.contains(&"m"), "names: {names:?}");
-        assert!(!names.contains(&"C::m"), "names: {names:?}");
-    }
+            #[test]
+            fn pointer_returning_definition_is_captured() {
+                let src = b"void *alloc(int n) { return 0; }";
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::Cpp, &tree, src);
+                assert!(symbols.iter().any(|s| s.name == "alloc"), "{symbols:?}");
+            }
 
-    #[test]
-    fn pointer_returning_definition_is_captured() {
-        let src = b"void *alloc(int n) { return 0; }";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::Cpp, &tree, src);
-        assert!(symbols.iter().any(|s| s.name == "alloc"), "{symbols:?}");
-    }
+            #[test]
+            fn reference_returning_definition_is_captured() {
+                let src = b"int &ref(int n) { return n; }";
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::Cpp, &tree, src);
+                assert!(symbols.iter().any(|s| s.name == "ref"), "{symbols:?}");
+            }
 
-    #[test]
-    fn reference_returning_definition_is_captured() {
-        let src = b"int &ref(int n) { return n; }";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::Cpp, &tree, src);
-        assert!(symbols.iter().any(|s| s.name == "ref"), "{symbols:?}");
-    }
-
-    #[test]
-    fn data_member_is_not_a_symbol() {
-        let src = b"class C { int x; };";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::Cpp, &tree, src);
-        assert!(!symbols.iter().any(|s| s.name == "x"));
-    }
-
-    #[test]
-    fn cpp_insta_snapshot() {
-        let src = std::fs::read_to_string(
-            std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-                .join("tests/fixtures/cpp/classes.cpp"),
-        )
-        .unwrap();
-        let tree = parse(src.as_bytes());
-        let symbols = extract_symbols_for(LangId::Cpp, &tree, src.as_bytes());
-        insta::assert_json_snapshot!(symbols);
-    }
-}
+            #[test]
+            fn data_member_is_not_a_symbol() {
+                let src = b"class C { int x; };";
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::Cpp, &tree, src);
+                assert!(!symbols.iter().any(|s| s.name == "x"));
+            }
+    },
+);

--- a/src/language/go.rs
+++ b/src/language/go.rs
@@ -1,7 +1,7 @@
-use crate::language::{DefaultVisibility, DocCommentConfig, LanguageSpec};
+use crate::language::pack::define_language_pack;
+use crate::language::{DefaultVisibility, DocCommentConfig};
 use crate::model::Visibility;
 use std::path::{Path, PathBuf};
-use std::sync::LazyLock;
 
 fn resolve_go_import(raw: &str, _source_dir: &Path, project_root: &Path) -> Option<PathBuf> {
     use crate::language::import_resolver::{find_go_module, strip_import_quotes};
@@ -23,10 +23,34 @@ fn resolve_go_import(raw: &str, _source_dir: &Path, project_root: &Path) -> Opti
     Some(dir.join(relative).with_extension("go"))
 }
 
-static GO_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
-    crate::language::common::compile_query(
-        &tree_sitter_go::LANGUAGE.into(),
-        r#"
+const GO_IMPORT_QUERY_STR: &str = r#"
+(import_spec
+  name: (_)? @import.alias
+  path:     (interpreted_string_literal) @import.path)
+"#;
+
+const GO_REFERENCE_QUERY_STR: &str = r#"
+(call_expression
+  function: (identifier) @reference.name)
+(call_expression
+  function: (selector_expression
+    field: (field_identifier) @reference.name))
+(call_expression
+  function: (selector_expression
+    operand: (identifier) @reference.name))
+"#;
+
+define_language_pack!(
+    spec: GO_SPEC,
+    label: "Go",
+    lang: LangId::Go,
+    grammar: tree_sitter_go::LANGUAGE,
+    extensions: ["go"],
+    resolver: resolve_go_import,
+    symbols: {
+        static: GO_QUERY,
+        accessor: go_query,
+        query: r#"
 (function_declaration
   name: (identifier) @name
   parameters: (parameter_list) @signature
@@ -74,181 +98,127 @@ static GO_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
   name: (identifier) @name
 ) @kind.object
 "#,
-        "Go",
-    )
-});
-
-const GO_IMPORT_QUERY_STR: &str = r#"
-(import_spec
-  name: (_)? @import.alias
-  path:     (interpreted_string_literal) @import.path)
-"#;
-
-const GO_REFERENCE_QUERY_STR: &str = r#"
-(call_expression
-  function: (identifier) @reference.name)
-(call_expression
-  function: (selector_expression
-    field: (field_identifier) @reference.name))
-(call_expression
-  function: (selector_expression
-    operand: (identifier) @reference.name))
-"#;
-
-fn go_query() -> &'static tree_sitter::Query {
-    &GO_QUERY
-}
-
-static GO_IMPORT_REF_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
-    crate::language::common::compile_query(
-        &tree_sitter_go::LANGUAGE.into(),
-        &format!("{}\n{}", GO_IMPORT_QUERY_STR, GO_REFERENCE_QUERY_STR),
-        "Go combined import+ref",
-    )
-});
-
-fn go_import_ref_query() -> &'static tree_sitter::Query {
-    &GO_IMPORT_REF_QUERY
-}
-
-pub(crate) const GO_SPEC: LanguageSpec = LanguageSpec {
-    extensions: &["go"],
-    grammar_fn: || tree_sitter_go::LANGUAGE.into(),
-    query_fn: go_query,
-    import_path_resolver: resolve_go_import,
-    import_ref_query_fn: go_import_ref_query,
-    class_like_parents: &[],
-    ancestor_visibility_rules: &[],
+    },
+    imports_refs: {
+        static: GO_IMPORT_REF_QUERY,
+        accessor: go_import_ref_query,
+        import: GO_IMPORT_QUERY_STR,
+        reference: GO_REFERENCE_QUERY_STR,
+    },
+    import_statement_kinds: ["import_declaration"],
+    class_like_parents: [],
+    ancestors: [],
     visibility_from_name: Some(|name| {
         name.starts_with(|c: char| c.is_uppercase())
             .then_some(Visibility::Public)
     }),
-    import_statement_kinds: &["import_declaration"],
     default_visibility: DefaultVisibility::PrivateByDefault,
-    doc_comment_config: Some(DocCommentConfig {
+    doc_comment: Some(DocCommentConfig {
         line_prefixes: &["//"],
         block_open: None,
         block_close: "",
         strip_continuation_marker: false,
     }),
-};
+    fixture: "tests/fixtures/go/methods.go",
+    snapshot: go_insta_snapshot,
+    tests {
+            use crate::model::SymbolKind;
 
-#[cfg(test)]
-mod tests {
-    use crate::language::{LangId, extract_symbols_for, grammar_for};
-    use crate::model::SymbolKind;
 
-    fn parse(source: &[u8]) -> tree_sitter::Tree {
-        let mut parser = tree_sitter::Parser::new();
-        parser.set_language(&grammar_for(LangId::Go)).unwrap();
-        parser.parse(source, None).unwrap()
-    }
+            #[test]
+            fn extract_function() {
+                let src = b"package main\n\nfunc Hello() {}";
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::Go, &tree, src);
+                assert_eq!(symbols.len(), 1);
+                assert_eq!(symbols[0].name, "Hello");
+                assert!(matches!(symbols[0].kind, SymbolKind::Function));
+            }
 
-    #[test]
-    fn extract_function() {
-        let src = b"package main\n\nfunc Hello() {}";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::Go, &tree, src);
-        assert_eq!(symbols.len(), 1);
-        assert_eq!(symbols[0].name, "Hello");
-        assert!(matches!(symbols[0].kind, SymbolKind::Function));
-    }
+            #[test]
+            fn extract_struct() {
+                let src = b"package main\n\ntype Rect struct {\n\tWidth float64\n}";
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::Go, &tree, src);
+                assert_eq!(symbols.len(), 1);
+                assert_eq!(symbols[0].name, "Rect");
+                assert!(matches!(symbols[0].kind, SymbolKind::Struct));
+            }
 
-    #[test]
-    fn extract_struct() {
-        let src = b"package main\n\ntype Rect struct {\n\tWidth float64\n}";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::Go, &tree, src);
-        assert_eq!(symbols.len(), 1);
-        assert_eq!(symbols[0].name, "Rect");
-        assert!(matches!(symbols[0].kind, SymbolKind::Struct));
-    }
+            #[test]
+            fn extract_method_with_receiver() {
+                let src = b"package main\n\nfunc (r *Rect) Area() float64 { return 0 }";
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::Go, &tree, src);
+                assert_eq!(symbols.len(), 1);
+                assert_eq!(symbols[0].name, "Area");
+                assert!(matches!(symbols[0].kind, SymbolKind::Method));
+            }
 
-    #[test]
-    fn extract_method_with_receiver() {
-        let src = b"package main\n\nfunc (r *Rect) Area() float64 { return 0 }";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::Go, &tree, src);
-        assert_eq!(symbols.len(), 1);
-        assert_eq!(symbols[0].name, "Area");
-        assert!(matches!(symbols[0].kind, SymbolKind::Method));
-    }
+            #[test]
+            fn extract_import_no_alias() {
+                use crate::language::extract_imports_and_references_for;
+                let src = b"package main\n\nimport \"fmt\"\n";
+                let tree = parse(src);
+                let (imports, _, _) = extract_imports_and_references_for(
+                    LangId::Go,
+                    &tree,
+                    src,
+                    &std::path::PathBuf::from("test.go"),
+                );
+                assert_eq!(
+                    imports.len(),
+                    1,
+                    "expected 1 import record for non-aliased import"
+                );
+                assert_eq!(imports[0].import_specifier, "fmt");
+                assert!(imports[0].alias.is_none());
+            }
 
-    #[test]
-    fn extract_import_no_alias() {
-        use crate::language::extract_imports_and_references_for;
-        let src = b"package main\n\nimport \"fmt\"\n";
-        let tree = parse(src);
-        let (imports, _, _) = extract_imports_and_references_for(
-            LangId::Go,
-            &tree,
-            src,
-            &std::path::PathBuf::from("test.go"),
-        );
-        assert_eq!(
-            imports.len(),
-            1,
-            "expected 1 import record for non-aliased import"
-        );
-        assert_eq!(imports[0].import_specifier, "fmt");
-        assert!(imports[0].alias.is_none());
-    }
+            #[test]
+            fn extract_aliased_import_no_duplicates() {
+                use crate::language::extract_imports_and_references_for;
+                let src = b"package main\n\nimport alias \"fmt\"\n";
+                let tree = parse(src);
+                let (imports, _, _) = extract_imports_and_references_for(
+                    LangId::Go,
+                    &tree,
+                    src,
+                    &std::path::PathBuf::from("test.go"),
+                );
+                assert_eq!(
+                    imports.len(),
+                    1,
+                    "expected 1 import record, not 2 (CR-03 regression check)"
+                );
+                assert_eq!(imports[0].import_specifier, "fmt");
+                assert_eq!(imports[0].alias.as_deref(), Some("alias"));
+            }
 
-    #[test]
-    fn extract_aliased_import_no_duplicates() {
-        use crate::language::extract_imports_and_references_for;
-        let src = b"package main\n\nimport alias \"fmt\"\n";
-        let tree = parse(src);
-        let (imports, _, _) = extract_imports_and_references_for(
-            LangId::Go,
-            &tree,
-            src,
-            &std::path::PathBuf::from("test.go"),
-        );
-        assert_eq!(
-            imports.len(),
-            1,
-            "expected 1 import record, not 2 (CR-03 regression check)"
-        );
-        assert_eq!(imports[0].import_specifier, "fmt");
-        assert_eq!(imports[0].alias.as_deref(), Some("alias"));
-    }
+            #[test]
+            fn extract_multiple_named_imports_no_aliases() {
+                use crate::language::extract_imports_and_references_for;
+                let src = b"package main\n\nimport (\n\t\"fmt\"\n\t\"os\"\n)\n";
+                let tree = parse(src);
+                let (imports, _, _) = extract_imports_and_references_for(
+                    LangId::Go,
+                    &tree,
+                    src,
+                    &std::path::PathBuf::from("test.go"),
+                );
+                assert_eq!(imports.len(), 2, "expected 2 import records for fmt and os");
+                assert_eq!(imports[0].import_specifier, "fmt");
+                assert_eq!(imports[1].import_specifier, "os");
+            }
 
-    #[test]
-    fn extract_multiple_named_imports_no_aliases() {
-        use crate::language::extract_imports_and_references_for;
-        let src = b"package main\n\nimport (\n\t\"fmt\"\n\t\"os\"\n)\n";
-        let tree = parse(src);
-        let (imports, _, _) = extract_imports_and_references_for(
-            LangId::Go,
-            &tree,
-            src,
-            &std::path::PathBuf::from("test.go"),
-        );
-        assert_eq!(imports.len(), 2, "expected 2 import records for fmt and os");
-        assert_eq!(imports[0].import_specifier, "fmt");
-        assert_eq!(imports[1].import_specifier, "os");
-    }
-
-    #[test]
-    fn go_docstring_extraction() {
-        let src = b"package main\n\n// Godoc comment.\nfunc Documented() {}";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::Go, &tree, src);
-        let func = symbols.iter().find(|s| s.name == "Documented").unwrap();
-        assert!(func.docstring.is_some(), "Documented should have docstring");
-        assert!(func.docstring.as_ref().unwrap().contains("Godoc comment"));
-    }
-
-    #[test]
-    fn go_insta_snapshot() {
-        let src = std::fs::read_to_string(
-            std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-                .join("tests/fixtures/go/methods.go"),
-        )
-        .unwrap();
-        let tree = parse(src.as_bytes());
-        let symbols = extract_symbols_for(LangId::Go, &tree, src.as_bytes());
-        insta::assert_json_snapshot!(symbols);
-    }
-}
+            #[test]
+            fn go_docstring_extraction() {
+                let src = b"package main\n\n// Godoc comment.\nfunc Documented() {}";
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::Go, &tree, src);
+                let func = symbols.iter().find(|s| s.name == "Documented").unwrap();
+                assert!(func.docstring.is_some(), "Documented should have docstring");
+                assert!(func.docstring.as_ref().unwrap().contains("Godoc comment"));
+            }
+    },
+);

--- a/src/language/javascript.rs
+++ b/src/language/javascript.rs
@@ -1,17 +1,48 @@
-use crate::language::{DefaultVisibility, LanguageSpec};
+use crate::language::DefaultVisibility;
+use crate::language::pack::define_language_pack;
 use crate::model::Visibility;
 use std::path::{Path, PathBuf};
-use std::sync::LazyLock;
 
 fn resolve_js_import(raw: &str, source_dir: &Path, _project_root: &Path) -> Option<PathBuf> {
     use crate::language::import_resolver::{JS_EXTS, resolve_js_family_import};
     resolve_js_family_import(raw, source_dir, JS_EXTS, &|p| p.is_file())
 }
 
-static JS_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
-    crate::language::common::compile_query(
-        &tree_sitter_javascript::LANGUAGE.into(),
-        r#"
+const JS_IMPORT_QUERY_STR: &str = r#"
+(import_statement
+  source: (string) @import.path)
+(import_statement
+  (import_clause
+    (named_imports
+      (import_specifier
+        name: (identifier) @import.symbol
+        alias: (identifier)? @import.alias))))
+(import_statement
+  (import_clause
+    (identifier) @import.symbol))
+(import_statement
+  (import_clause
+    (namespace_import
+      (identifier) @import.symbol)))
+(call_expression
+  function: (identifier) @call.name
+  arguments: (arguments . (string) @import.path .)
+  (#eq? @call.name "require"))
+"#;
+
+const JS_REFERENCE_QUERY_STR: &str = crate::language::typescript::TS_FAMILY_REFERENCE_QUERY;
+
+define_language_pack!(
+    spec: JS_SPEC,
+    label: "JavaScript",
+    lang: LangId::JavaScript,
+    grammar: tree_sitter_javascript::LANGUAGE,
+    extensions: ["js", "mjs", "cjs"],
+    resolver: resolve_js_import,
+    symbols: {
+        static: JS_QUERY,
+        accessor: js_query,
+        query: r#"
 (function_declaration
   "async"? @async
   name: (identifier) @name
@@ -64,63 +95,423 @@ static JS_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
     parameters: (formal_parameters) @signature)
 ) @kind.function
 "#,
-        "JavaScript",
-    )
-});
-
-fn js_query() -> &'static tree_sitter::Query {
-    &JS_QUERY
-}
-
-const JS_IMPORT_QUERY_STR: &str = r#"
-(import_statement
-  source: (string) @import.path)
-(import_statement
-  (import_clause
-    (named_imports
-      (import_specifier
-        name: (identifier) @import.symbol
-        alias: (identifier)? @import.alias))))
-(import_statement
-  (import_clause
-    (identifier) @import.symbol))
-(import_statement
-  (import_clause
-    (namespace_import
-      (identifier) @import.symbol)))
-(call_expression
-  function: (identifier) @call.name
-  arguments: (arguments . (string) @import.path .)
-  (#eq? @call.name "require"))
-"#;
-
-const JS_REFERENCE_QUERY_STR: &str = crate::language::typescript::TS_FAMILY_REFERENCE_QUERY;
-
-static JS_IMPORT_REF_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
-    crate::language::common::compile_query(
-        &tree_sitter_javascript::LANGUAGE.into(),
-        &format!("{}\n{}", JS_IMPORT_QUERY_STR, JS_REFERENCE_QUERY_STR),
-        "JavaScript combined import+ref",
-    )
-});
-
-fn js_import_ref_query() -> &'static tree_sitter::Query {
-    &JS_IMPORT_REF_QUERY
-}
-
-pub(crate) const JS_SPEC: LanguageSpec = LanguageSpec {
-    extensions: &["js", "mjs", "cjs"],
-    grammar_fn: || tree_sitter_javascript::LANGUAGE.into(),
-    query_fn: js_query,
-    import_path_resolver: resolve_js_import,
-    import_ref_query_fn: js_import_ref_query,
-    class_like_parents: &["class_declaration", "class"],
-    ancestor_visibility_rules: &[("export_statement", Visibility::Public)],
+    },
+    imports_refs: {
+        static: JS_IMPORT_REF_QUERY,
+        accessor: js_import_ref_query,
+        import: JS_IMPORT_QUERY_STR,
+        reference: JS_REFERENCE_QUERY_STR,
+    },
+    import_statement_kinds: ["import_statement"],
+    class_like_parents: ["class_declaration", "class"],
+    ancestors: [("export_statement", Visibility::Public)],
     visibility_from_name: None,
-    import_statement_kinds: &["import_statement"],
     default_visibility: DefaultVisibility::PrivateByDefault,
-    doc_comment_config: Some(crate::language::C_LIKE_DOC_COMMENT),
-};
+    doc_comment: Some(crate::language::C_LIKE_DOC_COMMENT),
+    fixture: "tests/fixtures/javascript/functions.js",
+    snapshot: js_insta_snapshot,
+    tests {
+            use crate::model::{SymbolKind, Visibility};
+
+
+            #[test]
+            fn extract_function_declaration() {
+                let src = b"function hello() {}";
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::JavaScript, &tree, src);
+                assert_eq!(symbols.len(), 1);
+                assert_eq!(symbols[0].name, "hello");
+                assert!(matches!(symbols[0].kind, SymbolKind::Function));
+            }
+
+            #[test]
+            fn extract_async_function() {
+                let src = b"async function fetch() {}";
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::JavaScript, &tree, src);
+                assert_eq!(symbols.len(), 1);
+                assert!(symbols[0].is_async);
+            }
+
+            #[test]
+            fn extract_class_and_methods() {
+                let src = b"class Foo {\n  constructor() {}\n  bar() {}\n}";
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::JavaScript, &tree, src);
+                let class = symbols.iter().find(|s| s.name == "Foo").unwrap();
+                assert!(matches!(class.kind, SymbolKind::Class));
+                let methods: Vec<_> = symbols
+                    .iter()
+                    .filter(|s| matches!(s.kind, SymbolKind::Method))
+                    .collect();
+                assert_eq!(methods.len(), 2);
+            }
+
+            #[test]
+            fn extract_exported_class() {
+                let src = b"export class Foo { bar() {} }";
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::JavaScript, &tree, src);
+                let class = symbols.iter().find(|s| s.name == "Foo").unwrap();
+                assert_eq!(class.visibility, Some(Visibility::Public));
+            }
+
+            #[test]
+            fn extract_named_imports() {
+                use crate::language::extract_imports_and_references_for;
+                let src = b"import { foo, bar } from 'utils';";
+                let tree = parse(src);
+                let (imports, _, _) = extract_imports_and_references_for(
+                    LangId::JavaScript,
+                    &tree,
+                    src,
+                    &std::path::PathBuf::from("test.js"),
+                );
+                let named: Vec<_> = imports.iter().filter(|i| i.symbol.is_some()).collect();
+                assert_eq!(
+                    named.len(),
+                    2,
+                    "expected 2 named import records for foo and bar"
+                );
+                for imp in &named {
+                    assert_eq!(imp.import_specifier, "utils");
+                }
+                assert_eq!(named[0].symbol.as_deref(), Some("foo"));
+                assert_eq!(named[1].symbol.as_deref(), Some("bar"));
+            }
+
+            #[test]
+            fn extract_default_import() {
+                use crate::language::extract_imports_and_references_for;
+                let src = b"import React from 'react';";
+                let tree = parse(src);
+                let (imports, _, _) = extract_imports_and_references_for(
+                    LangId::JavaScript,
+                    &tree,
+                    src,
+                    &std::path::PathBuf::from("test.js"),
+                );
+                let named: Vec<_> = imports.iter().filter(|i| i.symbol.is_some()).collect();
+                assert_eq!(named.len(), 1);
+                assert_eq!(named[0].import_specifier, "react");
+                assert_eq!(named[0].symbol.as_deref(), Some("React"));
+            }
+
+            #[test]
+            fn extract_side_effect_import() {
+                use crate::language::extract_imports_and_references_for;
+                let src = b"import 'styles.css';";
+                let tree = parse(src);
+                let (imports, _, _) = extract_imports_and_references_for(
+                    LangId::JavaScript,
+                    &tree,
+                    src,
+                    &std::path::PathBuf::from("test.js"),
+                );
+                assert_eq!(imports.len(), 1);
+                assert_eq!(imports[0].import_specifier, "styles.css");
+                assert!(imports[0].symbol.is_none());
+            }
+
+            #[test]
+            fn js_docstring_extraction() {
+                let src = b"/** JSDoc comment. */\nfunction documented() {}";
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::JavaScript, &tree, src);
+                let func = symbols.iter().find(|s| s.name == "documented").unwrap();
+                assert!(func.docstring.is_some(), "documented should have docstring");
+                assert!(func.docstring.as_ref().unwrap().contains("JSDoc comment"));
+            }
+
+            fn symbol_names(symbols: &[crate::language::RawSymbol<'_>]) -> Vec<String> {
+                symbols.iter().map(|s| s.name.to_string()).collect()
+            }
+
+            #[test]
+            fn extract_arrow_function_assigned_to_const() {
+                let src = b"const compute = (a, b) => a + b;";
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::JavaScript, &tree, src);
+                let found = symbols.iter().find(|s| s.name == "compute");
+                assert!(
+                    found.is_some(),
+                    "missing compute: {:?}",
+                    symbol_names(&symbols)
+                );
+                let found = found.unwrap();
+                assert!(matches!(found.kind, SymbolKind::Function));
+                assert_eq!(found.signature.as_deref(), Some("(a, b)"));
+            }
+
+            #[test]
+            fn extract_exported_async_arrow_function() {
+                let src = b"export const handler = async () => {};";
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::JavaScript, &tree, src);
+                let found = symbols.iter().find(|s| s.name == "handler");
+                assert!(
+                    found.is_some(),
+                    "missing handler: {:?}",
+                    symbol_names(&symbols)
+                );
+                let found = found.unwrap();
+                assert!(matches!(found.kind, SymbolKind::Function));
+                assert!(found.is_async);
+                assert_eq!(found.visibility, Some(Visibility::Public));
+            }
+
+            #[test]
+            fn extract_function_expression_assigned_to_const() {
+                let src = b"const greet = function inner(x) { return x; };";
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::JavaScript, &tree, src);
+                let found = symbols.iter().find(|s| s.name == "greet");
+                assert!(
+                    found.is_some(),
+                    "missing greet: {:?}",
+                    symbol_names(&symbols)
+                );
+                assert!(!symbols.iter().any(|s| s.name == "inner"));
+                assert_eq!(found.unwrap().signature.as_deref(), Some("(x)"));
+            }
+
+
+            #[cfg(feature = "dataflow")]
+            mod dataflow_tests {
+                use super::*;
+                use crate::language::javascript::extract_javascript_dataflow;
+                use crate::model::{DataScope, FlowKind};
+
+                fn extract(source: &[u8]) -> (Vec<crate::model::DataNode>, Vec<crate::model::FlowEdge>) {
+                    let id_gen = crate::model::IdGenerator::new();
+                    extract_javascript_dataflow(&parse(source), source, &id_gen)
+                }
+
+                #[test]
+                fn const_declaration_captured_as_local() {
+                    let src = b"function f() { const x = 42; return x; }";
+                    let (nodes, _) = extract(src);
+                    let x = nodes
+                        .iter()
+                        .find(|n| n.name.as_deref() == Some("x") && n.scope == DataScope::Local)
+                        .expect("const x should be captured as Local");
+                    assert_eq!(x.scope, DataScope::Local);
+                }
+
+                #[test]
+                fn function_parameter_captured_as_parameter() {
+                    let src = b"function add(a, b) { return a + b; }";
+                    let (nodes, edges) = extract(src);
+                    let params: Vec<_> = nodes
+                        .iter()
+                        .filter(|n| n.scope == DataScope::Parameter)
+                        .collect();
+                    assert_eq!(params.len(), 2, "expected 2 parameters");
+                    let names: Vec<_> = params.iter().map(|n| n.name.as_deref()).collect();
+                    assert!(names.contains(&Some("a")));
+                    assert!(names.contains(&Some("b")));
+                    assert!(
+                        !edges.is_empty(),
+                        "parameter usages should produce def-use edges"
+                    );
+                    for edge in &edges {
+                        assert_eq!(edge.kind, FlowKind::DefUse);
+                        assert!(
+                            (edge.confidence - 0.9).abs() < f32::EPSILON,
+                            "confidence should be 0.9, got {}",
+                            edge.confidence
+                        );
+                    }
+                }
+
+                #[test]
+                fn def_use_edge_anchored_in_graph() {
+                    // Each flow edge's target must reference a real data node id.
+                    let src = b"function f() { let x = 1; let y = x; }";
+                    let (nodes, edges) = extract(src);
+                    let ids: std::collections::HashSet<_> = nodes.iter().map(|n| n.id).collect();
+                    for edge in &edges {
+                        assert!(
+                            ids.contains(&edge.source),
+                            "edge source {:?} not in nodes",
+                            edge.source
+                        );
+                        assert!(
+                            ids.contains(&edge.target),
+                            "edge target {:?} not in nodes (dangling edge)",
+                            edge.target
+                        );
+                    }
+                }
+
+                #[test]
+                fn no_cross_function_def_use_leak() {
+                    // `x` defined in outer scope must not link to `x` in nested function.
+                    let src = b"function outer() { let x = 1; function inner() { let x = 2; return x; } return x; }";
+                    let (nodes, edges) = extract(src);
+                    // 2 def nodes + 2 use nodes (one per `return x` site) all named "x".
+                    let defs_for_x: Vec<_> = nodes
+                        .iter()
+                        .filter(|n| n.name.as_deref() == Some("x") && n.scope == DataScope::Local)
+                        .collect();
+                    assert_eq!(defs_for_x.len(), 4, "2 def + 2 use nodes for `x` expected");
+                    // Of those, exactly 2 are definitions (Local scope with no incoming edge
+                    // of the same name; we identify them by being earlier in source order).
+                    let defs: Vec<_> = nodes
+                        .iter()
+                        .filter(|n| {
+                            n.name.as_deref() == Some("x")
+                                && n.scope == DataScope::Local
+                                && !edges.iter().any(|e| e.target == n.id)
+                        })
+                        .collect();
+                    assert_eq!(defs.len(), 2, "two distinct `x` defs expected");
+
+                    // The use nodes anchor to the def in the same function scope.
+                    let use_nodes: Vec<_> = nodes
+                        .iter()
+                        .filter(|n| {
+                            n.name.as_deref() == Some("x")
+                                && n.scope == DataScope::Local
+                                && edges.iter().any(|e| e.target == n.id)
+                        })
+                        .collect();
+                    assert_eq!(use_nodes.len(), 2);
+
+                    let outer_def = defs
+                        .iter()
+                        .min_by_key(|n| n.source_range.byte_start)
+                        .unwrap();
+                    let inner_def = defs
+                        .iter()
+                        .max_by_key(|n| n.source_range.byte_start)
+                        .unwrap();
+                    let use_for_inner_x = use_nodes
+                        .iter()
+                        .min_by_key(|n| n.source_range.byte_start)
+                        .unwrap();
+                    let use_for_outer_x = use_nodes
+                        .iter()
+                        .max_by_key(|n| n.source_range.byte_start)
+                        .unwrap();
+                    let edge_for_inner = edges
+                        .iter()
+                        .find(|e| e.target == use_for_inner_x.id)
+                        .expect("inner x-use must have an edge");
+                    let edge_for_outer = edges
+                        .iter()
+                        .find(|e| e.target == use_for_outer_x.id)
+                        .expect("outer x-use must have an edge");
+                    assert_eq!(
+                        edge_for_inner.source, inner_def.id,
+                        "inner use must bind to inner def"
+                    );
+                    assert_eq!(
+                        edge_for_outer.source, outer_def.id,
+                        "outer use must bind to outer def"
+                    );
+                    assert_ne!(edge_for_inner.source, edge_for_outer.source);
+                }
+
+                #[test]
+                fn arrow_function_creates_new_scope() {
+                    // `x` inside the arrow must not link to outer `x`.
+                    let src = b"function outer() { let x = 1; const f = () => { let x = 2; return x; }; return x; }";
+                    let (_nodes, edges) = extract(src);
+                    // Just ensure no panic and that the implementation respects arrow scopes.
+                    // We can't easily distinguish edges from text alone; rely on non-emptiness
+                    // and absence of panics.
+                    assert!(!edges.is_empty());
+                }
+
+                #[test]
+                fn no_edges_for_undefined_names() {
+                    let src = b"function f() { return undefinedSymbol; }";
+                    let (_nodes, edges) = extract(src);
+                    assert!(edges.is_empty(), "unresolved identifiers produce no edges");
+                }
+
+                #[test]
+                fn empty_function_yields_no_nodes() {
+                    let src = b"function f() {}";
+                    let (nodes, edges) = extract(src);
+                    assert!(nodes.is_empty());
+                    assert!(edges.is_empty());
+                }
+
+                #[test]
+                fn dataflow_against_fixture_file() {
+                    // Oracle against the shared JS fixture: must extract nodes and edges.
+                    let src = std::fs::read_to_string(
+                        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                            .join("tests/fixtures/javascript/functions.js"),
+                    )
+                    .unwrap();
+                    let (nodes, edges) = extract(src.as_bytes());
+                    assert!(!nodes.is_empty(), "fixture must yield data nodes");
+                    assert!(!edges.is_empty(), "fixture must yield flow edges");
+                    // Every flow edge must be anchored in a real node.
+                    let ids: std::collections::HashSet<_> = nodes.iter().map(|n| n.id).collect();
+                    for edge in &edges {
+                        assert!(ids.contains(&edge.source));
+                        assert!(ids.contains(&edge.target));
+                    }
+                }
+
+                #[test]
+                fn def_use_pairs_follow_the_nearest_preceding_definition() {
+                    // Two functions declare their own `x`: a use must never link to a
+                    // definition in the other function, and the nearest preceding
+                    // definition wins inside one function.
+                    let src = b"function f() { let x = 1; let x = x + 1; return x; }\nfunction g() { let x = 9; return x; }";
+                    let (nodes, edges) = extract(src);
+                    assert_eq!(nodes.len(), 6, "three definitions and three uses");
+                    assert_eq!(edges.len(), 3, "one edge per use site");
+
+                    let span = |id| {
+                        let node = nodes.iter().find(|node| node.id == id).unwrap();
+                        (
+                            node.name.clone().unwrap_or_default(),
+                            node.source_range.byte_start,
+                        )
+                    };
+
+                    let mut definitions = std::collections::BTreeSet::new();
+                    for edge in &edges {
+                        let (def_name, def_start) = span(edge.source);
+                        let (use_name, use_start) = span(edge.target);
+                        assert_eq!(def_name, use_name, "a def-use edge keeps the name");
+                        assert!(
+                            def_start < use_start,
+                            "a definition precedes its use: {def_start} against {use_start}"
+                        );
+                        definitions.insert(def_start);
+                    }
+                    assert_eq!(
+                        definitions.len(),
+                        2,
+                        "two definitions feed the three uses: {definitions:?}"
+                    );
+
+                    // `function g(` starts the second scope; uses and definitions must
+                    // sit on the same side of that boundary.
+                    let boundary = src
+                        .windows(b"function g(".len())
+                        .position(|window| window == b"function g(")
+                        .unwrap();
+                    for edge in &edges {
+                        let def_start = span(edge.source).1;
+                        let use_start = span(edge.target).1;
+                        assert_eq!(
+                            def_start > boundary,
+                            use_start > boundary,
+                            "a use links within its own function: {def_start} and {use_start}"
+                        );
+                    }
+                }
+            }
+    },
+);
 
 // ── Dataflow extraction ─────────────────────────────────────────────
 
@@ -218,7 +609,7 @@ pub(crate) fn extract_js_family_dataflow_with_query(
 }
 
 #[cfg(feature = "dataflow")]
-static JS_DATAFLOW_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
+static JS_DATAFLOW_QUERY: std::sync::LazyLock<tree_sitter::Query> = std::sync::LazyLock::new(|| {
     crate::language::common::compile_query(
         &tree_sitter_javascript::LANGUAGE.into(),
         JS_DATAFLOW_QUERY_STR,
@@ -244,374 +635,4 @@ pub fn extract_javascript_dataflow(
         JS_FUNCTION_KINDS,
         id_gen,
     )
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::language::{LangId, extract_symbols_for, grammar_for};
-    use crate::model::{SymbolKind, Visibility};
-
-    fn parse(source: &[u8]) -> tree_sitter::Tree {
-        let mut parser = tree_sitter::Parser::new();
-        parser
-            .set_language(&grammar_for(LangId::JavaScript))
-            .unwrap();
-        parser.parse(source, None).unwrap()
-    }
-
-    #[test]
-    fn extract_function_declaration() {
-        let src = b"function hello() {}";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::JavaScript, &tree, src);
-        assert_eq!(symbols.len(), 1);
-        assert_eq!(symbols[0].name, "hello");
-        assert!(matches!(symbols[0].kind, SymbolKind::Function));
-    }
-
-    #[test]
-    fn extract_async_function() {
-        let src = b"async function fetch() {}";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::JavaScript, &tree, src);
-        assert_eq!(symbols.len(), 1);
-        assert!(symbols[0].is_async);
-    }
-
-    #[test]
-    fn extract_class_and_methods() {
-        let src = b"class Foo {\n  constructor() {}\n  bar() {}\n}";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::JavaScript, &tree, src);
-        let class = symbols.iter().find(|s| s.name == "Foo").unwrap();
-        assert!(matches!(class.kind, SymbolKind::Class));
-        let methods: Vec<_> = symbols
-            .iter()
-            .filter(|s| matches!(s.kind, SymbolKind::Method))
-            .collect();
-        assert_eq!(methods.len(), 2);
-    }
-
-    #[test]
-    fn extract_exported_class() {
-        let src = b"export class Foo { bar() {} }";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::JavaScript, &tree, src);
-        let class = symbols.iter().find(|s| s.name == "Foo").unwrap();
-        assert_eq!(class.visibility, Some(Visibility::Public));
-    }
-
-    #[test]
-    fn extract_named_imports() {
-        use crate::language::extract_imports_and_references_for;
-        let src = b"import { foo, bar } from 'utils';";
-        let tree = parse(src);
-        let (imports, _, _) = extract_imports_and_references_for(
-            LangId::JavaScript,
-            &tree,
-            src,
-            &std::path::PathBuf::from("test.js"),
-        );
-        let named: Vec<_> = imports.iter().filter(|i| i.symbol.is_some()).collect();
-        assert_eq!(
-            named.len(),
-            2,
-            "expected 2 named import records for foo and bar"
-        );
-        for imp in &named {
-            assert_eq!(imp.import_specifier, "utils");
-        }
-        assert_eq!(named[0].symbol.as_deref(), Some("foo"));
-        assert_eq!(named[1].symbol.as_deref(), Some("bar"));
-    }
-
-    #[test]
-    fn extract_default_import() {
-        use crate::language::extract_imports_and_references_for;
-        let src = b"import React from 'react';";
-        let tree = parse(src);
-        let (imports, _, _) = extract_imports_and_references_for(
-            LangId::JavaScript,
-            &tree,
-            src,
-            &std::path::PathBuf::from("test.js"),
-        );
-        let named: Vec<_> = imports.iter().filter(|i| i.symbol.is_some()).collect();
-        assert_eq!(named.len(), 1);
-        assert_eq!(named[0].import_specifier, "react");
-        assert_eq!(named[0].symbol.as_deref(), Some("React"));
-    }
-
-    #[test]
-    fn extract_side_effect_import() {
-        use crate::language::extract_imports_and_references_for;
-        let src = b"import 'styles.css';";
-        let tree = parse(src);
-        let (imports, _, _) = extract_imports_and_references_for(
-            LangId::JavaScript,
-            &tree,
-            src,
-            &std::path::PathBuf::from("test.js"),
-        );
-        assert_eq!(imports.len(), 1);
-        assert_eq!(imports[0].import_specifier, "styles.css");
-        assert!(imports[0].symbol.is_none());
-    }
-
-    #[test]
-    fn js_docstring_extraction() {
-        let src = b"/** JSDoc comment. */\nfunction documented() {}";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::JavaScript, &tree, src);
-        let func = symbols.iter().find(|s| s.name == "documented").unwrap();
-        assert!(func.docstring.is_some(), "documented should have docstring");
-        assert!(func.docstring.as_ref().unwrap().contains("JSDoc comment"));
-    }
-
-    fn symbol_names(symbols: &[crate::language::RawSymbol<'_>]) -> Vec<String> {
-        symbols.iter().map(|s| s.name.to_string()).collect()
-    }
-
-    #[test]
-    fn extract_arrow_function_assigned_to_const() {
-        let src = b"const compute = (a, b) => a + b;";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::JavaScript, &tree, src);
-        let found = symbols.iter().find(|s| s.name == "compute");
-        assert!(
-            found.is_some(),
-            "missing compute: {:?}",
-            symbol_names(&symbols)
-        );
-        let found = found.unwrap();
-        assert!(matches!(found.kind, SymbolKind::Function));
-        assert_eq!(found.signature.as_deref(), Some("(a, b)"));
-    }
-
-    #[test]
-    fn extract_exported_async_arrow_function() {
-        let src = b"export const handler = async () => {};";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::JavaScript, &tree, src);
-        let found = symbols.iter().find(|s| s.name == "handler");
-        assert!(
-            found.is_some(),
-            "missing handler: {:?}",
-            symbol_names(&symbols)
-        );
-        let found = found.unwrap();
-        assert!(matches!(found.kind, SymbolKind::Function));
-        assert!(found.is_async);
-        assert_eq!(found.visibility, Some(Visibility::Public));
-    }
-
-    #[test]
-    fn extract_function_expression_assigned_to_const() {
-        let src = b"const greet = function inner(x) { return x; };";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::JavaScript, &tree, src);
-        let found = symbols.iter().find(|s| s.name == "greet");
-        assert!(
-            found.is_some(),
-            "missing greet: {:?}",
-            symbol_names(&symbols)
-        );
-        assert!(!symbols.iter().any(|s| s.name == "inner"));
-        assert_eq!(found.unwrap().signature.as_deref(), Some("(x)"));
-    }
-
-    #[test]
-    fn js_insta_snapshot() {
-        let src = std::fs::read_to_string(
-            std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-                .join("tests/fixtures/javascript/functions.js"),
-        )
-        .unwrap();
-        let tree = parse(src.as_bytes());
-        let symbols = extract_symbols_for(LangId::JavaScript, &tree, src.as_bytes());
-        insta::assert_json_snapshot!(symbols);
-    }
-
-    #[cfg(feature = "dataflow")]
-    mod dataflow_tests {
-        use super::*;
-        use crate::language::javascript::extract_javascript_dataflow;
-        use crate::model::{DataScope, FlowKind};
-
-        fn extract(source: &[u8]) -> (Vec<crate::model::DataNode>, Vec<crate::model::FlowEdge>) {
-            let id_gen = crate::model::IdGenerator::new();
-            extract_javascript_dataflow(&parse(source), source, &id_gen)
-        }
-
-        #[test]
-        fn const_declaration_captured_as_local() {
-            let src = b"function f() { const x = 42; return x; }";
-            let (nodes, _) = extract(src);
-            let x = nodes
-                .iter()
-                .find(|n| n.name.as_deref() == Some("x") && n.scope == DataScope::Local)
-                .expect("const x should be captured as Local");
-            assert_eq!(x.scope, DataScope::Local);
-        }
-
-        #[test]
-        fn function_parameter_captured_as_parameter() {
-            let src = b"function add(a, b) { return a + b; }";
-            let (nodes, edges) = extract(src);
-            let params: Vec<_> = nodes
-                .iter()
-                .filter(|n| n.scope == DataScope::Parameter)
-                .collect();
-            assert_eq!(params.len(), 2, "expected 2 parameters");
-            let names: Vec<_> = params.iter().map(|n| n.name.as_deref()).collect();
-            assert!(names.contains(&Some("a")));
-            assert!(names.contains(&Some("b")));
-            assert!(
-                !edges.is_empty(),
-                "parameter usages should produce def-use edges"
-            );
-            for edge in &edges {
-                assert_eq!(edge.kind, FlowKind::DefUse);
-                assert!(
-                    (edge.confidence - 0.9).abs() < f32::EPSILON,
-                    "confidence should be 0.9, got {}",
-                    edge.confidence
-                );
-            }
-        }
-
-        #[test]
-        fn def_use_edge_anchored_in_graph() {
-            // Each flow edge's target must reference a real data node id.
-            let src = b"function f() { let x = 1; let y = x; }";
-            let (nodes, edges) = extract(src);
-            let ids: std::collections::HashSet<_> = nodes.iter().map(|n| n.id).collect();
-            for edge in &edges {
-                assert!(
-                    ids.contains(&edge.source),
-                    "edge source {:?} not in nodes",
-                    edge.source
-                );
-                assert!(
-                    ids.contains(&edge.target),
-                    "edge target {:?} not in nodes (dangling edge)",
-                    edge.target
-                );
-            }
-        }
-
-        #[test]
-        fn no_cross_function_def_use_leak() {
-            // `x` defined in outer scope must not link to `x` in nested function.
-            let src = b"function outer() { let x = 1; function inner() { let x = 2; return x; } return x; }";
-            let (nodes, edges) = extract(src);
-            // 2 def nodes + 2 use nodes (one per `return x` site) all named "x".
-            let defs_for_x: Vec<_> = nodes
-                .iter()
-                .filter(|n| n.name.as_deref() == Some("x") && n.scope == DataScope::Local)
-                .collect();
-            assert_eq!(defs_for_x.len(), 4, "2 def + 2 use nodes for `x` expected");
-            // Of those, exactly 2 are definitions (Local scope with no incoming edge
-            // of the same name; we identify them by being earlier in source order).
-            let defs: Vec<_> = nodes
-                .iter()
-                .filter(|n| {
-                    n.name.as_deref() == Some("x")
-                        && n.scope == DataScope::Local
-                        && !edges.iter().any(|e| e.target == n.id)
-                })
-                .collect();
-            assert_eq!(defs.len(), 2, "two distinct `x` defs expected");
-
-            // The use nodes anchor to the def in the same function scope.
-            let use_nodes: Vec<_> = nodes
-                .iter()
-                .filter(|n| {
-                    n.name.as_deref() == Some("x")
-                        && n.scope == DataScope::Local
-                        && edges.iter().any(|e| e.target == n.id)
-                })
-                .collect();
-            assert_eq!(use_nodes.len(), 2);
-
-            let outer_def = defs
-                .iter()
-                .min_by_key(|n| n.source_range.byte_start)
-                .unwrap();
-            let inner_def = defs
-                .iter()
-                .max_by_key(|n| n.source_range.byte_start)
-                .unwrap();
-            let use_for_inner_x = use_nodes
-                .iter()
-                .min_by_key(|n| n.source_range.byte_start)
-                .unwrap();
-            let use_for_outer_x = use_nodes
-                .iter()
-                .max_by_key(|n| n.source_range.byte_start)
-                .unwrap();
-            let edge_for_inner = edges
-                .iter()
-                .find(|e| e.target == use_for_inner_x.id)
-                .expect("inner x-use must have an edge");
-            let edge_for_outer = edges
-                .iter()
-                .find(|e| e.target == use_for_outer_x.id)
-                .expect("outer x-use must have an edge");
-            assert_eq!(
-                edge_for_inner.source, inner_def.id,
-                "inner use must bind to inner def"
-            );
-            assert_eq!(
-                edge_for_outer.source, outer_def.id,
-                "outer use must bind to outer def"
-            );
-            assert_ne!(edge_for_inner.source, edge_for_outer.source);
-        }
-
-        #[test]
-        fn arrow_function_creates_new_scope() {
-            // `x` inside the arrow must not link to outer `x`.
-            let src = b"function outer() { let x = 1; const f = () => { let x = 2; return x; }; return x; }";
-            let (_nodes, edges) = extract(src);
-            // Just ensure no panic and that the implementation respects arrow scopes.
-            // We can't easily distinguish edges from text alone; rely on non-emptiness
-            // and absence of panics.
-            assert!(!edges.is_empty());
-        }
-
-        #[test]
-        fn no_edges_for_undefined_names() {
-            let src = b"function f() { return undefinedSymbol; }";
-            let (_nodes, edges) = extract(src);
-            assert!(edges.is_empty(), "unresolved identifiers produce no edges");
-        }
-
-        #[test]
-        fn empty_function_yields_no_nodes() {
-            let src = b"function f() {}";
-            let (nodes, edges) = extract(src);
-            assert!(nodes.is_empty());
-            assert!(edges.is_empty());
-        }
-
-        #[test]
-        fn dataflow_against_fixture_file() {
-            // Oracle against the shared JS fixture: must extract nodes and edges.
-            let src = std::fs::read_to_string(
-                std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-                    .join("tests/fixtures/javascript/functions.js"),
-            )
-            .unwrap();
-            let (nodes, edges) = extract(src.as_bytes());
-            assert!(!nodes.is_empty(), "fixture must yield data nodes");
-            assert!(!edges.is_empty(), "fixture must yield flow edges");
-            // Every flow edge must be anchored in a real node.
-            let ids: std::collections::HashSet<_> = nodes.iter().map(|n| n.id).collect();
-            for edge in &edges {
-                assert!(ids.contains(&edge.source));
-                assert!(ids.contains(&edge.target));
-            }
-        }
-    }
 }

--- a/src/language/javascript.rs
+++ b/src/language/javascript.rs
@@ -609,13 +609,14 @@ pub(crate) fn extract_js_family_dataflow_with_query(
 }
 
 #[cfg(feature = "dataflow")]
-static JS_DATAFLOW_QUERY: std::sync::LazyLock<tree_sitter::Query> = std::sync::LazyLock::new(|| {
-    crate::language::common::compile_query(
-        &tree_sitter_javascript::LANGUAGE.into(),
-        JS_DATAFLOW_QUERY_STR,
-        "JavaScript dataflow",
-    )
-});
+static JS_DATAFLOW_QUERY: std::sync::LazyLock<tree_sitter::Query> =
+    std::sync::LazyLock::new(|| {
+        crate::language::common::compile_query(
+            &tree_sitter_javascript::LANGUAGE.into(),
+            JS_DATAFLOW_QUERY_STR,
+            "JavaScript dataflow",
+        )
+    });
 
 /// JavaScript AST node kinds that introduce a new intra-procedural scope.
 #[cfg(feature = "dataflow")]

--- a/src/language/mod.rs
+++ b/src/language/mod.rs
@@ -13,6 +13,7 @@ pub(crate) mod dataflow;
 pub(crate) mod go;
 pub mod import_resolver;
 pub(crate) mod javascript;
+pub(crate) mod pack;
 pub(crate) mod python;
 pub(crate) mod ruby;
 pub(crate) mod rust;
@@ -358,5 +359,190 @@ mod tests {
         assert_eq!(LangId::Rust.metacall_tag(), "rs");
         assert_eq!(LangId::Go.metacall_tag(), "go");
         assert_eq!(LangId::Ruby.metacall_tag(), "rb");
+    }
+
+    /// The pack declarations keep this surface when a macro owns them:
+    /// extensions, visibility defaults, doc comment rules and the node kinds
+    /// each extraction step keys on.
+    #[test]
+    fn specs_keep_their_documented_surface() {
+        struct Expected {
+            extensions: &'static [&'static str],
+            default_visibility: DefaultVisibility,
+            doc_prefixes: Option<&'static [&'static str]>,
+            doc_block_open: Option<&'static str>,
+            class_like_parents: &'static [&'static str],
+            ancestor_rules: usize,
+            import_kinds: &'static [&'static str],
+            visibility_from_name: bool,
+        }
+
+        let public = DefaultVisibility::PublicByDefault;
+        let private = DefaultVisibility::PrivateByDefault;
+        let cases: [(LangId, Expected); 9] = [
+            (
+                LangId::Python,
+                Expected {
+                    extensions: &["py", "pyi"],
+                    default_visibility: public,
+                    doc_prefixes: None,
+                    doc_block_open: None,
+                    class_like_parents: &["class_definition"],
+                    ancestor_rules: 0,
+                    import_kinds: &["import_statement", "import_from_statement"],
+                    visibility_from_name: false,
+                },
+            ),
+            (
+                LangId::JavaScript,
+                Expected {
+                    extensions: &["js", "mjs", "cjs"],
+                    default_visibility: private,
+                    doc_prefixes: Some(&["//"]),
+                    doc_block_open: Some("/**"),
+                    class_like_parents: &["class_declaration", "class"],
+                    ancestor_rules: 1,
+                    import_kinds: &["import_statement"],
+                    visibility_from_name: false,
+                },
+            ),
+            (
+                LangId::TypeScript,
+                Expected {
+                    extensions: &["ts", "cts", "mts"],
+                    default_visibility: private,
+                    doc_prefixes: Some(&["//"]),
+                    doc_block_open: Some("/**"),
+                    class_like_parents: &["class_declaration", "class"],
+                    ancestor_rules: 1,
+                    import_kinds: &["import_statement"],
+                    visibility_from_name: false,
+                },
+            ),
+            (
+                LangId::Tsx,
+                Expected {
+                    extensions: &["tsx"],
+                    default_visibility: private,
+                    doc_prefixes: Some(&["//"]),
+                    doc_block_open: Some("/**"),
+                    class_like_parents: &["class_declaration", "class"],
+                    ancestor_rules: 1,
+                    import_kinds: &["import_statement"],
+                    visibility_from_name: false,
+                },
+            ),
+            (
+                LangId::C,
+                Expected {
+                    extensions: &["c", "h"],
+                    default_visibility: public,
+                    doc_prefixes: Some(&["//"]),
+                    doc_block_open: Some("/**"),
+                    class_like_parents: &[],
+                    ancestor_rules: 0,
+                    import_kinds: &["preproc_include"],
+                    visibility_from_name: false,
+                },
+            ),
+            (
+                LangId::Cpp,
+                Expected {
+                    extensions: &["cc", "cpp", "cxx", "hpp"],
+                    default_visibility: private,
+                    doc_prefixes: Some(&["//"]),
+                    doc_block_open: Some("/**"),
+                    class_like_parents: &["class_specifier", "struct_specifier"],
+                    ancestor_rules: 0,
+                    import_kinds: &["preproc_include"],
+                    visibility_from_name: false,
+                },
+            ),
+            (
+                LangId::Rust,
+                Expected {
+                    extensions: &["rs"],
+                    default_visibility: private,
+                    doc_prefixes: Some(&["///", "//!"]),
+                    doc_block_open: Some("/**"),
+                    class_like_parents: &["impl_item"],
+                    ancestor_rules: 0,
+                    import_kinds: &["use_declaration"],
+                    visibility_from_name: false,
+                },
+            ),
+            (
+                LangId::Go,
+                Expected {
+                    extensions: &["go"],
+                    default_visibility: private,
+                    doc_prefixes: Some(&["//"]),
+                    doc_block_open: None,
+                    class_like_parents: &[],
+                    ancestor_rules: 0,
+                    import_kinds: &["import_declaration"],
+                    visibility_from_name: true,
+                },
+            ),
+            (
+                LangId::Ruby,
+                Expected {
+                    extensions: &["rb", "gemspec"],
+                    default_visibility: public,
+                    doc_prefixes: Some(&["#"]),
+                    doc_block_open: None,
+                    class_like_parents: &["class", "module"],
+                    ancestor_rules: 0,
+                    import_kinds: &[],
+                    visibility_from_name: false,
+                },
+            ),
+        ];
+
+        for (lang, want) in cases {
+            let spec = spec_for(lang);
+            assert_eq!(spec.extensions, want.extensions, "{lang:?} extensions");
+            assert_eq!(
+                spec.default_visibility, want.default_visibility,
+                "{lang:?} default visibility"
+            );
+            assert_eq!(
+                spec.class_like_parents, want.class_like_parents,
+                "{lang:?} class-like parents"
+            );
+            assert_eq!(
+                spec.ancestor_visibility_rules.len(),
+                want.ancestor_rules,
+                "{lang:?} ancestor visibility rules"
+            );
+            assert_eq!(
+                spec.import_statement_kinds, want.import_kinds,
+                "{lang:?} import statement kinds"
+            );
+            assert_eq!(
+                spec.visibility_from_name.is_some(),
+                want.visibility_from_name,
+                "{lang:?} name-based visibility"
+            );
+            match (spec.doc_comment_config.as_ref(), want.doc_prefixes) {
+                (None, None) => {}
+                (Some(config), Some(prefixes)) => {
+                    assert_eq!(config.line_prefixes, prefixes, "{lang:?} doc prefixes");
+                    assert_eq!(
+                        config.block_open, want.doc_block_open,
+                        "{lang:?} doc block opener"
+                    );
+                }
+                (config, prefixes) => panic!(
+                    "{lang:?} doc comment configuration mismatch: {config:?} against {prefixes:?}"
+                ),
+            }
+        }
+
+        let rule = spec_for(LangId::Go).visibility_from_name;
+        assert!(rule.is_some(), "Go derives visibility from the name");
+        let rule = rule.unwrap();
+        assert_eq!(rule("Exported"), Some(Visibility::Public));
+        assert_eq!(rule("hidden"), None);
     }
 }

--- a/src/language/pack.rs
+++ b/src/language/pack.rs
@@ -1,0 +1,118 @@
+//! One macro that declares a language pack.
+//!
+//! Nine packs repeat the same wiring: a compiled symbol query, a compiled
+//! import and reference query, an accessor for each, the `LanguageSpec`
+//! literal and a test module that parses one fixture and snapshots the
+//! extracted symbols. The macro owns that wiring, so a pack only carries what
+//! differs: its grammar, its query text, its resolver and its extraction rules.
+//!
+//! Invariant: the generated test module keeps the module path and the test
+//! name it is given. The `insta` snapshot file that pins a pack's extraction
+//! output is keyed by both, so renaming either moves the snapshot.
+
+/// Declares the queries, the spec and the test module of one language pack.
+///
+/// `symbols.query` holds the symbol query text and `imports_refs` names the
+/// import and reference query texts that are joined into one compiled query.
+/// `fixture` and `snapshot` name the pack's snapshot test; the optional
+/// `tests` group carries the pack's own tests, which land inside the generated
+/// test module next to the snapshot test.
+macro_rules! define_language_pack {
+    (
+        $(#[$spec_doc:meta])*
+        spec: $spec:ident,
+        label: $label:literal,
+        lang: $lang:expr,
+        grammar: $grammar:path,
+        extensions: [$($extension:literal),* $(,)?],
+        resolver: $resolver:path,
+        symbols: {
+            static: $symbols_static:ident,
+            accessor: $symbols_accessor:ident,
+            query: $symbols_query:expr $(,)?
+        },
+        imports_refs: {
+            static: $imports_refs_static:ident,
+            accessor: $imports_refs_accessor:ident,
+            import: $import_query:expr,
+            reference: $reference_query:expr $(,)?
+        },
+        import_statement_kinds: [$($import_kind:literal),* $(,)?],
+        class_like_parents: [$($class_like_parent:literal),* $(,)?],
+        ancestors: [$($ancestor:expr),* $(,)?],
+        visibility_from_name: $visibility_from_name:expr,
+        default_visibility: $default_visibility:expr,
+        doc_comment: $doc_comment:expr,
+        fixture: $fixture:literal,
+        snapshot: $snapshot:ident
+        $(, tests { $($pack_tests:tt)* })?
+        $(,)?
+    ) => {
+        static $symbols_static: ::std::sync::LazyLock<::tree_sitter::Query> =
+            ::std::sync::LazyLock::new(|| {
+                $crate::language::common::compile_query(
+                    &$grammar.into(),
+                    $symbols_query,
+                    $label,
+                )
+            });
+
+        fn $symbols_accessor() -> &'static ::tree_sitter::Query {
+            &$symbols_static
+        }
+
+        static $imports_refs_static: ::std::sync::LazyLock<::tree_sitter::Query> =
+            ::std::sync::LazyLock::new(|| {
+                $crate::language::common::compile_query(
+                    &$grammar.into(),
+                    &::std::format!("{}\n{}", $import_query, $reference_query),
+                    ::std::concat!($label, " combined import+ref"),
+                )
+            });
+
+        fn $imports_refs_accessor() -> &'static ::tree_sitter::Query {
+            &$imports_refs_static
+        }
+
+        $(#[$spec_doc])*
+        pub(crate) const $spec: $crate::language::LanguageSpec = $crate::language::LanguageSpec {
+            extensions: &[$($extension),*],
+            grammar_fn: || $grammar.into(),
+            query_fn: $symbols_accessor,
+            import_path_resolver: $resolver,
+            import_ref_query_fn: $imports_refs_accessor,
+            class_like_parents: &[$($class_like_parent),*],
+            ancestor_visibility_rules: &[$($ancestor),*],
+            visibility_from_name: $visibility_from_name,
+            import_statement_kinds: &[$($import_kind),*],
+            default_visibility: $default_visibility,
+            doc_comment_config: $doc_comment,
+        };
+
+        #[cfg(test)]
+        mod tests {
+            use $crate::language::{LangId, extract_symbols_for, grammar_for};
+
+            fn parse(source: &[u8]) -> ::tree_sitter::Tree {
+                let mut parser = ::tree_sitter::Parser::new();
+                parser.set_language(&grammar_for($lang)).unwrap();
+                parser.parse(source, None).unwrap()
+            }
+
+            #[test]
+            fn $snapshot() {
+                let source = ::std::fs::read_to_string(
+                    ::std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join($fixture),
+                )
+                .unwrap();
+                let tree = parse(source.as_bytes());
+                let symbols = extract_symbols_for($lang, &tree, source.as_bytes());
+                insta::assert_json_snapshot!(symbols);
+            }
+
+            $($($pack_tests)*)?
+        }
+    };
+}
+
+pub(crate) use define_language_pack;

--- a/src/language/python.rs
+++ b/src/language/python.rs
@@ -1,6 +1,6 @@
-use crate::language::{DefaultVisibility, LanguageSpec};
+use crate::language::DefaultVisibility;
+use crate::language::pack::define_language_pack;
 use std::path::{Path, PathBuf};
-use std::sync::LazyLock;
 
 fn resolve_python_import(raw: &str, source_dir: &Path, project_root: &Path) -> Option<PathBuf> {
     use crate::language::import_resolver::python_candidate_paths;
@@ -29,51 +29,6 @@ pub(crate) fn normalize_relative_specifier<'a>(
         Some(name) if !name.is_empty() => std::borrow::Cow::Owned(format!("{specifier}{name}")),
         _ => std::borrow::Cow::Borrowed(specifier),
     }
-}
-
-static PYTHON_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
-    crate::language::common::compile_query(
-        &tree_sitter_python::LANGUAGE.into(),
-        r#"
-(function_definition
-  "async"? @async
-  name: (identifier) @name
-  parameters: (parameters) @signature
-  body: (block (expression_statement (string) @docstring)?)
-) @kind.function
-
-(class_definition
-  name: (identifier) @name
-  body: (block (expression_statement (string) @docstring)?)
-) @kind.class
-
-(decorated_definition
-  definition: [
-    (function_definition
-      "async"? @async
-      name: (identifier) @name
-      parameters: (parameters) @signature
-      body: (block (expression_statement (string) @docstring)?)
-    ) @kind.function
-    (class_definition
-      name: (identifier) @name
-      body: (block (expression_statement (string) @docstring)?)
-    ) @kind.class
-  ]
-)
-
-(module
-  (expression_statement
-    (assignment
-      left: (identifier) @name) @kind.constant)
-)
-"#,
-        "Python",
-    )
-});
-
-fn python_query() -> &'static tree_sitter::Query {
-    &PYTHON_QUERY
 }
 
 const PYTHON_IMPORT_QUERY_STR: &str = r#"
@@ -111,39 +66,312 @@ const PYTHON_REFERENCE_QUERY_STR: &str = r#"
     attribute: (identifier) @reference.name))
 "#;
 
-static PYTHON_IMPORT_REF_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
-    crate::language::common::compile_query(
-        &tree_sitter_python::LANGUAGE.into(),
-        &format!(
-            "{}\n{}",
-            PYTHON_IMPORT_QUERY_STR, PYTHON_REFERENCE_QUERY_STR
-        ),
-        "Python combined import+ref",
-    )
-});
+define_language_pack!(
+    spec: PYTHON_SPEC,
+    label: "Python",
+    lang: LangId::Python,
+    grammar: tree_sitter_python::LANGUAGE,
+    extensions: ["py", "pyi"],
+    resolver: resolve_python_import,
+    symbols: {
+        static: PYTHON_QUERY,
+        accessor: python_query,
+        query: r#"
+(function_definition
+  "async"? @async
+  name: (identifier) @name
+  parameters: (parameters) @signature
+  body: (block (expression_statement (string) @docstring)?)
+) @kind.function
 
-fn python_import_ref_query() -> &'static tree_sitter::Query {
-    &PYTHON_IMPORT_REF_QUERY
-}
+(class_definition
+  name: (identifier) @name
+  body: (block (expression_statement (string) @docstring)?)
+) @kind.class
 
-pub(crate) const PYTHON_SPEC: LanguageSpec = LanguageSpec {
-    extensions: &["py", "pyi"],
-    grammar_fn: || tree_sitter_python::LANGUAGE.into(),
-    query_fn: python_query,
-    import_path_resolver: resolve_python_import,
-    import_ref_query_fn: python_import_ref_query,
-    class_like_parents: &["class_definition"],
-    ancestor_visibility_rules: &[],
+(decorated_definition
+  definition: [
+    (function_definition
+      "async"? @async
+      name: (identifier) @name
+      parameters: (parameters) @signature
+      body: (block (expression_statement (string) @docstring)?)
+    ) @kind.function
+    (class_definition
+      name: (identifier) @name
+      body: (block (expression_statement (string) @docstring)?)
+    ) @kind.class
+  ]
+)
+
+(module
+  (expression_statement
+    (assignment
+      left: (identifier) @name) @kind.constant)
+)
+"#,
+    },
+    imports_refs: {
+        static: PYTHON_IMPORT_REF_QUERY,
+        accessor: python_import_ref_query,
+        import: PYTHON_IMPORT_QUERY_STR,
+        reference: PYTHON_REFERENCE_QUERY_STR,
+    },
+    import_statement_kinds: ["import_statement", "import_from_statement"],
+    class_like_parents: ["class_definition"],
+    ancestors: [],
     visibility_from_name: None,
-    import_statement_kinds: &["import_statement", "import_from_statement"],
     default_visibility: DefaultVisibility::PublicByDefault,
-    doc_comment_config: None,
-};
+    doc_comment: None,
+    fixture: "tests/fixtures/python/simple_functions.py",
+    snapshot: python_insta_snapshot,
+    tests {
+            use crate::model::SymbolKind;
+
+
+            #[test]
+            fn python_grammar_loads() {
+                let _ = grammar_for(LangId::Python);
+            }
+
+            #[test]
+            fn extract_simple_function() {
+                let tree = parse(b"def hello(): pass");
+                let symbols = extract_symbols_for(LangId::Python, &tree, b"def hello(): pass");
+                assert_eq!(symbols.len(), 1);
+                assert_eq!(symbols[0].name, "hello");
+                assert!(matches!(symbols[0].kind, SymbolKind::Function));
+            }
+
+            #[test]
+            fn extract_async_function() {
+                let tree = parse(b"async def fetch(): pass");
+                let symbols = extract_symbols_for(LangId::Python, &tree, b"async def fetch(): pass");
+                assert_eq!(symbols.len(), 1);
+                assert!(symbols[0].is_async);
+            }
+
+            #[test]
+            fn extract_class_and_methods() {
+                let src =
+                    "class Foo:\n    def __init__(self):\n        pass\n    def bar(self):\n        pass\n";
+                let tree = parse(src.as_bytes());
+                let symbols = extract_symbols_for(LangId::Python, &tree, src.as_bytes());
+                let foo = symbols.iter().find(|s| s.name == "Foo").unwrap();
+                assert!(matches!(foo.kind, SymbolKind::Class));
+                let bar = symbols.iter().find(|s| s.name == "bar").unwrap();
+                assert!(matches!(bar.kind, SymbolKind::Method));
+            }
+
+            #[test]
+            fn extract_decorated_function() {
+                let src = "@decorator\ndef decorated_func(x):\n    return x * 2\n";
+                let tree = parse(src.as_bytes());
+                let symbols = extract_symbols_for(LangId::Python, &tree, src.as_bytes());
+                assert_eq!(symbols.len(), 1);
+                assert_eq!(symbols[0].name, "decorated_func");
+            }
+
+            #[test]
+            fn extract_function_with_docstring() {
+                let src = br#"def greet():
+            """Say hello."""
+            pass
+        "#;
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::Python, &tree, src);
+                assert_eq!(symbols.len(), 1);
+                assert_eq!(symbols[0].docstring.as_deref(), Some("Say hello."));
+            }
+
+            #[test]
+            fn docstring_does_not_eat_content_starting_with_quote() {
+                let src = br#"def f():
+            """"Quoted" at start."""
+            pass
+        "#;
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::Python, &tree, src);
+                assert_eq!(symbols.len(), 1);
+                let ds = symbols[0].docstring.as_deref().unwrap();
+                assert!(
+                    ds.starts_with('"'),
+                    "docstring content should start with a quote char, got: {ds:?}"
+                );
+                assert!(
+                    ds.contains("Quoted"),
+                    "docstring should contain 'Quoted', got: {ds:?}"
+                );
+            }
+
+            #[test]
+            fn docstring_does_not_eat_content_ending_with_quote() {
+                let src = br#"def f():
+            '''She said "hello"'''
+            pass
+        "#;
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::Python, &tree, src);
+                assert_eq!(symbols.len(), 1);
+                let ds = symbols[0].docstring.as_deref().unwrap();
+                assert!(
+                    ds.contains("hello"),
+                    "docstring should contain 'hello', got: {ds:?}"
+                );
+                assert!(
+                    ds.contains(r#"""#),
+                    "docstring should preserve inner double quotes, got: {ds:?}"
+                );
+            }
+
+            #[test]
+            fn docstring_multiline_strips_delimiters_not_content() {
+                let src = br#"def f():
+            """
+            She said "hi".
+            """
+            pass
+        "#;
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::Python, &tree, src);
+                assert_eq!(symbols.len(), 1);
+                let ds = symbols[0].docstring.as_deref().unwrap();
+                assert!(
+                    !ds.starts_with('"'),
+                    "docstring should not start with delimiter quote, got: {ds:?}"
+                );
+                assert!(
+                    ds.contains(r#""hi""#),
+                    "docstring should preserve inner quotes, got: {ds:?}"
+                );
+            }
+
+
+            #[cfg(feature = "dataflow")]
+            #[test]
+            fn python_dataflow_extracts_assignments_and_parameters() {
+                let src = b"def add(x, y):\n    result = x + y\n    return result\n";
+                let tree = parse(src);
+                let id_gen = crate::model::IdGenerator::new();
+                let (nodes, edges) = super::extract_python_dataflow(&tree, src, &id_gen);
+
+                let names: Vec<Option<&str>> = nodes.iter().map(|n| n.name.as_deref()).collect();
+                assert!(names.contains(&Some("x")));
+                assert!(names.contains(&Some("y")));
+                assert!(names.contains(&Some("result")));
+
+                assert!(!edges.is_empty(), "should extract def-use flow edges");
+                assert_eq!(edges[0].kind, crate::model::FlowKind::DefUse);
+            }
+
+            fn symbol_names(symbols: &[crate::language::RawSymbol<'_>]) -> Vec<String> {
+                symbols.iter().map(|s| s.name.to_string()).collect()
+            }
+
+            #[test]
+            fn module_level_assignment_is_a_constant() {
+                let src = b"MAX_RETRIES = 3\n";
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::Python, &tree, src);
+                let found = symbols.iter().find(|s| s.name == "MAX_RETRIES");
+                assert!(
+                    found.is_some(),
+                    "missing MAX_RETRIES: {:?}",
+                    symbol_names(&symbols)
+                );
+                assert!(matches!(found.unwrap().kind, SymbolKind::Constant));
+            }
+
+            #[test]
+            fn function_local_assignment_is_not_a_symbol() {
+                let src = b"def f():\n    local = 1\n";
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::Python, &tree, src);
+                assert!(!symbols.iter().any(|s| s.name == "local"));
+            }
+
+            #[test]
+            fn relative_import_with_bare_dot_is_captured() {
+                use crate::language::extract_imports_and_references_for;
+                let src = b"from . import util\n";
+                let tree = parse(src);
+                let (imports, _, _) = extract_imports_and_references_for(
+                    LangId::Python,
+                    &tree,
+                    src,
+                    std::path::Path::new("pkg/mod.py"),
+                );
+                assert_eq!(imports.len(), 1, "imports: {imports:?}");
+                assert_eq!(imports[0].import_specifier, ".");
+                assert_eq!(imports[0].symbol.as_deref(), Some("util"));
+            }
+
+            #[test]
+            fn relative_import_with_module_is_captured() {
+                use crate::language::extract_imports_and_references_for;
+                let src = b"from .util import helper\n";
+                let tree = parse(src);
+                let (imports, _, _) = extract_imports_and_references_for(
+                    LangId::Python,
+                    &tree,
+                    src,
+                    std::path::Path::new("pkg/mod.py"),
+                );
+                assert_eq!(imports.len(), 1, "imports: {imports:?}");
+                assert_eq!(imports[0].import_specifier, ".util");
+                assert_eq!(imports[0].symbol.as_deref(), Some("helper"));
+            }
+
+            #[test]
+            fn relative_parent_import_is_captured() {
+                use crate::language::extract_imports_and_references_for;
+                let src = b"from ..pkg.mod import baz\n";
+                let tree = parse(src);
+                let (imports, _, _) = extract_imports_and_references_for(
+                    LangId::Python,
+                    &tree,
+                    src,
+                    std::path::Path::new("pkg/mod.py"),
+                );
+                assert_eq!(imports.len(), 1, "imports: {imports:?}");
+                assert_eq!(imports[0].import_specifier, "..pkg.mod");
+            }
+
+            #[test]
+            fn aliased_from_import_is_recorded_once() {
+                use crate::language::extract_imports_and_references_for;
+                let src = b"from a.b import c as d\n";
+                let tree = parse(src);
+                let (imports, _, _) = extract_imports_and_references_for(
+                    LangId::Python,
+                    &tree,
+                    src,
+                    std::path::Path::new("pkg/mod.py"),
+                );
+                assert_eq!(imports.len(), 1, "imports: {imports:?}");
+                assert_eq!(imports[0].symbol.as_deref(), Some("c"));
+                assert_eq!(imports[0].alias.as_deref(), Some("d"));
+            }
+
+            #[cfg(feature = "dataflow")]
+            #[test]
+            fn python_dataflow_for_loop_assignment() {
+                let src = b"def calc():\n    total = 0\n    for i in items:\n        total += i\n";
+                let tree = parse(src);
+                let id_gen = crate::model::IdGenerator::new();
+                let (nodes, _edges) = super::extract_python_dataflow(&tree, src, &id_gen);
+
+                let names: Vec<Option<&str>> = nodes.iter().map(|n| n.name.as_deref()).collect();
+                assert!(names.contains(&Some("total")));
+                assert!(names.contains(&Some("i")));
+            }
+    },
+);
 
 // ── Dataflow extraction ─────────────────────────────────────────────
 
 #[cfg(feature = "dataflow")]
-static PYTHON_DATAFLOW_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
+static PYTHON_DATAFLOW_QUERY: std::sync::LazyLock<tree_sitter::Query> = std::sync::LazyLock::new(|| {
     crate::language::common::compile_query(
         &tree_sitter_python::LANGUAGE.into(),
         r#"
@@ -202,264 +430,4 @@ pub fn extract_python_dataflow(
         PYTHON_FUNCTION_KINDS,
         id_gen,
     )
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::language::{LangId, extract_symbols_for, grammar_for};
-    use crate::model::SymbolKind;
-
-    fn parse(source: &[u8]) -> tree_sitter::Tree {
-        let mut parser = tree_sitter::Parser::new();
-        parser.set_language(&grammar_for(LangId::Python)).unwrap();
-        parser.parse(source, None).unwrap()
-    }
-
-    #[test]
-    fn python_grammar_loads() {
-        let _ = grammar_for(LangId::Python);
-    }
-
-    #[test]
-    fn extract_simple_function() {
-        let tree = parse(b"def hello(): pass");
-        let symbols = extract_symbols_for(LangId::Python, &tree, b"def hello(): pass");
-        assert_eq!(symbols.len(), 1);
-        assert_eq!(symbols[0].name, "hello");
-        assert!(matches!(symbols[0].kind, SymbolKind::Function));
-    }
-
-    #[test]
-    fn extract_async_function() {
-        let tree = parse(b"async def fetch(): pass");
-        let symbols = extract_symbols_for(LangId::Python, &tree, b"async def fetch(): pass");
-        assert_eq!(symbols.len(), 1);
-        assert!(symbols[0].is_async);
-    }
-
-    #[test]
-    fn extract_class_and_methods() {
-        let src =
-            "class Foo:\n    def __init__(self):\n        pass\n    def bar(self):\n        pass\n";
-        let tree = parse(src.as_bytes());
-        let symbols = extract_symbols_for(LangId::Python, &tree, src.as_bytes());
-        let foo = symbols.iter().find(|s| s.name == "Foo").unwrap();
-        assert!(matches!(foo.kind, SymbolKind::Class));
-        let bar = symbols.iter().find(|s| s.name == "bar").unwrap();
-        assert!(matches!(bar.kind, SymbolKind::Method));
-    }
-
-    #[test]
-    fn extract_decorated_function() {
-        let src = "@decorator\ndef decorated_func(x):\n    return x * 2\n";
-        let tree = parse(src.as_bytes());
-        let symbols = extract_symbols_for(LangId::Python, &tree, src.as_bytes());
-        assert_eq!(symbols.len(), 1);
-        assert_eq!(symbols[0].name, "decorated_func");
-    }
-
-    #[test]
-    fn extract_function_with_docstring() {
-        let src = br#"def greet():
-    """Say hello."""
-    pass
-"#;
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::Python, &tree, src);
-        assert_eq!(symbols.len(), 1);
-        assert_eq!(symbols[0].docstring.as_deref(), Some("Say hello."));
-    }
-
-    #[test]
-    fn docstring_does_not_eat_content_starting_with_quote() {
-        let src = br#"def f():
-    """"Quoted" at start."""
-    pass
-"#;
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::Python, &tree, src);
-        assert_eq!(symbols.len(), 1);
-        let ds = symbols[0].docstring.as_deref().unwrap();
-        assert!(
-            ds.starts_with('"'),
-            "docstring content should start with a quote char, got: {ds:?}"
-        );
-        assert!(
-            ds.contains("Quoted"),
-            "docstring should contain 'Quoted', got: {ds:?}"
-        );
-    }
-
-    #[test]
-    fn docstring_does_not_eat_content_ending_with_quote() {
-        let src = br#"def f():
-    '''She said "hello"'''
-    pass
-"#;
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::Python, &tree, src);
-        assert_eq!(symbols.len(), 1);
-        let ds = symbols[0].docstring.as_deref().unwrap();
-        assert!(
-            ds.contains("hello"),
-            "docstring should contain 'hello', got: {ds:?}"
-        );
-        assert!(
-            ds.contains(r#"""#),
-            "docstring should preserve inner double quotes, got: {ds:?}"
-        );
-    }
-
-    #[test]
-    fn docstring_multiline_strips_delimiters_not_content() {
-        let src = br#"def f():
-    """
-    She said "hi".
-    """
-    pass
-"#;
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::Python, &tree, src);
-        assert_eq!(symbols.len(), 1);
-        let ds = symbols[0].docstring.as_deref().unwrap();
-        assert!(
-            !ds.starts_with('"'),
-            "docstring should not start with delimiter quote, got: {ds:?}"
-        );
-        assert!(
-            ds.contains(r#""hi""#),
-            "docstring should preserve inner quotes, got: {ds:?}"
-        );
-    }
-
-    #[test]
-    fn python_insta_snapshot() {
-        let src = std::fs::read_to_string(
-            std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-                .join("tests/fixtures/python/simple_functions.py"),
-        )
-        .unwrap();
-        let tree = parse(src.as_bytes());
-        let symbols = extract_symbols_for(LangId::Python, &tree, src.as_bytes());
-        insta::assert_json_snapshot!(symbols);
-    }
-
-    #[cfg(feature = "dataflow")]
-    #[test]
-    fn python_dataflow_extracts_assignments_and_parameters() {
-        let src = b"def add(x, y):\n    result = x + y\n    return result\n";
-        let tree = parse(src);
-        let id_gen = crate::model::IdGenerator::new();
-        let (nodes, edges) = super::extract_python_dataflow(&tree, src, &id_gen);
-
-        let names: Vec<Option<&str>> = nodes.iter().map(|n| n.name.as_deref()).collect();
-        assert!(names.contains(&Some("x")));
-        assert!(names.contains(&Some("y")));
-        assert!(names.contains(&Some("result")));
-
-        assert!(!edges.is_empty(), "should extract def-use flow edges");
-        assert_eq!(edges[0].kind, crate::model::FlowKind::DefUse);
-    }
-
-    fn symbol_names(symbols: &[crate::language::RawSymbol<'_>]) -> Vec<String> {
-        symbols.iter().map(|s| s.name.to_string()).collect()
-    }
-
-    #[test]
-    fn module_level_assignment_is_a_constant() {
-        let src = b"MAX_RETRIES = 3\n";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::Python, &tree, src);
-        let found = symbols.iter().find(|s| s.name == "MAX_RETRIES");
-        assert!(
-            found.is_some(),
-            "missing MAX_RETRIES: {:?}",
-            symbol_names(&symbols)
-        );
-        assert!(matches!(found.unwrap().kind, SymbolKind::Constant));
-    }
-
-    #[test]
-    fn function_local_assignment_is_not_a_symbol() {
-        let src = b"def f():\n    local = 1\n";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::Python, &tree, src);
-        assert!(!symbols.iter().any(|s| s.name == "local"));
-    }
-
-    #[test]
-    fn relative_import_with_bare_dot_is_captured() {
-        use crate::language::extract_imports_and_references_for;
-        let src = b"from . import util\n";
-        let tree = parse(src);
-        let (imports, _, _) = extract_imports_and_references_for(
-            LangId::Python,
-            &tree,
-            src,
-            std::path::Path::new("pkg/mod.py"),
-        );
-        assert_eq!(imports.len(), 1, "imports: {imports:?}");
-        assert_eq!(imports[0].import_specifier, ".");
-        assert_eq!(imports[0].symbol.as_deref(), Some("util"));
-    }
-
-    #[test]
-    fn relative_import_with_module_is_captured() {
-        use crate::language::extract_imports_and_references_for;
-        let src = b"from .util import helper\n";
-        let tree = parse(src);
-        let (imports, _, _) = extract_imports_and_references_for(
-            LangId::Python,
-            &tree,
-            src,
-            std::path::Path::new("pkg/mod.py"),
-        );
-        assert_eq!(imports.len(), 1, "imports: {imports:?}");
-        assert_eq!(imports[0].import_specifier, ".util");
-        assert_eq!(imports[0].symbol.as_deref(), Some("helper"));
-    }
-
-    #[test]
-    fn relative_parent_import_is_captured() {
-        use crate::language::extract_imports_and_references_for;
-        let src = b"from ..pkg.mod import baz\n";
-        let tree = parse(src);
-        let (imports, _, _) = extract_imports_and_references_for(
-            LangId::Python,
-            &tree,
-            src,
-            std::path::Path::new("pkg/mod.py"),
-        );
-        assert_eq!(imports.len(), 1, "imports: {imports:?}");
-        assert_eq!(imports[0].import_specifier, "..pkg.mod");
-    }
-
-    #[test]
-    fn aliased_from_import_is_recorded_once() {
-        use crate::language::extract_imports_and_references_for;
-        let src = b"from a.b import c as d\n";
-        let tree = parse(src);
-        let (imports, _, _) = extract_imports_and_references_for(
-            LangId::Python,
-            &tree,
-            src,
-            std::path::Path::new("pkg/mod.py"),
-        );
-        assert_eq!(imports.len(), 1, "imports: {imports:?}");
-        assert_eq!(imports[0].symbol.as_deref(), Some("c"));
-        assert_eq!(imports[0].alias.as_deref(), Some("d"));
-    }
-
-    #[cfg(feature = "dataflow")]
-    #[test]
-    fn python_dataflow_for_loop_assignment() {
-        let src = b"def calc():\n    total = 0\n    for i in items:\n        total += i\n";
-        let tree = parse(src);
-        let id_gen = crate::model::IdGenerator::new();
-        let (nodes, _edges) = super::extract_python_dataflow(&tree, src, &id_gen);
-
-        let names: Vec<Option<&str>> = nodes.iter().map(|n| n.name.as_deref()).collect();
-        assert!(names.contains(&Some("total")));
-        assert!(names.contains(&Some("i")));
-    }
 }

--- a/src/language/python.rs
+++ b/src/language/python.rs
@@ -371,10 +371,11 @@ define_language_pack!(
 // ── Dataflow extraction ─────────────────────────────────────────────
 
 #[cfg(feature = "dataflow")]
-static PYTHON_DATAFLOW_QUERY: std::sync::LazyLock<tree_sitter::Query> = std::sync::LazyLock::new(|| {
-    crate::language::common::compile_query(
-        &tree_sitter_python::LANGUAGE.into(),
-        r#"
+static PYTHON_DATAFLOW_QUERY: std::sync::LazyLock<tree_sitter::Query> =
+    std::sync::LazyLock::new(|| {
+        crate::language::common::compile_query(
+            &tree_sitter_python::LANGUAGE.into(),
+            r#"
 ; Assignments
 (assignment
   left: (identifier) @def.var)
@@ -408,9 +409,9 @@ static PYTHON_DATAFLOW_QUERY: std::sync::LazyLock<tree_sitter::Query> = std::syn
 (subscript
   value: (identifier) @use.var)
 "#,
-        "Python dataflow",
-    )
-});
+            "Python dataflow",
+        )
+    });
 
 /// Python AST node kinds that introduce a new intra-procedural scope.
 #[cfg(feature = "dataflow")]

--- a/src/language/ruby.rs
+++ b/src/language/ruby.rs
@@ -15,9 +15,9 @@
 //! - `attr_reader`, `alias`, `include`, and `extend` are not handled.
 //! - Extension-less `Gemfile` and `Rakefile` are not detected.
 
-use crate::language::{DefaultVisibility, DocCommentConfig, LanguageSpec};
+use crate::language::pack::define_language_pack;
+use crate::language::{DefaultVisibility, DocCommentConfig};
 use std::path::{Path, PathBuf};
-use std::sync::LazyLock;
 
 fn resolve_ruby_candidate(path: PathBuf) -> Option<PathBuf> {
     if path.is_file() {
@@ -55,10 +55,36 @@ fn resolve_ruby_import(raw: &str, source_dir: &Path, project_root: &Path) -> Opt
     Some(PathBuf::from(raw))
 }
 
-static RUBY_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
-    crate::language::common::compile_query(
-        &tree_sitter_ruby::LANGUAGE.into(),
-        r#"
+const RUBY_IMPORT_QUERY_STR: &str = r#"
+(call
+  method: (identifier) @import.method
+  arguments: (argument_list . (string) @import.path .)
+  (#match? @import.method "^(require|require_relative)$"))
+"#;
+
+const RUBY_REFERENCE_QUERY_STR: &str = r#"
+(call
+  method: (identifier) @reference.name
+  (#not-match? @reference.name "^(require|require_relative)$"))
+(call
+  receiver: (constant) @reference.name)
+(call
+  receiver: (scope_resolution) @reference.name)
+(scope_resolution
+  name: (constant) @reference.name)
+"#;
+
+define_language_pack!(
+    spec: RUBY_SPEC,
+    label: "Ruby",
+    lang: LangId::Ruby,
+    grammar: tree_sitter_ruby::LANGUAGE,
+    extensions: ["rb", "gemspec"],
+    resolver: resolve_ruby_import,
+    symbols: {
+        static: RUBY_QUERY,
+        accessor: ruby_query,
+        query: r#"
 (method
   name: (identifier) @name
   parameters: (method_parameters)? @signature
@@ -81,231 +107,174 @@ static RUBY_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
   left: (constant) @name
 ) @kind.constant
 "#,
-        "Ruby",
-    )
-});
-
-const RUBY_IMPORT_QUERY_STR: &str = r#"
-(call
-  method: (identifier) @import.method
-  arguments: (argument_list . (string) @import.path .)
-  (#match? @import.method "^(require|require_relative)$"))
-"#;
-
-const RUBY_REFERENCE_QUERY_STR: &str = r#"
-(call
-  method: (identifier) @reference.name
-  (#not-match? @reference.name "^(require|require_relative)$"))
-(call
-  receiver: (constant) @reference.name)
-(call
-  receiver: (scope_resolution) @reference.name)
-(scope_resolution
-  name: (constant) @reference.name)
-"#;
-
-static RUBY_IMPORT_REF_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
-    crate::language::common::compile_query(
-        &tree_sitter_ruby::LANGUAGE.into(),
-        &format!("{}\n{}", RUBY_IMPORT_QUERY_STR, RUBY_REFERENCE_QUERY_STR),
-        "Ruby combined import+ref",
-    )
-});
-
-fn ruby_query() -> &'static tree_sitter::Query {
-    &RUBY_QUERY
-}
-
-fn ruby_import_ref_query() -> &'static tree_sitter::Query {
-    &RUBY_IMPORT_REF_QUERY
-}
-
-pub(crate) const RUBY_SPEC: LanguageSpec = LanguageSpec {
-    extensions: &["rb", "gemspec"],
-    grammar_fn: || tree_sitter_ruby::LANGUAGE.into(),
-    query_fn: ruby_query,
-    import_path_resolver: resolve_ruby_import,
-    import_ref_query_fn: ruby_import_ref_query,
-    class_like_parents: &["class", "module"],
-    ancestor_visibility_rules: &[],
+    },
+    imports_refs: {
+        static: RUBY_IMPORT_REF_QUERY,
+        accessor: ruby_import_ref_query,
+        import: RUBY_IMPORT_QUERY_STR,
+        reference: RUBY_REFERENCE_QUERY_STR,
+    },
+    import_statement_kinds: [],
+    class_like_parents: ["class", "module"],
+    ancestors: [],
     visibility_from_name: None,
-    import_statement_kinds: &[],
     default_visibility: DefaultVisibility::PublicByDefault,
-    doc_comment_config: Some(DocCommentConfig {
+    doc_comment: Some(DocCommentConfig {
         line_prefixes: &["#"],
         block_open: None,
         block_close: "",
         strip_continuation_marker: false,
     }),
-};
+    fixture: "tests/fixtures/ruby/classes_and_modules.rb",
+    snapshot: ruby_insta_snapshot,
+    tests {
+        use crate::language::extract_imports_and_references_for;
+            use crate::model::SymbolKind;
+            use std::path::PathBuf;
 
-#[cfg(test)]
-mod tests {
-    use crate::language::{
-        LangId, extract_imports_and_references_for, extract_symbols_for, grammar_for,
-    };
-    use crate::model::SymbolKind;
-    use std::path::PathBuf;
 
-    fn parse(source: &[u8]) -> tree_sitter::Tree {
-        let mut parser = tree_sitter::Parser::new();
-        parser.set_language(&grammar_for(LangId::Ruby)).unwrap();
-        parser.parse(source, None).unwrap()
-    }
+            #[test]
+            fn ruby_grammar_loads() {
+                let _ = grammar_for(LangId::Ruby);
+            }
 
-    #[test]
-    fn ruby_grammar_loads() {
-        let _ = grammar_for(LangId::Ruby);
-    }
+            #[test]
+            fn extract_method_with_signature() {
+                let src = b"def greet(name)\n  \"hi #{name}\"\nend";
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::Ruby, &tree, src);
+                assert_eq!(symbols.len(), 1);
+                assert_eq!(symbols[0].name, "greet");
+                assert!(matches!(symbols[0].kind, SymbolKind::Function));
+                assert!(symbols[0].signature.as_deref().unwrap().contains("(name)"));
+            }
 
-    #[test]
-    fn extract_method_with_signature() {
-        let src = b"def greet(name)\n  \"hi #{name}\"\nend";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::Ruby, &tree, src);
-        assert_eq!(symbols.len(), 1);
-        assert_eq!(symbols[0].name, "greet");
-        assert!(matches!(symbols[0].kind, SymbolKind::Function));
-        assert!(symbols[0].signature.as_deref().unwrap().contains("(name)"));
-    }
+            #[test]
+            fn extract_singleton_method() {
+                let src = b"class Calc\n  def self.square(x)\n    x * x\n  end\nend";
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::Ruby, &tree, src);
+                let square = symbols.iter().find(|s| s.name == "square").unwrap();
+                assert!(matches!(square.kind, SymbolKind::Method));
+            }
 
-    #[test]
-    fn extract_singleton_method() {
-        let src = b"class Calc\n  def self.square(x)\n    x * x\n  end\nend";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::Ruby, &tree, src);
-        let square = symbols.iter().find(|s| s.name == "square").unwrap();
-        assert!(matches!(square.kind, SymbolKind::Method));
-    }
+            #[test]
+            fn extract_class_and_module() {
+                let src = b"module Util\n  class Helper\n  end\nend";
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::Ruby, &tree, src);
+                let util = symbols.iter().find(|s| s.name == "Util").unwrap();
+                assert!(matches!(util.kind, SymbolKind::Module));
+                let helper = symbols.iter().find(|s| s.name == "Helper").unwrap();
+                assert!(matches!(helper.kind, SymbolKind::Class));
+            }
 
-    #[test]
-    fn extract_class_and_module() {
-        let src = b"module Util\n  class Helper\n  end\nend";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::Ruby, &tree, src);
-        let util = symbols.iter().find(|s| s.name == "Util").unwrap();
-        assert!(matches!(util.kind, SymbolKind::Module));
-        let helper = symbols.iter().find(|s| s.name == "Helper").unwrap();
-        assert!(matches!(helper.kind, SymbolKind::Class));
-    }
+            #[test]
+            fn extract_method_promoted_inside_class() {
+                let src = b"class Foo\n  def bar\n  end\nend";
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::Ruby, &tree, src);
+                let bar = symbols.iter().find(|s| s.name == "bar").unwrap();
+                assert!(matches!(bar.kind, SymbolKind::Method));
+            }
 
-    #[test]
-    fn extract_method_promoted_inside_class() {
-        let src = b"class Foo\n  def bar\n  end\nend";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::Ruby, &tree, src);
-        let bar = symbols.iter().find(|s| s.name == "bar").unwrap();
-        assert!(matches!(bar.kind, SymbolKind::Method));
-    }
+            #[test]
+            fn extract_constant_assignment() {
+                let src = b"MAX_SIZE = 1024";
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::Ruby, &tree, src);
+                assert_eq!(symbols.len(), 1);
+                assert_eq!(symbols[0].name, "MAX_SIZE");
+                assert!(matches!(symbols[0].kind, SymbolKind::Constant));
+            }
 
-    #[test]
-    fn extract_constant_assignment() {
-        let src = b"MAX_SIZE = 1024";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::Ruby, &tree, src);
-        assert_eq!(symbols.len(), 1);
-        assert_eq!(symbols[0].name, "MAX_SIZE");
-        assert!(matches!(symbols[0].kind, SymbolKind::Constant));
-    }
+            #[test]
+            fn extract_docstring_from_comment() {
+                let src = b"# Adds two numbers.\ndef add(a, b)\n  a + b\nend";
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::Ruby, &tree, src);
+                let add = symbols.iter().find(|s| s.name == "add").unwrap();
+                assert!(
+                    add.docstring
+                        .as_deref()
+                        .unwrap()
+                        .contains("Adds two numbers.")
+                );
+            }
 
-    #[test]
-    fn extract_docstring_from_comment() {
-        let src = b"# Adds two numbers.\ndef add(a, b)\n  a + b\nend";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::Ruby, &tree, src);
-        let add = symbols.iter().find(|s| s.name == "add").unwrap();
-        assert!(
-            add.docstring
-                .as_deref()
-                .unwrap()
-                .contains("Adds two numbers.")
-        );
-    }
+            #[test]
+            fn extract_require_import() {
+                let src = b"require 'json'";
+                let tree = parse(src);
+                let (imports, _, _) =
+                    extract_imports_and_references_for(LangId::Ruby, &tree, src, &PathBuf::from("test.rb"));
+                assert_eq!(imports.len(), 1);
+                assert_eq!(imports[0].import_specifier, "json");
+                assert!(imports[0].symbol.is_none());
+            }
 
-    #[test]
-    fn extract_require_import() {
-        let src = b"require 'json'";
-        let tree = parse(src);
-        let (imports, _, _) =
-            extract_imports_and_references_for(LangId::Ruby, &tree, src, &PathBuf::from("test.rb"));
-        assert_eq!(imports.len(), 1);
-        assert_eq!(imports[0].import_specifier, "json");
-        assert!(imports[0].symbol.is_none());
-    }
+            #[test]
+            fn extract_require_relative_import() {
+                let src = b"require_relative './helper'";
+                let tree = parse(src);
+                let (imports, _, _) =
+                    extract_imports_and_references_for(LangId::Ruby, &tree, src, &PathBuf::from("test.rb"));
+                assert_eq!(imports.len(), 1);
+                assert_eq!(imports[0].import_specifier, "./helper");
+            }
 
-    #[test]
-    fn extract_require_relative_import() {
-        let src = b"require_relative './helper'";
-        let tree = parse(src);
-        let (imports, _, _) =
-            extract_imports_and_references_for(LangId::Ruby, &tree, src, &PathBuf::from("test.rb"));
-        assert_eq!(imports.len(), 1);
-        assert_eq!(imports[0].import_specifier, "./helper");
-    }
+            #[test]
+            fn require_calls_do_not_leak_as_references() {
+                let src = b"require 'json'\nputs 'hi'";
+                let tree = parse(src);
+                let (imports, references, _) =
+                    extract_imports_and_references_for(LangId::Ruby, &tree, src, &PathBuf::from("test.rb"));
+                assert_eq!(imports.len(), 1);
+                assert!(references.iter().any(|r| r.name == "puts"));
+                assert!(!references.iter().any(|r| r.name == "require"));
+            }
 
-    #[test]
-    fn require_calls_do_not_leak_as_references() {
-        let src = b"require 'json'\nputs 'hi'";
-        let tree = parse(src);
-        let (imports, references, _) =
-            extract_imports_and_references_for(LangId::Ruby, &tree, src, &PathBuf::from("test.rb"));
-        assert_eq!(imports.len(), 1);
-        assert!(references.iter().any(|r| r.name == "puts"));
-        assert!(!references.iter().any(|r| r.name == "require"));
-    }
+            #[test]
+            fn extract_bare_call_reference() {
+                let src = b"calc_total(items)";
+                let tree = parse(src);
+                let (_, references, _) =
+                    extract_imports_and_references_for(LangId::Ruby, &tree, src, &PathBuf::from("test.rb"));
+                assert!(references.iter().any(|r| r.name == "calc_total"));
+            }
 
-    #[test]
-    fn extract_bare_call_reference() {
-        let src = b"calc_total(items)";
-        let tree = parse(src);
-        let (_, references, _) =
-            extract_imports_and_references_for(LangId::Ruby, &tree, src, &PathBuf::from("test.rb"));
-        assert!(references.iter().any(|r| r.name == "calc_total"));
-    }
+            #[test]
+            fn extract_constant_receiver_reference() {
+                let src = b"Math.sqrt(4)";
+                let tree = parse(src);
+                let (_, references, _) =
+                    extract_imports_and_references_for(LangId::Ruby, &tree, src, &PathBuf::from("test.rb"));
+                assert!(references.iter().any(|r| r.name == "Math"));
+                assert!(references.iter().any(|r| r.name == "sqrt"));
+            }
 
-    #[test]
-    fn extract_constant_receiver_reference() {
-        let src = b"Math.sqrt(4)";
-        let tree = parse(src);
-        let (_, references, _) =
-            extract_imports_and_references_for(LangId::Ruby, &tree, src, &PathBuf::from("test.rb"));
-        assert!(references.iter().any(|r| r.name == "Math"));
-        assert!(references.iter().any(|r| r.name == "sqrt"));
-    }
+            #[test]
+            fn resolve_ruby_import_bare_gem_name() {
+                let source_dir = PathBuf::from("/tmp/src");
+                let project_root = PathBuf::from("/tmp/project");
+                let result = super::resolve_ruby_import("json", &source_dir, &project_root);
+                assert_eq!(result, Some(PathBuf::from("json")));
+            }
 
-    #[test]
-    fn resolve_ruby_import_bare_gem_name() {
-        let source_dir = PathBuf::from("/tmp/src");
-        let project_root = PathBuf::from("/tmp/project");
-        let result = super::resolve_ruby_import("json", &source_dir, &project_root);
-        assert_eq!(result, Some(PathBuf::from("json")));
-    }
-
-    #[test]
-    fn resolve_ruby_import_relative_joins_source_dir() {
-        let source_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/ruby");
-        let project_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        let result =
-            super::resolve_ruby_import("./classes_and_modules", &source_dir, &project_root);
-        assert_eq!(
-            result,
-            Some(
-                source_dir
-                    .join("./classes_and_modules")
-                    .with_extension("rb")
-            )
-        );
-    }
-
-    #[test]
-    fn ruby_insta_snapshot() {
-        let src = std::fs::read_to_string(
-            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-                .join("tests/fixtures/ruby/classes_and_modules.rb"),
-        )
-        .unwrap();
-        let tree = parse(src.as_bytes());
-        let symbols = extract_symbols_for(LangId::Ruby, &tree, src.as_bytes());
-        insta::assert_json_snapshot!(symbols);
-    }
-}
+            #[test]
+            fn resolve_ruby_import_relative_joins_source_dir() {
+                let source_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/ruby");
+                let project_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+                let result =
+                    super::resolve_ruby_import("./classes_and_modules", &source_dir, &project_root);
+                assert_eq!(
+                    result,
+                    Some(
+                        source_dir
+                            .join("./classes_and_modules")
+                            .with_extension("rb")
+                    )
+                );
+            }
+    },
+);

--- a/src/language/rust.rs
+++ b/src/language/rust.rs
@@ -303,10 +303,11 @@ define_language_pack!(
 // ── Dataflow extraction ─────────────────────────────────────────────
 
 #[cfg(feature = "dataflow")]
-static RUST_DATAFLOW_QUERY: std::sync::LazyLock<tree_sitter::Query> = std::sync::LazyLock::new(|| {
-    crate::language::common::compile_query(
-        &tree_sitter_rust::LANGUAGE.into(),
-        r#"
+static RUST_DATAFLOW_QUERY: std::sync::LazyLock<tree_sitter::Query> =
+    std::sync::LazyLock::new(|| {
+        crate::language::common::compile_query(
+            &tree_sitter_rust::LANGUAGE.into(),
+            r#"
 ; Let binding definitions: let x = expr;
 (let_declaration
   pattern: (identifier) @def.var
@@ -338,9 +339,9 @@ static RUST_DATAFLOW_QUERY: std::sync::LazyLock<tree_sitter::Query> = std::sync:
 (field_expression
   value: (identifier) @use.var)
 "#,
-        "Rust dataflow",
-    )
-});
+            "Rust dataflow",
+        )
+    });
 
 /// Extract data nodes (definitions) and flow edges (def-use) from a Rust parse tree.
 ///

--- a/src/language/rust.rs
+++ b/src/language/rust.rs
@@ -1,6 +1,6 @@
-use crate::language::{DefaultVisibility, DocCommentConfig, LanguageSpec};
+use crate::language::pack::define_language_pack;
+use crate::language::{DefaultVisibility, DocCommentConfig};
 use std::path::{Path, PathBuf};
-use std::sync::LazyLock;
 
 /// Resolve a module path against a base directory.
 ///
@@ -58,10 +58,44 @@ fn resolve_rust_import(raw: &str, source_dir: &Path, project_root: &Path) -> Opt
     None
 }
 
-static RUST_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
-    crate::language::common::compile_query(
-        &tree_sitter_rust::LANGUAGE.into(),
-        r#"
+const RUST_IMPORT_QUERY_STR: &str = r#"
+(use_declaration
+  argument: (scoped_identifier) @import.path)
+(use_declaration
+  argument: (scoped_use_list
+    path: (scoped_identifier) @import.path))
+(use_as_clause
+  path: (_) @import.path
+  alias: (identifier) @import.alias)
+"#;
+
+const RUST_REFERENCE_QUERY_STR: &str = r#"
+(call_expression
+  function: (identifier) @reference.name)
+(call_expression
+  function: (scoped_identifier
+    name: (identifier) @reference.name))
+(call_expression
+  function: (field_expression
+    field: (field_identifier) @reference.name))
+(call_expression
+  function: (field_expression
+    value: (identifier) @reference.name))
+(macro_invocation
+  macro: (identifier) @reference.name)
+"#;
+
+define_language_pack!(
+    spec: RUST_SPEC,
+    label: "Rust",
+    lang: LangId::Rust,
+    grammar: tree_sitter_rust::LANGUAGE,
+    extensions: ["rs"],
+    resolver: resolve_rust_import,
+    symbols: {
+        static: RUST_QUERY,
+        accessor: rust_query,
+        query: r#"
 (function_item
   (visibility_modifier)? @visibility.public
   (function_modifiers "async"? @async)?
@@ -104,76 +138,172 @@ static RUST_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
   name: (identifier) @name
 ) @kind.module
 "#,
-        "Rust",
-    )
-});
-
-fn rust_query() -> &'static tree_sitter::Query {
-    &RUST_QUERY
-}
-
-const RUST_IMPORT_QUERY_STR: &str = r#"
-(use_declaration
-  argument: (scoped_identifier) @import.path)
-(use_declaration
-  argument: (scoped_use_list
-    path: (scoped_identifier) @import.path))
-(use_as_clause
-  path: (_) @import.path
-  alias: (identifier) @import.alias)
-"#;
-
-const RUST_REFERENCE_QUERY_STR: &str = r#"
-(call_expression
-  function: (identifier) @reference.name)
-(call_expression
-  function: (scoped_identifier
-    name: (identifier) @reference.name))
-(call_expression
-  function: (field_expression
-    field: (field_identifier) @reference.name))
-(call_expression
-  function: (field_expression
-    value: (identifier) @reference.name))
-(macro_invocation
-  macro: (identifier) @reference.name)
-"#;
-
-static RUST_IMPORT_REF_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
-    crate::language::common::compile_query(
-        &tree_sitter_rust::LANGUAGE.into(),
-        &format!("{}\n{}", RUST_IMPORT_QUERY_STR, RUST_REFERENCE_QUERY_STR),
-        "Rust combined import+ref",
-    )
-});
-
-fn rust_import_ref_query() -> &'static tree_sitter::Query {
-    &RUST_IMPORT_REF_QUERY
-}
-
-pub(crate) const RUST_SPEC: LanguageSpec = LanguageSpec {
-    extensions: &["rs"],
-    grammar_fn: || tree_sitter_rust::LANGUAGE.into(),
-    query_fn: rust_query,
-    import_path_resolver: resolve_rust_import,
-    import_ref_query_fn: rust_import_ref_query,
-    class_like_parents: &["impl_item"],
-    ancestor_visibility_rules: &[],
+    },
+    imports_refs: {
+        static: RUST_IMPORT_REF_QUERY,
+        accessor: rust_import_ref_query,
+        import: RUST_IMPORT_QUERY_STR,
+        reference: RUST_REFERENCE_QUERY_STR,
+    },
+    import_statement_kinds: ["use_declaration"],
+    class_like_parents: ["impl_item"],
+    ancestors: [],
     visibility_from_name: None,
-    import_statement_kinds: &["use_declaration"],
     default_visibility: DefaultVisibility::PrivateByDefault,
-    doc_comment_config: Some(DocCommentConfig {
+    doc_comment: Some(DocCommentConfig {
         line_prefixes: &["///", "//!"],
         block_open: Some("/**"),
         block_close: "*/",
         strip_continuation_marker: true,
     }),
-};
+    fixture: "tests/fixtures/rust/structs_enums.rs",
+    snapshot: rust_insta_snapshot,
+    tests {
+            use crate::model::{SymbolKind, Visibility};
+
+
+            #[test]
+            fn extract_function() {
+                let src = b"fn hello() {}";
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::Rust, &tree, src);
+                assert_eq!(symbols.len(), 1);
+                assert_eq!(symbols[0].name, "hello");
+                assert!(matches!(symbols[0].kind, SymbolKind::Function));
+            }
+
+            #[test]
+            fn extract_pub_function() {
+                let src = b"pub fn hello() {}";
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::Rust, &tree, src);
+                assert_eq!(symbols.len(), 1);
+                assert_eq!(symbols[0].visibility, Some(Visibility::Public));
+            }
+
+            #[test]
+            fn extract_async_function() {
+                let src = b"async fn fetch() {}";
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::Rust, &tree, src);
+                assert_eq!(symbols.len(), 1);
+                assert!(symbols[0].is_async);
+            }
+
+            #[test]
+            fn extract_struct() {
+                let src = b"struct Point { x: f64, y: f64 }";
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::Rust, &tree, src);
+                assert_eq!(symbols.len(), 1);
+                assert_eq!(symbols[0].name, "Point");
+                assert!(matches!(symbols[0].kind, SymbolKind::Struct));
+            }
+
+            #[test]
+            fn pub_crate_is_not_public() {
+                let src = b"pub(crate) fn internal() {}";
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::Rust, &tree, src);
+                assert_eq!(symbols.len(), 1);
+                assert_ne!(symbols[0].visibility, Some(Visibility::Public));
+            }
+
+            #[test]
+            fn pub_super_is_not_public() {
+                let src = b"pub(super) fn internal() {}";
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::Rust, &tree, src);
+                assert_eq!(symbols.len(), 1);
+                assert_ne!(symbols[0].visibility, Some(Visibility::Public));
+            }
+
+            #[test]
+            fn pub_in_path_is_not_public() {
+                let src = b"pub(in crate::foo) fn internal() {}";
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::Rust, &tree, src);
+                assert_eq!(symbols.len(), 1);
+                assert_ne!(symbols[0].visibility, Some(Visibility::Public));
+            }
+
+            #[test]
+            fn pub_crate_struct_is_not_public() {
+                let src = b"pub(crate) struct Internal {}";
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::Rust, &tree, src);
+                assert_eq!(symbols.len(), 1);
+                assert_ne!(symbols[0].visibility, Some(Visibility::Public));
+            }
+
+            #[test]
+            fn bare_pub_function_is_public() {
+                let src = b"pub fn hello() {}";
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::Rust, &tree, src);
+                assert_eq!(symbols.len(), 1);
+                assert_eq!(symbols[0].visibility, Some(Visibility::Public));
+            }
+
+            #[test]
+            fn extract_impl_methods() {
+                let src = b"impl Foo { fn bar(&self) {} }";
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::Rust, &tree, src);
+                let bar = symbols.iter().find(|s| s.name == "bar").unwrap();
+                assert!(matches!(bar.kind, SymbolKind::Method));
+            }
+
+
+            #[test]
+            fn rust_docstring_extraction() {
+                let src = br#"/// This is a doc comment.
+        /// It has two lines.
+        pub fn documented_func() {}
+
+        //! Module-level doc comment.
+
+        /// Single line doc.
+        pub struct DocumentedStruct;
+        "#;
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::Rust, &tree, src);
+
+                let func = symbols
+                    .iter()
+                    .find(|s| s.name == "documented_func")
+                    .unwrap();
+                assert!(
+                    func.docstring.is_some(),
+                    "documented_func should have docstring"
+                );
+                let ds = func.docstring.as_ref().unwrap();
+                assert!(
+                    ds.contains("This is a doc comment"),
+                    "docstring should contain first line, got: {ds}"
+                );
+                assert!(
+                    ds.contains("It has two lines"),
+                    "docstring should contain second line, got: {ds}"
+                );
+
+                let st = symbols
+                    .iter()
+                    .find(|s| s.name == "DocumentedStruct")
+                    .unwrap();
+                assert!(
+                    st.docstring.is_some(),
+                    "DocumentedStruct should have docstring"
+                );
+                assert!(st.docstring.as_ref().unwrap().contains("Single line doc"));
+            }
+    },
+);
 
 // ── Dataflow extraction ─────────────────────────────────────────────
 
 #[cfg(feature = "dataflow")]
-static RUST_DATAFLOW_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
+static RUST_DATAFLOW_QUERY: std::sync::LazyLock<tree_sitter::Query> = std::sync::LazyLock::new(|| {
     crate::language::common::compile_query(
         &tree_sitter_rust::LANGUAGE.into(),
         r#"
@@ -316,164 +446,5 @@ mod dataflow_tests {
         let (nodes, edges) = extract(source);
         assert!(nodes.is_empty());
         assert!(edges.is_empty());
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::language::{LangId, extract_symbols_for, grammar_for};
-    use crate::model::{SymbolKind, Visibility};
-
-    fn parse(source: &[u8]) -> tree_sitter::Tree {
-        let mut parser = tree_sitter::Parser::new();
-        parser.set_language(&grammar_for(LangId::Rust)).unwrap();
-        parser.parse(source, None).unwrap()
-    }
-
-    #[test]
-    fn extract_function() {
-        let src = b"fn hello() {}";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::Rust, &tree, src);
-        assert_eq!(symbols.len(), 1);
-        assert_eq!(symbols[0].name, "hello");
-        assert!(matches!(symbols[0].kind, SymbolKind::Function));
-    }
-
-    #[test]
-    fn extract_pub_function() {
-        let src = b"pub fn hello() {}";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::Rust, &tree, src);
-        assert_eq!(symbols.len(), 1);
-        assert_eq!(symbols[0].visibility, Some(Visibility::Public));
-    }
-
-    #[test]
-    fn extract_async_function() {
-        let src = b"async fn fetch() {}";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::Rust, &tree, src);
-        assert_eq!(symbols.len(), 1);
-        assert!(symbols[0].is_async);
-    }
-
-    #[test]
-    fn extract_struct() {
-        let src = b"struct Point { x: f64, y: f64 }";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::Rust, &tree, src);
-        assert_eq!(symbols.len(), 1);
-        assert_eq!(symbols[0].name, "Point");
-        assert!(matches!(symbols[0].kind, SymbolKind::Struct));
-    }
-
-    #[test]
-    fn pub_crate_is_not_public() {
-        let src = b"pub(crate) fn internal() {}";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::Rust, &tree, src);
-        assert_eq!(symbols.len(), 1);
-        assert_ne!(symbols[0].visibility, Some(Visibility::Public));
-    }
-
-    #[test]
-    fn pub_super_is_not_public() {
-        let src = b"pub(super) fn internal() {}";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::Rust, &tree, src);
-        assert_eq!(symbols.len(), 1);
-        assert_ne!(symbols[0].visibility, Some(Visibility::Public));
-    }
-
-    #[test]
-    fn pub_in_path_is_not_public() {
-        let src = b"pub(in crate::foo) fn internal() {}";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::Rust, &tree, src);
-        assert_eq!(symbols.len(), 1);
-        assert_ne!(symbols[0].visibility, Some(Visibility::Public));
-    }
-
-    #[test]
-    fn pub_crate_struct_is_not_public() {
-        let src = b"pub(crate) struct Internal {}";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::Rust, &tree, src);
-        assert_eq!(symbols.len(), 1);
-        assert_ne!(symbols[0].visibility, Some(Visibility::Public));
-    }
-
-    #[test]
-    fn bare_pub_function_is_public() {
-        let src = b"pub fn hello() {}";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::Rust, &tree, src);
-        assert_eq!(symbols.len(), 1);
-        assert_eq!(symbols[0].visibility, Some(Visibility::Public));
-    }
-
-    #[test]
-    fn extract_impl_methods() {
-        let src = b"impl Foo { fn bar(&self) {} }";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::Rust, &tree, src);
-        let bar = symbols.iter().find(|s| s.name == "bar").unwrap();
-        assert!(matches!(bar.kind, SymbolKind::Method));
-    }
-
-    #[test]
-    fn rust_insta_snapshot() {
-        let src = std::fs::read_to_string(
-            std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-                .join("tests/fixtures/rust/structs_enums.rs"),
-        )
-        .unwrap();
-        let tree = parse(src.as_bytes());
-        let symbols = extract_symbols_for(LangId::Rust, &tree, src.as_bytes());
-        insta::assert_json_snapshot!(symbols);
-    }
-
-    #[test]
-    fn rust_docstring_extraction() {
-        let src = br#"/// This is a doc comment.
-/// It has two lines.
-pub fn documented_func() {}
-
-//! Module-level doc comment.
-
-/// Single line doc.
-pub struct DocumentedStruct;
-"#;
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::Rust, &tree, src);
-
-        let func = symbols
-            .iter()
-            .find(|s| s.name == "documented_func")
-            .unwrap();
-        assert!(
-            func.docstring.is_some(),
-            "documented_func should have docstring"
-        );
-        let ds = func.docstring.as_ref().unwrap();
-        assert!(
-            ds.contains("This is a doc comment"),
-            "docstring should contain first line, got: {ds}"
-        );
-        assert!(
-            ds.contains("It has two lines"),
-            "docstring should contain second line, got: {ds}"
-        );
-
-        let st = symbols
-            .iter()
-            .find(|s| s.name == "DocumentedStruct")
-            .unwrap();
-        assert!(
-            st.docstring.is_some(),
-            "DocumentedStruct should have docstring"
-        );
-        assert!(st.docstring.as_ref().unwrap().contains("Single line doc"));
     }
 }

--- a/src/language/tsx.rs
+++ b/src/language/tsx.rs
@@ -194,13 +194,14 @@ define_language_pack!(
 // ── Dataflow extraction ─────────────────────────────────────────────
 
 #[cfg(feature = "dataflow")]
-static TSX_DATAFLOW_QUERY: std::sync::LazyLock<tree_sitter::Query> = std::sync::LazyLock::new(|| {
-    crate::language::common::compile_query(
-        &tree_sitter_typescript::LANGUAGE_TSX.into(),
-        crate::language::javascript::TS_FAMILY_DATAFLOW_QUERY,
-        "TSX dataflow",
-    )
-});
+static TSX_DATAFLOW_QUERY: std::sync::LazyLock<tree_sitter::Query> =
+    std::sync::LazyLock::new(|| {
+        crate::language::common::compile_query(
+            &tree_sitter_typescript::LANGUAGE_TSX.into(),
+            crate::language::javascript::TS_FAMILY_DATAFLOW_QUERY,
+            "TSX dataflow",
+        )
+    });
 
 /// TSX AST node kinds that introduce a new intra-procedural scope.
 #[cfg(feature = "dataflow")]

--- a/src/language/tsx.rs
+++ b/src/language/tsx.rs
@@ -1,10 +1,10 @@
+use crate::language::DefaultVisibility;
+use crate::language::pack::define_language_pack;
 use crate::language::typescript::{
     TS_FAMILY_IMPORT_QUERY, TS_FAMILY_QUERY, TS_FAMILY_REFERENCE_QUERY,
 };
-use crate::language::{DefaultVisibility, LanguageSpec};
 use crate::model::Visibility;
 use std::path::{Path, PathBuf};
-use std::sync::LazyLock;
 
 fn resolve_tsx_import(raw: &str, source_dir: &Path, _project_root: &Path) -> Option<PathBuf> {
     use crate::language::import_resolver::{TS_EXTS, resolve_js_family_import};
@@ -13,48 +13,188 @@ fn resolve_tsx_import(raw: &str, source_dir: &Path, _project_root: &Path) -> Opt
     resolve_js_family_import(raw, source_dir, TS_EXTS, &|p| p.is_file())
 }
 
-static TSX_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
-    crate::language::common::compile_query(
-        &tree_sitter_typescript::LANGUAGE_TSX.into(),
-        TS_FAMILY_QUERY,
-        "TSX",
-    )
-});
-
-static TSX_IMPORT_REF_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
-    crate::language::common::compile_query(
-        &tree_sitter_typescript::LANGUAGE_TSX.into(),
-        &format!("{}\n{}", TS_FAMILY_IMPORT_QUERY, TS_FAMILY_REFERENCE_QUERY),
-        "TSX combined import+ref",
-    )
-});
-
-fn tsx_import_ref_query() -> &'static tree_sitter::Query {
-    &TSX_IMPORT_REF_QUERY
-}
-
-fn tsx_query() -> &'static tree_sitter::Query {
-    &TSX_QUERY
-}
-
-pub(crate) const TSX_SPEC: LanguageSpec = LanguageSpec {
-    extensions: &["tsx"],
-    grammar_fn: || tree_sitter_typescript::LANGUAGE_TSX.into(),
-    query_fn: tsx_query,
-    import_path_resolver: resolve_tsx_import,
-    import_ref_query_fn: tsx_import_ref_query,
-    class_like_parents: &["class_declaration", "class"],
-    ancestor_visibility_rules: &[("export_statement", Visibility::Public)],
+define_language_pack!(
+    spec: TSX_SPEC,
+    label: "TSX",
+    lang: LangId::Tsx,
+    grammar: tree_sitter_typescript::LANGUAGE_TSX,
+    extensions: ["tsx"],
+    resolver: resolve_tsx_import,
+    symbols: {
+        static: TSX_QUERY,
+        accessor: tsx_query,
+        query: TS_FAMILY_QUERY,
+    },
+    imports_refs: {
+        static: TSX_IMPORT_REF_QUERY,
+        accessor: tsx_import_ref_query,
+        import: TS_FAMILY_IMPORT_QUERY,
+        reference: TS_FAMILY_REFERENCE_QUERY,
+    },
+    import_statement_kinds: ["import_statement"],
+    class_like_parents: ["class_declaration", "class"],
+    ancestors: [("export_statement", Visibility::Public)],
     visibility_from_name: None,
-    import_statement_kinds: &["import_statement"],
     default_visibility: DefaultVisibility::PrivateByDefault,
-    doc_comment_config: Some(crate::language::C_LIKE_DOC_COMMENT),
-};
+    doc_comment: Some(crate::language::C_LIKE_DOC_COMMENT),
+    fixture: "tests/fixtures/tsx/components.tsx",
+    snapshot: tsx_insta_snapshot,
+    tests {
+            use crate::model::{SymbolKind, Visibility};
+
+
+            #[test]
+            fn extract_tsx_function() {
+                let src = b"function App(): JSX.Element { return <div/>; }";
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::Tsx, &tree, src);
+                assert_eq!(symbols.len(), 1);
+                assert_eq!(symbols[0].name, "App");
+                assert!(matches!(symbols[0].kind, SymbolKind::Function));
+            }
+
+            #[test]
+            fn extract_tsx_exported_class() {
+                let src = b"export class Foo extends React.Component { render() { return <div/>; } }";
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::Tsx, &tree, src);
+                let class = symbols.iter().find(|s| s.name == "Foo").unwrap();
+                assert!(matches!(class.kind, SymbolKind::Class));
+                assert_eq!(class.visibility, Some(Visibility::Public));
+            }
+
+            #[test]
+            fn tsx_docstring_extraction() {
+                let src = b"/** Component doc. */\nfunction App() {}";
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::Tsx, &tree, src);
+                let func = symbols.iter().find(|s| s.name == "App").unwrap();
+                assert!(func.docstring.is_some(), "App should have docstring");
+                assert!(func.docstring.as_ref().unwrap().contains("Component doc"));
+            }
+
+
+            #[test]
+            fn tsx_bare_import_resolves_to_external() {
+                use crate::language::LangId;
+                let spec = crate::language::spec_for(LangId::Tsx);
+                let out = (spec.import_path_resolver)(
+                    "react",
+                    std::path::Path::new("/proj/src"),
+                    std::path::Path::new("/proj"),
+                );
+                assert_eq!(out, Some(std::path::PathBuf::from("react")));
+            }
+
+            #[cfg(feature = "dataflow")]
+            mod dataflow_tests {
+                use super::*;
+                use crate::language::tsx::extract_tsx_dataflow;
+                use crate::model::{DataScope, FlowKind};
+
+                fn extract(source: &[u8]) -> (Vec<crate::model::DataNode>, Vec<crate::model::FlowEdge>) {
+                    let id_gen = crate::model::IdGenerator::new();
+                    extract_tsx_dataflow(&parse(source), source, &id_gen)
+                }
+
+                #[test]
+                fn typed_parameter_captured() {
+                    let src = b"function App(props: { name: string }): JSX.Element { return <div>{props.name}</div>; }";
+                    let (nodes, edges) = extract(src);
+                    let params: Vec<_> = nodes
+                        .iter()
+                        .filter(|n| n.scope == DataScope::Parameter)
+                        .collect();
+                    assert!(
+                        params.iter().any(|n| n.name.as_deref() == Some("props")),
+                        "props parameter must be captured"
+                    );
+                    assert!(!edges.is_empty());
+                }
+
+                #[test]
+                fn flow_edges_anchored_to_real_nodes() {
+                    let src = b"function App(props: { name: string }): JSX.Element { let local = 1; return <div>{local}</div>; }";
+                    let (nodes, edges) = extract(src);
+                    let ids: std::collections::HashSet<_> = nodes.iter().map(|n| n.id).collect();
+                    for edge in &edges {
+                        assert!(ids.contains(&edge.source), "edge source not in nodes");
+                        assert!(ids.contains(&edge.target), "edge target not in nodes");
+                        assert_eq!(edge.kind, FlowKind::DefUse);
+                        assert!((edge.confidence - 0.9).abs() < f32::EPSILON);
+                    }
+                }
+
+                #[test]
+                fn cross_function_scoping() {
+                    let src = b"function outer() { let x = 1; const Inner = () => { let x = 2; return x; }; return x; }";
+                    let (nodes, edges) = extract(src);
+                    // 2 distinct `x` defs (one per scope).
+                    let defs: Vec<_> = nodes
+                        .iter()
+                        .filter(|n| {
+                            n.name.as_deref() == Some("x")
+                                && n.scope == DataScope::Local
+                                && !edges.iter().any(|e| e.target == n.id)
+                        })
+                        .collect();
+                    assert_eq!(defs.len(), 2);
+                    // 2 use edges must exist.
+                    assert!(edges.len() >= 2);
+                    // Edges must connect each use to the def in the same scope.
+                    let inner_def = defs
+                        .iter()
+                        .max_by_key(|n| n.source_range.byte_start)
+                        .unwrap();
+                    let outer_def = defs
+                        .iter()
+                        .min_by_key(|n| n.source_range.byte_start)
+                        .unwrap();
+                    let uses: Vec<_> = nodes
+                        .iter()
+                        .filter(|n| {
+                            n.name.as_deref() == Some("x")
+                                && n.scope == DataScope::Local
+                                && edges.iter().any(|e| e.target == n.id)
+                        })
+                        .collect();
+                    let inner_use = uses
+                        .iter()
+                        .min_by_key(|n| n.source_range.byte_start)
+                        .unwrap();
+                    let outer_use = uses
+                        .iter()
+                        .max_by_key(|n| n.source_range.byte_start)
+                        .unwrap();
+                    let inner_edge = edges.iter().find(|e| e.target == inner_use.id).unwrap();
+                    let outer_edge = edges.iter().find(|e| e.target == outer_use.id).unwrap();
+                    assert_eq!(inner_edge.source, inner_def.id);
+                    assert_eq!(outer_edge.source, outer_def.id);
+                }
+
+                #[test]
+                fn dataflow_against_fixture_file() {
+                    let src = std::fs::read_to_string(
+                        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                            .join("tests/fixtures/tsx/components.tsx"),
+                    )
+                    .unwrap();
+                    let (nodes, edges) = extract(src.as_bytes());
+                    assert!(!nodes.is_empty(), "fixture must yield data nodes");
+                    let ids: std::collections::HashSet<_> = nodes.iter().map(|n| n.id).collect();
+                    for edge in &edges {
+                        assert!(ids.contains(&edge.source));
+                        assert!(ids.contains(&edge.target));
+                    }
+                }
+            }
+    },
+);
 
 // ── Dataflow extraction ─────────────────────────────────────────────
 
 #[cfg(feature = "dataflow")]
-static TSX_DATAFLOW_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
+static TSX_DATAFLOW_QUERY: std::sync::LazyLock<tree_sitter::Query> = std::sync::LazyLock::new(|| {
     crate::language::common::compile_query(
         &tree_sitter_typescript::LANGUAGE_TSX.into(),
         crate::language::javascript::TS_FAMILY_DATAFLOW_QUERY,
@@ -80,173 +220,4 @@ pub fn extract_tsx_dataflow(
         TSX_FUNCTION_KINDS,
         id_gen,
     )
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::language::{LangId, extract_symbols_for, grammar_for};
-    use crate::model::{SymbolKind, Visibility};
-
-    fn parse(source: &[u8]) -> tree_sitter::Tree {
-        let mut parser = tree_sitter::Parser::new();
-        parser.set_language(&grammar_for(LangId::Tsx)).unwrap();
-        parser.parse(source, None).unwrap()
-    }
-
-    #[test]
-    fn extract_tsx_function() {
-        let src = b"function App(): JSX.Element { return <div/>; }";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::Tsx, &tree, src);
-        assert_eq!(symbols.len(), 1);
-        assert_eq!(symbols[0].name, "App");
-        assert!(matches!(symbols[0].kind, SymbolKind::Function));
-    }
-
-    #[test]
-    fn extract_tsx_exported_class() {
-        let src = b"export class Foo extends React.Component { render() { return <div/>; } }";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::Tsx, &tree, src);
-        let class = symbols.iter().find(|s| s.name == "Foo").unwrap();
-        assert!(matches!(class.kind, SymbolKind::Class));
-        assert_eq!(class.visibility, Some(Visibility::Public));
-    }
-
-    #[test]
-    fn tsx_docstring_extraction() {
-        let src = b"/** Component doc. */\nfunction App() {}";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::Tsx, &tree, src);
-        let func = symbols.iter().find(|s| s.name == "App").unwrap();
-        assert!(func.docstring.is_some(), "App should have docstring");
-        assert!(func.docstring.as_ref().unwrap().contains("Component doc"));
-    }
-
-    #[test]
-    fn tsx_insta_snapshot() {
-        let src = std::fs::read_to_string(
-            std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-                .join("tests/fixtures/tsx/components.tsx"),
-        )
-        .unwrap();
-        let tree = parse(src.as_bytes());
-        let symbols = extract_symbols_for(LangId::Tsx, &tree, src.as_bytes());
-        insta::assert_json_snapshot!(symbols);
-    }
-
-    #[test]
-    fn tsx_bare_import_resolves_to_external() {
-        use crate::language::LangId;
-        let spec = crate::language::spec_for(LangId::Tsx);
-        let out = (spec.import_path_resolver)(
-            "react",
-            std::path::Path::new("/proj/src"),
-            std::path::Path::new("/proj"),
-        );
-        assert_eq!(out, Some(std::path::PathBuf::from("react")));
-    }
-
-    #[cfg(feature = "dataflow")]
-    mod dataflow_tests {
-        use super::*;
-        use crate::language::tsx::extract_tsx_dataflow;
-        use crate::model::{DataScope, FlowKind};
-
-        fn extract(source: &[u8]) -> (Vec<crate::model::DataNode>, Vec<crate::model::FlowEdge>) {
-            let id_gen = crate::model::IdGenerator::new();
-            extract_tsx_dataflow(&parse(source), source, &id_gen)
-        }
-
-        #[test]
-        fn typed_parameter_captured() {
-            let src = b"function App(props: { name: string }): JSX.Element { return <div>{props.name}</div>; }";
-            let (nodes, edges) = extract(src);
-            let params: Vec<_> = nodes
-                .iter()
-                .filter(|n| n.scope == DataScope::Parameter)
-                .collect();
-            assert!(
-                params.iter().any(|n| n.name.as_deref() == Some("props")),
-                "props parameter must be captured"
-            );
-            assert!(!edges.is_empty());
-        }
-
-        #[test]
-        fn flow_edges_anchored_to_real_nodes() {
-            let src = b"function App(props: { name: string }): JSX.Element { let local = 1; return <div>{local}</div>; }";
-            let (nodes, edges) = extract(src);
-            let ids: std::collections::HashSet<_> = nodes.iter().map(|n| n.id).collect();
-            for edge in &edges {
-                assert!(ids.contains(&edge.source), "edge source not in nodes");
-                assert!(ids.contains(&edge.target), "edge target not in nodes");
-                assert_eq!(edge.kind, FlowKind::DefUse);
-                assert!((edge.confidence - 0.9).abs() < f32::EPSILON);
-            }
-        }
-
-        #[test]
-        fn cross_function_scoping() {
-            let src = b"function outer() { let x = 1; const Inner = () => { let x = 2; return x; }; return x; }";
-            let (nodes, edges) = extract(src);
-            // 2 distinct `x` defs (one per scope).
-            let defs: Vec<_> = nodes
-                .iter()
-                .filter(|n| {
-                    n.name.as_deref() == Some("x")
-                        && n.scope == DataScope::Local
-                        && !edges.iter().any(|e| e.target == n.id)
-                })
-                .collect();
-            assert_eq!(defs.len(), 2);
-            // 2 use edges must exist.
-            assert!(edges.len() >= 2);
-            // Edges must connect each use to the def in the same scope.
-            let inner_def = defs
-                .iter()
-                .max_by_key(|n| n.source_range.byte_start)
-                .unwrap();
-            let outer_def = defs
-                .iter()
-                .min_by_key(|n| n.source_range.byte_start)
-                .unwrap();
-            let uses: Vec<_> = nodes
-                .iter()
-                .filter(|n| {
-                    n.name.as_deref() == Some("x")
-                        && n.scope == DataScope::Local
-                        && edges.iter().any(|e| e.target == n.id)
-                })
-                .collect();
-            let inner_use = uses
-                .iter()
-                .min_by_key(|n| n.source_range.byte_start)
-                .unwrap();
-            let outer_use = uses
-                .iter()
-                .max_by_key(|n| n.source_range.byte_start)
-                .unwrap();
-            let inner_edge = edges.iter().find(|e| e.target == inner_use.id).unwrap();
-            let outer_edge = edges.iter().find(|e| e.target == outer_use.id).unwrap();
-            assert_eq!(inner_edge.source, inner_def.id);
-            assert_eq!(outer_edge.source, outer_def.id);
-        }
-
-        #[test]
-        fn dataflow_against_fixture_file() {
-            let src = std::fs::read_to_string(
-                std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-                    .join("tests/fixtures/tsx/components.tsx"),
-            )
-            .unwrap();
-            let (nodes, edges) = extract(src.as_bytes());
-            assert!(!nodes.is_empty(), "fixture must yield data nodes");
-            let ids: std::collections::HashSet<_> = nodes.iter().map(|n| n.id).collect();
-            for edge in &edges {
-                assert!(ids.contains(&edge.source));
-                assert!(ids.contains(&edge.target));
-            }
-        }
-    }
 }

--- a/src/language/typescript.rs
+++ b/src/language/typescript.rs
@@ -419,13 +419,14 @@ define_language_pack!(
 // ── Dataflow extraction ─────────────────────────────────────────────
 
 #[cfg(feature = "dataflow")]
-static TS_DATAFLOW_QUERY: std::sync::LazyLock<tree_sitter::Query> = std::sync::LazyLock::new(|| {
-    crate::language::common::compile_query(
-        &tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
-        crate::language::javascript::TS_FAMILY_DATAFLOW_QUERY,
-        "TypeScript dataflow",
-    )
-});
+static TS_DATAFLOW_QUERY: std::sync::LazyLock<tree_sitter::Query> =
+    std::sync::LazyLock::new(|| {
+        crate::language::common::compile_query(
+            &tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
+            crate::language::javascript::TS_FAMILY_DATAFLOW_QUERY,
+            "TypeScript dataflow",
+        )
+    });
 
 /// TypeScript AST node kinds that introduce a new intra-procedural scope.
 #[cfg(feature = "dataflow")]

--- a/src/language/typescript.rs
+++ b/src/language/typescript.rs
@@ -1,7 +1,7 @@
-use crate::language::{DefaultVisibility, LanguageSpec};
+use crate::language::DefaultVisibility;
+use crate::language::pack::define_language_pack;
 use crate::model::Visibility;
 use std::path::{Path, PathBuf};
-use std::sync::LazyLock;
 
 fn resolve_ts_import(raw: &str, source_dir: &Path, _project_root: &Path) -> Option<PathBuf> {
     use crate::language::import_resolver::{TS_EXTS, resolve_js_family_import};
@@ -87,14 +87,6 @@ pub(crate) const TS_FAMILY_QUERY: &str = r#"
 ) @kind.function
 "#;
 
-static TS_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
-    crate::language::common::compile_query(
-        &tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
-        TS_FAMILY_QUERY,
-        "TypeScript",
-    )
-});
-
 pub(crate) const TS_FAMILY_IMPORT_QUERY: &str = r#"
 (import_statement
   source: (string) @import.path)
@@ -128,40 +120,306 @@ pub(crate) const TS_FAMILY_REFERENCE_QUERY: &str = r#"
     object: (identifier) @reference.name))
 "#;
 
-static TS_IMPORT_REF_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
-    crate::language::common::compile_query(
-        &tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
-        &format!("{}\n{}", TS_FAMILY_IMPORT_QUERY, TS_FAMILY_REFERENCE_QUERY),
-        "TypeScript combined import+ref",
-    )
-});
-
-fn ts_import_ref_query() -> &'static tree_sitter::Query {
-    &TS_IMPORT_REF_QUERY
-}
-
-fn ts_query() -> &'static tree_sitter::Query {
-    &TS_QUERY
-}
-
-pub(crate) const TS_SPEC: LanguageSpec = LanguageSpec {
-    extensions: &["ts", "cts", "mts"],
-    grammar_fn: || tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
-    query_fn: ts_query,
-    import_path_resolver: resolve_ts_import,
-    import_ref_query_fn: ts_import_ref_query,
-    class_like_parents: &["class_declaration", "class"],
-    ancestor_visibility_rules: &[("export_statement", Visibility::Public)],
+define_language_pack!(
+    spec: TS_SPEC,
+    label: "TypeScript",
+    lang: LangId::TypeScript,
+    grammar: tree_sitter_typescript::LANGUAGE_TYPESCRIPT,
+    extensions: ["ts", "cts", "mts"],
+    resolver: resolve_ts_import,
+    symbols: {
+        static: TS_QUERY,
+        accessor: ts_query,
+        query: TS_FAMILY_QUERY,
+    },
+    imports_refs: {
+        static: TS_IMPORT_REF_QUERY,
+        accessor: ts_import_ref_query,
+        import: TS_FAMILY_IMPORT_QUERY,
+        reference: TS_FAMILY_REFERENCE_QUERY,
+    },
+    import_statement_kinds: ["import_statement"],
+    class_like_parents: ["class_declaration", "class"],
+    ancestors: [("export_statement", Visibility::Public)],
     visibility_from_name: None,
-    import_statement_kinds: &["import_statement"],
     default_visibility: DefaultVisibility::PrivateByDefault,
-    doc_comment_config: Some(crate::language::C_LIKE_DOC_COMMENT),
-};
+    doc_comment: Some(crate::language::C_LIKE_DOC_COMMENT),
+    fixture: "tests/fixtures/typescript/interfaces.ts",
+    snapshot: ts_insta_snapshot,
+    tests {
+            use crate::model::SymbolKind;
+
+
+            #[test]
+            fn extract_interface() {
+                let src = b"interface Foo { bar(): void; }";
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::TypeScript, &tree, src);
+                assert_eq!(symbols.len(), 1);
+                assert_eq!(symbols[0].name, "Foo");
+                assert!(matches!(symbols[0].kind, SymbolKind::Interface));
+            }
+
+            #[test]
+            fn extract_type_alias() {
+                let src = b"type Point = { x: number; };";
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::TypeScript, &tree, src);
+                assert_eq!(symbols.len(), 1);
+                assert_eq!(symbols[0].name, "Point");
+                assert!(matches!(symbols[0].kind, SymbolKind::TypeAlias));
+            }
+
+            #[test]
+            fn extract_enum() {
+                let src = b"enum Dir { A, B }";
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::TypeScript, &tree, src);
+                assert_eq!(symbols.len(), 1);
+                assert_eq!(symbols[0].name, "Dir");
+                assert!(matches!(symbols[0].kind, SymbolKind::Enum));
+            }
+
+            #[test]
+            fn extract_ts_named_imports() {
+                use crate::language::extract_imports_and_references_for;
+                let src = b"import { Component, OnInit } from '@angular/core';";
+                let tree = parse(src);
+                let (imports, _, _) = extract_imports_and_references_for(
+                    LangId::TypeScript,
+                    &tree,
+                    src,
+                    &std::path::PathBuf::from("test.ts"),
+                );
+                let named: Vec<_> = imports.iter().filter(|i| i.symbol.is_some()).collect();
+                assert_eq!(named.len(), 2);
+                for imp in &named {
+                    assert_eq!(imp.import_specifier, "@angular/core");
+                }
+                assert_eq!(named[0].symbol.as_deref(), Some("Component"));
+                assert_eq!(named[1].symbol.as_deref(), Some("OnInit"));
+            }
+
+            #[test]
+            fn extract_ts_default_import() {
+                use crate::language::extract_imports_and_references_for;
+                let src = b"import React from 'react';";
+                let tree = parse(src);
+                let (imports, _, _) = extract_imports_and_references_for(
+                    LangId::TypeScript,
+                    &tree,
+                    src,
+                    &std::path::PathBuf::from("test.ts"),
+                );
+                let named: Vec<_> = imports.iter().filter(|i| i.symbol.is_some()).collect();
+                assert_eq!(named.len(), 1);
+                assert_eq!(named[0].import_specifier, "react");
+                assert_eq!(named[0].symbol.as_deref(), Some("React"));
+            }
+
+            #[test]
+            fn ts_docstring_extraction() {
+                let src = b"/** TSDoc comment. */\nfunction documented() {}";
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::TypeScript, &tree, src);
+                let func = symbols.iter().find(|s| s.name == "documented").unwrap();
+                assert!(func.docstring.is_some(), "documented should have docstring");
+                assert!(func.docstring.as_ref().unwrap().contains("TSDoc comment"));
+            }
+
+            fn symbol_names(symbols: &[crate::language::RawSymbol<'_>]) -> Vec<String> {
+                symbols.iter().map(|s| s.name.to_string()).collect()
+            }
+
+            #[test]
+            fn extract_annotated_arrow_function() {
+                let src = b"const f: T = () => {};";
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::TypeScript, &tree, src);
+                let found = symbols.iter().find(|s| s.name == "f");
+                assert!(found.is_some(), "missing f: {:?}", symbol_names(&symbols));
+                let found = found.unwrap();
+                assert!(matches!(found.kind, SymbolKind::Function));
+                assert_eq!(found.signature.as_deref(), Some("()"));
+            }
+
+            #[test]
+            fn extract_exported_annotated_arrow_function() {
+                let src = b"export const handler: Handler = async () => {};";
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::TypeScript, &tree, src);
+                let found = symbols.iter().find(|s| s.name == "handler");
+                assert!(
+                    found.is_some(),
+                    "missing handler: {:?}",
+                    symbol_names(&symbols)
+                );
+                let found = found.unwrap();
+                assert!(matches!(found.kind, SymbolKind::Function));
+                assert!(found.is_async);
+            }
+
+            #[test]
+            fn extract_typed_function_expression() {
+                let src = b"const g = function n(): void {};";
+                let tree = parse(src);
+                let symbols = extract_symbols_for(LangId::TypeScript, &tree, src);
+                assert!(
+                    symbols.iter().any(|s| s.name == "g"),
+                    "missing g: {:?}",
+                    symbol_names(&symbols)
+                );
+                assert!(!symbols.iter().any(|s| s.name == "n"));
+            }
+
+
+            #[cfg(feature = "dataflow")]
+            mod dataflow_tests {
+                use super::*;
+                use crate::language::typescript::extract_typescript_dataflow;
+                use crate::model::{DataScope, FlowKind};
+
+                fn extract(source: &[u8]) -> (Vec<crate::model::DataNode>, Vec<crate::model::FlowEdge>) {
+                    let id_gen = crate::model::IdGenerator::new();
+                    extract_typescript_dataflow(&parse(source), source, &id_gen)
+                }
+
+                #[test]
+                fn typed_let_binding_captured() {
+                    let src = b"function f(): number { let x: number = 42; return x; }";
+                    let (nodes, edges) = extract(src);
+                    assert!(
+                        nodes
+                            .iter()
+                            .any(|n| n.name.as_deref() == Some("x") && n.scope == DataScope::Local)
+                    );
+                    assert!(!edges.is_empty(), "x usage should yield an edge");
+                }
+
+                #[test]
+                fn typed_parameter_captured_as_parameter() {
+                    let src = b"function add(a: number, b: number): number { return a + b; }";
+                    let (nodes, edges) = extract(src);
+                    let params: Vec<_> = nodes
+                        .iter()
+                        .filter(|n| n.scope == DataScope::Parameter)
+                        .collect();
+                    assert_eq!(params.len(), 2);
+                    let names: Vec<_> = params.iter().map(|n| n.name.as_deref()).collect();
+                    assert!(names.contains(&Some("a")));
+                    assert!(names.contains(&Some("b")));
+                    assert!(!edges.is_empty());
+                }
+
+                #[test]
+                fn flow_edges_anchored_to_real_nodes() {
+                    let src = b"function f() { let x = 1; return x; }";
+                    let (nodes, edges) = extract(src);
+                    let ids: std::collections::HashSet<_> = nodes.iter().map(|n| n.id).collect();
+                    for edge in &edges {
+                        assert!(ids.contains(&edge.source), "edge source not in nodes");
+                        assert!(ids.contains(&edge.target), "edge target not in nodes");
+                        assert_eq!(edge.kind, FlowKind::DefUse);
+                        assert!((edge.confidence - 0.9).abs() < f32::EPSILON);
+                    }
+                }
+
+                #[test]
+                fn no_duplicate_def_for_typed_let() {
+                    // Regression: the type annotation must not double-capture the var.
+                    let src = b"function f() { let x: number = 1; return x; }";
+                    let (nodes, _edges) = extract(src);
+                    let x_defs: Vec<_> = nodes
+                        .iter()
+                        .filter(|n| n.name.as_deref() == Some("x") && n.scope == DataScope::Local)
+                        .collect();
+                    // 1 definition + 1 usage-node.
+                    assert_eq!(
+                        x_defs.len(),
+                        2,
+                        "expected exactly one def + one use for `x` (no double-capture)"
+                    );
+                }
+
+                #[test]
+                fn cross_function_scoping() {
+                    let src = b"function outer() { let x = 1; function inner() { let x = 2; return x; } return x; }";
+                    let (nodes, edges) = extract(src);
+                    // 2 def + 2 use nodes for `x`, all named "x".
+                    let defs: Vec<_> = nodes
+                        .iter()
+                        .filter(|n| n.name.as_deref() == Some("x") && n.scope == DataScope::Local)
+                        .collect();
+                    assert_eq!(defs.len(), 4);
+                    // Of those, the defs are the ones without an incoming edge.
+                    let true_defs: Vec<_> = nodes
+                        .iter()
+                        .filter(|n| {
+                            n.name.as_deref() == Some("x")
+                                && n.scope == DataScope::Local
+                                && !edges.iter().any(|e| e.target == n.id)
+                        })
+                        .collect();
+                    assert_eq!(true_defs.len(), 2, "two distinct `x` defs expected");
+                    // 2 use edges must exist.
+                    assert!(edges.len() >= 2);
+                    // Each use must be anchored to a def in the same function scope.
+                    let inner_def = true_defs
+                        .iter()
+                        .max_by_key(|n| n.source_range.byte_start)
+                        .unwrap();
+                    let outer_def = true_defs
+                        .iter()
+                        .min_by_key(|n| n.source_range.byte_start)
+                        .unwrap();
+                    let uses: Vec<_> = nodes
+                        .iter()
+                        .filter(|n| {
+                            n.name.as_deref() == Some("x")
+                                && n.scope == DataScope::Local
+                                && edges.iter().any(|e| e.target == n.id)
+                        })
+                        .collect();
+                    let inner_use = uses
+                        .iter()
+                        .min_by_key(|n| n.source_range.byte_start)
+                        .unwrap();
+                    let outer_use = uses
+                        .iter()
+                        .max_by_key(|n| n.source_range.byte_start)
+                        .unwrap();
+                    let inner_edge = edges.iter().find(|e| e.target == inner_use.id).unwrap();
+                    let outer_edge = edges.iter().find(|e| e.target == outer_use.id).unwrap();
+                    assert_eq!(inner_edge.source, inner_def.id);
+                    assert_eq!(outer_edge.source, outer_def.id);
+                    assert_ne!(inner_edge.source, outer_edge.source);
+                }
+
+                #[test]
+                fn dataflow_against_fixture_file() {
+                    let src = std::fs::read_to_string(
+                        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                            .join("tests/fixtures/typescript/interfaces.ts"),
+                    )
+                    .unwrap();
+                    let (nodes, edges) = extract(src.as_bytes());
+                    // Interfaces / type aliases don't introduce data nodes,
+                    // but the class methods in the fixture should produce some.
+                    assert!(!nodes.is_empty(), "fixture must yield some data nodes");
+                    let ids: std::collections::HashSet<_> = nodes.iter().map(|n| n.id).collect();
+                    for edge in &edges {
+                        assert!(ids.contains(&edge.source));
+                        assert!(ids.contains(&edge.target));
+                    }
+                }
+            }
+    },
+);
 
 // ── Dataflow extraction ─────────────────────────────────────────────
 
 #[cfg(feature = "dataflow")]
-static TS_DATAFLOW_QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
+static TS_DATAFLOW_QUERY: std::sync::LazyLock<tree_sitter::Query> = std::sync::LazyLock::new(|| {
     crate::language::common::compile_query(
         &tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
         crate::language::javascript::TS_FAMILY_DATAFLOW_QUERY,
@@ -187,293 +445,4 @@ pub fn extract_typescript_dataflow(
         TS_FUNCTION_KINDS,
         id_gen,
     )
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::language::{LangId, extract_symbols_for, grammar_for};
-    use crate::model::SymbolKind;
-
-    fn parse(source: &[u8]) -> tree_sitter::Tree {
-        let mut parser = tree_sitter::Parser::new();
-        parser
-            .set_language(&grammar_for(LangId::TypeScript))
-            .unwrap();
-        parser.parse(source, None).unwrap()
-    }
-
-    #[test]
-    fn extract_interface() {
-        let src = b"interface Foo { bar(): void; }";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::TypeScript, &tree, src);
-        assert_eq!(symbols.len(), 1);
-        assert_eq!(symbols[0].name, "Foo");
-        assert!(matches!(symbols[0].kind, SymbolKind::Interface));
-    }
-
-    #[test]
-    fn extract_type_alias() {
-        let src = b"type Point = { x: number; };";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::TypeScript, &tree, src);
-        assert_eq!(symbols.len(), 1);
-        assert_eq!(symbols[0].name, "Point");
-        assert!(matches!(symbols[0].kind, SymbolKind::TypeAlias));
-    }
-
-    #[test]
-    fn extract_enum() {
-        let src = b"enum Dir { A, B }";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::TypeScript, &tree, src);
-        assert_eq!(symbols.len(), 1);
-        assert_eq!(symbols[0].name, "Dir");
-        assert!(matches!(symbols[0].kind, SymbolKind::Enum));
-    }
-
-    #[test]
-    fn extract_ts_named_imports() {
-        use crate::language::extract_imports_and_references_for;
-        let src = b"import { Component, OnInit } from '@angular/core';";
-        let tree = parse(src);
-        let (imports, _, _) = extract_imports_and_references_for(
-            LangId::TypeScript,
-            &tree,
-            src,
-            &std::path::PathBuf::from("test.ts"),
-        );
-        let named: Vec<_> = imports.iter().filter(|i| i.symbol.is_some()).collect();
-        assert_eq!(named.len(), 2);
-        for imp in &named {
-            assert_eq!(imp.import_specifier, "@angular/core");
-        }
-        assert_eq!(named[0].symbol.as_deref(), Some("Component"));
-        assert_eq!(named[1].symbol.as_deref(), Some("OnInit"));
-    }
-
-    #[test]
-    fn extract_ts_default_import() {
-        use crate::language::extract_imports_and_references_for;
-        let src = b"import React from 'react';";
-        let tree = parse(src);
-        let (imports, _, _) = extract_imports_and_references_for(
-            LangId::TypeScript,
-            &tree,
-            src,
-            &std::path::PathBuf::from("test.ts"),
-        );
-        let named: Vec<_> = imports.iter().filter(|i| i.symbol.is_some()).collect();
-        assert_eq!(named.len(), 1);
-        assert_eq!(named[0].import_specifier, "react");
-        assert_eq!(named[0].symbol.as_deref(), Some("React"));
-    }
-
-    #[test]
-    fn ts_docstring_extraction() {
-        let src = b"/** TSDoc comment. */\nfunction documented() {}";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::TypeScript, &tree, src);
-        let func = symbols.iter().find(|s| s.name == "documented").unwrap();
-        assert!(func.docstring.is_some(), "documented should have docstring");
-        assert!(func.docstring.as_ref().unwrap().contains("TSDoc comment"));
-    }
-
-    fn symbol_names(symbols: &[crate::language::RawSymbol<'_>]) -> Vec<String> {
-        symbols.iter().map(|s| s.name.to_string()).collect()
-    }
-
-    #[test]
-    fn extract_annotated_arrow_function() {
-        let src = b"const f: T = () => {};";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::TypeScript, &tree, src);
-        let found = symbols.iter().find(|s| s.name == "f");
-        assert!(found.is_some(), "missing f: {:?}", symbol_names(&symbols));
-        let found = found.unwrap();
-        assert!(matches!(found.kind, SymbolKind::Function));
-        assert_eq!(found.signature.as_deref(), Some("()"));
-    }
-
-    #[test]
-    fn extract_exported_annotated_arrow_function() {
-        let src = b"export const handler: Handler = async () => {};";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::TypeScript, &tree, src);
-        let found = symbols.iter().find(|s| s.name == "handler");
-        assert!(
-            found.is_some(),
-            "missing handler: {:?}",
-            symbol_names(&symbols)
-        );
-        let found = found.unwrap();
-        assert!(matches!(found.kind, SymbolKind::Function));
-        assert!(found.is_async);
-    }
-
-    #[test]
-    fn extract_typed_function_expression() {
-        let src = b"const g = function n(): void {};";
-        let tree = parse(src);
-        let symbols = extract_symbols_for(LangId::TypeScript, &tree, src);
-        assert!(
-            symbols.iter().any(|s| s.name == "g"),
-            "missing g: {:?}",
-            symbol_names(&symbols)
-        );
-        assert!(!symbols.iter().any(|s| s.name == "n"));
-    }
-
-    #[test]
-    fn ts_insta_snapshot() {
-        let src = std::fs::read_to_string(
-            std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-                .join("tests/fixtures/typescript/interfaces.ts"),
-        )
-        .unwrap();
-        let tree = parse(src.as_bytes());
-        let symbols = extract_symbols_for(LangId::TypeScript, &tree, src.as_bytes());
-        insta::assert_json_snapshot!(symbols);
-    }
-
-    #[cfg(feature = "dataflow")]
-    mod dataflow_tests {
-        use super::*;
-        use crate::language::typescript::extract_typescript_dataflow;
-        use crate::model::{DataScope, FlowKind};
-
-        fn extract(source: &[u8]) -> (Vec<crate::model::DataNode>, Vec<crate::model::FlowEdge>) {
-            let id_gen = crate::model::IdGenerator::new();
-            extract_typescript_dataflow(&parse(source), source, &id_gen)
-        }
-
-        #[test]
-        fn typed_let_binding_captured() {
-            let src = b"function f(): number { let x: number = 42; return x; }";
-            let (nodes, edges) = extract(src);
-            assert!(
-                nodes
-                    .iter()
-                    .any(|n| n.name.as_deref() == Some("x") && n.scope == DataScope::Local)
-            );
-            assert!(!edges.is_empty(), "x usage should yield an edge");
-        }
-
-        #[test]
-        fn typed_parameter_captured_as_parameter() {
-            let src = b"function add(a: number, b: number): number { return a + b; }";
-            let (nodes, edges) = extract(src);
-            let params: Vec<_> = nodes
-                .iter()
-                .filter(|n| n.scope == DataScope::Parameter)
-                .collect();
-            assert_eq!(params.len(), 2);
-            let names: Vec<_> = params.iter().map(|n| n.name.as_deref()).collect();
-            assert!(names.contains(&Some("a")));
-            assert!(names.contains(&Some("b")));
-            assert!(!edges.is_empty());
-        }
-
-        #[test]
-        fn flow_edges_anchored_to_real_nodes() {
-            let src = b"function f() { let x = 1; return x; }";
-            let (nodes, edges) = extract(src);
-            let ids: std::collections::HashSet<_> = nodes.iter().map(|n| n.id).collect();
-            for edge in &edges {
-                assert!(ids.contains(&edge.source), "edge source not in nodes");
-                assert!(ids.contains(&edge.target), "edge target not in nodes");
-                assert_eq!(edge.kind, FlowKind::DefUse);
-                assert!((edge.confidence - 0.9).abs() < f32::EPSILON);
-            }
-        }
-
-        #[test]
-        fn no_duplicate_def_for_typed_let() {
-            // Regression: the type annotation must not double-capture the var.
-            let src = b"function f() { let x: number = 1; return x; }";
-            let (nodes, _edges) = extract(src);
-            let x_defs: Vec<_> = nodes
-                .iter()
-                .filter(|n| n.name.as_deref() == Some("x") && n.scope == DataScope::Local)
-                .collect();
-            // 1 definition + 1 usage-node.
-            assert_eq!(
-                x_defs.len(),
-                2,
-                "expected exactly one def + one use for `x` (no double-capture)"
-            );
-        }
-
-        #[test]
-        fn cross_function_scoping() {
-            let src = b"function outer() { let x = 1; function inner() { let x = 2; return x; } return x; }";
-            let (nodes, edges) = extract(src);
-            // 2 def + 2 use nodes for `x`, all named "x".
-            let defs: Vec<_> = nodes
-                .iter()
-                .filter(|n| n.name.as_deref() == Some("x") && n.scope == DataScope::Local)
-                .collect();
-            assert_eq!(defs.len(), 4);
-            // Of those, the defs are the ones without an incoming edge.
-            let true_defs: Vec<_> = nodes
-                .iter()
-                .filter(|n| {
-                    n.name.as_deref() == Some("x")
-                        && n.scope == DataScope::Local
-                        && !edges.iter().any(|e| e.target == n.id)
-                })
-                .collect();
-            assert_eq!(true_defs.len(), 2, "two distinct `x` defs expected");
-            // 2 use edges must exist.
-            assert!(edges.len() >= 2);
-            // Each use must be anchored to a def in the same function scope.
-            let inner_def = true_defs
-                .iter()
-                .max_by_key(|n| n.source_range.byte_start)
-                .unwrap();
-            let outer_def = true_defs
-                .iter()
-                .min_by_key(|n| n.source_range.byte_start)
-                .unwrap();
-            let uses: Vec<_> = nodes
-                .iter()
-                .filter(|n| {
-                    n.name.as_deref() == Some("x")
-                        && n.scope == DataScope::Local
-                        && edges.iter().any(|e| e.target == n.id)
-                })
-                .collect();
-            let inner_use = uses
-                .iter()
-                .min_by_key(|n| n.source_range.byte_start)
-                .unwrap();
-            let outer_use = uses
-                .iter()
-                .max_by_key(|n| n.source_range.byte_start)
-                .unwrap();
-            let inner_edge = edges.iter().find(|e| e.target == inner_use.id).unwrap();
-            let outer_edge = edges.iter().find(|e| e.target == outer_use.id).unwrap();
-            assert_eq!(inner_edge.source, inner_def.id);
-            assert_eq!(outer_edge.source, outer_def.id);
-            assert_ne!(inner_edge.source, outer_edge.source);
-        }
-
-        #[test]
-        fn dataflow_against_fixture_file() {
-            let src = std::fs::read_to_string(
-                std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-                    .join("tests/fixtures/typescript/interfaces.ts"),
-            )
-            .unwrap();
-            let (nodes, edges) = extract(src.as_bytes());
-            // Interfaces / type aliases don't introduce data nodes,
-            // but the class methods in the fixture should produce some.
-            assert!(!nodes.is_empty(), "fixture must yield some data nodes");
-            let ids: std::collections::HashSet<_> = nodes.iter().map(|n| n.id).collect();
-            for edge in &edges {
-                assert!(ids.contains(&edge.source));
-                assert!(ids.contains(&edge.target));
-            }
-        }
-    }
 }


### PR DESCRIPTION
One macro declares every language pack: the query statics, their fallible accessors, the spec literal and the snapshot scaffolding, with the nine language snapshots byte identical. Lockfile resolution becomes a table of sources per ecosystem with one reader per format, so the differences between ecosystems are data, and subdirectories are visited in sorted order instead of file system order. The SCC pass classifies in one edge walk and the def-use matcher indexes definitions per scope.\n\nLadder: 6 failing tests before and after this level.