### PR TITLE
docs: match the module tree, the deploy pipeline and the item documentation

### DIFF
--- a/docs/src/ARCHITECTURE.md
+++ b/docs/src/ARCHITECTURE.md
@@ -87,7 +87,7 @@ Parallel parse + extract uses rayon per-file; graph assembly is sequential. See 
 The CLI supports JSON and YAML for programmatic consumption, plus an interactive HTML dashboard for visual analysis and datagraph JSON exports.
 
 - **JSON / YAML:** Controlled by the `-f, --format` flag. JSON is the default. YAML requires no extra setup - just pass `--format yaml`.
-- **HTML dashboard:** Separate concern, activated with `--html`. Generates a single `.html` file with an interactive Cytoscape.js graph loaded from a CDN (cached by the browser after first fetch). The browser auto-opens unless you redirect.
+- **HTML dashboard:** Separate concern, activated with `--html`. Generates a single `.html` file with an interactive Cytoscape.js graph whose bundle travels inside the document, so it renders without network access. The browser opens only with `--open`; without it the file is written and left alone.
 - **Datagraph JSON:** Activated with `--datagraph` (requires `--features dataflow`). Exports detailed data/flow node definitions and def-use relations.
 - **Language Filter:** Only analyze files detected as this language with `-l, --language <lang>`.
 

--- a/docs/src/DEMO.md
+++ b/docs/src/DEMO.md
@@ -42,6 +42,6 @@ cd meta-ast
 cargo build --release --all-features
 
 ./target/release/meta-ast inspect tests/fixtures/python
-./target/release/meta-ast graph tests/fixtures/mixed/three_lang_math --html
+./target/release/meta-ast graph tests/fixtures/mixed/three_lang_math --html  # writes three_lang_math.html
 ./target/release/meta-ast deploy tests/fixtures/mixed/three_lang_math --out ./deploy-out
 ```

--- a/docs/src/DEPLOY.md
+++ b/docs/src/DEPLOY.md
@@ -43,21 +43,23 @@ meta-ast deploy <path> --check
 
 ```
 run_deploy()
-  1. discover_files()                               - language-routed file list
-  2. pipeline::analyze_graph()                      - symbol, import, and SCC analysis
-  3. scanner::scan_file() per file (rayon parallel) - MetaCall call-site detection
-  4. inject MetaCall import edges into graph        - add_metacall_edge with path resolution
-  5. resolve client calls (two-phase)               - client_call::resolve_client_calls
-  6. SCC recompute with new edges                   - update SCC analysis
-  7. pod::partition_into_pods()                     - Union-Find over same-language edges
-  8. metrics::compute_file_metrics()                - AST node counts per file/pod
-  9. cut::find_cross_language_cuts()                - cheapest-edge split for cross-lang SCCs
- 10. cut::find_oversized_pod_cut() per pod          - second-pass rebalancing
- 11. dependency::resolve_dependencies()             - lockfile and manifest parsing
- 12. manifest::generate_pod_manifest()              - PodManifest serialization
- 13. mesh::generate_mesh_annotation()               - SCC-derived topology
- 14. write artifacts or check::check_cut_fairness() in --check mode
+  1. pipeline::analyze_graph()        - discovery, extraction, graph assembly, scope resolution,
+                                        client call projection and SCC analysis in one pass
+  2. scan_call_sites()                - MetaCall call-site detection over the extractions
+  3. inject_load_edges()              - load edges into the graph, with path resolution
+  4. orphaned_config_diagnostics()    - configuration files that no call site loads
+  5. partition_graph()                - Union-Find over same-language Import and Reference edges
+  6. detect_cuts()                    - cross-language SCC cuts plus oversized pods
+  7. build_documents()                - file and pod metrics, dependency resolution,
+                                        pod manifest and mesh annotation
+  8. write_documents()                - atomic writes, or the cut fairness check in --check mode
 ```
+
+The run returns every diagnostic it collected to the caller, which applies the diagnostic policy
+and decides the exit status. An ecosystem answers dependency questions from one table of sources:
+lockfiles are preferred over manifests, a lockfile that does not carry the entry falls through to
+the manifest for Python, Node and Go, and only Python and Node answer from an immediate
+subdirectory.
 
 ### Module map
 
@@ -68,7 +70,7 @@ src/deploy/
 ├── client_call.rs  resolve_client_calls(), resolve_script_to_file() - two-phase client invocation resolution
 ├── pod.rs          Union-Find partition_into_pods(), PodPartition, InterPodEdge
 ├── cut.rs          find_cross_language_cuts(), find_oversized_pod_cut(), CutEdge
-├── dependency.rs   classify_external(), resolve_dependencies(), per-language resolvers
+├── dependency.rs   one table of lockfile and manifest sources plus one reader per format
 ├── metrics.rs      compute_file_metrics(), compute_pod_metrics(), FileMetrics
 ├── manifest.rs     generate_pod_manifest(), PodManifest, ManifestEdge
 ├── mesh.rs         generate_mesh_annotation(), DeploymentUnit, CrossLanguageEdge

--- a/docs/src/ROADMAP.md
+++ b/docs/src/ROADMAP.md
@@ -35,7 +35,7 @@ Goals:
 
 - Extend model with optional data/flow nodes (DataNode, FlowEdge, DataScope, FlowKind).
 - Implement intra-procedural def-use extraction for Rust (let bindings, parameters).
-- Provide portable graph export contract with schema versioning. The graph document carries `SCHEMA_VERSION` and the shard format carries `SHARD_SCHEMA_VERSION` (4 as of this release).
+- Provide portable graph export contract with schema versioning. The graph document carries `SCHEMA_VERSION` and the shard format carries `SHARD_SCHEMA_VERSION` (5 as of this release).
 - Pluggable sink adapters (GraphSink trait + JsonSink).
 - CLI integration: `--datagraph` flag on graph subcommand.
 - Unified GraphOutput serialization (replaces separate datagraph module).

--- a/docs/src/STRUCTURE.md
+++ b/docs/src/STRUCTURE.md
@@ -8,85 +8,85 @@ This document defines the module layout, data structures, design patterns, langu
 
 ```
 src/
-├── lib.rs                    Public API re-exports
-├── main.rs                   CLI entrypoint
-├── error.rs                  Error + Diagnostic types (thiserror)
-├── pipeline.rs               Full graph analysis orchestration
-│
-├── model/
-│   ├── mod.rs                Symbol, SymbolKind, SourceRange, UnresolvedImport, UnresolvedReference, FileExtraction, DataNode, DataScope, FlowEdge, FlowKind (feature: dataflow)
-│   ├── ids.rs                FileId, SymbolId, SnapshotId, DataNodeId (newtyped NonZeroU32 via define_id_type! macro; generator starts at 1)
-│   └── output.rs             InspectOutput, FuncEntry, ClassEntry, ObjectEntry
-│
-├── language/
-│   ├── mod.rs                LangId enum, LanguageSpec struct, DefaultVisibility, DocCommentConfig
-│   ├── common.rs             extract_with_spec, extract_imports_and_references_with_spec, associate_docstrings
-│   ├── dataflow.rs           extract_dataflow() dispatcher (feature: dataflow; Rust impl in rust.rs)
-│   ├── python.rs             Python queries + extraction
-│   ├── javascript.rs         JavaScript queries + extraction
-│   ├── typescript.rs         TypeScript queries + extraction
-│   ├── tsx.rs                TSX queries + extraction (separate grammar from TS)
-│   ├── c.rs                  C queries + extraction
-│   ├── cpp.rs                C++ queries + extraction
-│   ├── rust.rs               Rust queries + extraction
-│   ├── go.rs                 Go queries + extraction
-│   ├── ruby.rs               Ruby queries + extraction
-│   └── import_resolver.rs    ImportResolver trait, stateful resolvers (Python, Go, JS, TS)
-│
-├── input/
-│   └── mod.rs                File discovery, filtering, language routing
-│
-├── parser/
-│   └── mod.rs                Tree-sitter parser lifecycle, parse function
-│
+├── cache.rs                BLAKE3 fingerprinting and the extraction cache
+├── error.rs                Error + Diagnostic types (thiserror)
+├── lib.rs                  Public API re-exports
+├── main.rs                 CLI entry point: parse, subscriber setup, dispatch
+├── pipeline.rs             Full graph analysis orchestration, one assembly path for both entry points
+├── reanalyze.rs            Incremental re-analysis: overlays, diffs, cache reuse
+├── deploy/
+│   ├── check.rs                check_cut_fairness() - bijection check between cuts and rpc_stub edges
+│   ├── client_call.rs          Client call resolution: load aware first, then the global name index
+│   ├── config.rs               DeployConfig and its defaults
+│   ├── cut.rs                  find_cross_language_cuts(), find_oversized_pod_cut(), CutEdge, CutAnnotation
+│   ├── dependency.rs           One table of lockfile and manifest sources plus one reader per format
+│   ├── manifest.rs             generate_pod_manifest(), PodManifest, ManifestEdge
+│   ├── mesh.rs                 generate_mesh_annotation(), DeploymentUnit, CrossLanguageEdge
+│   ├── metrics.rs              compute_file_metrics(), compute_pod_metrics(), FileMetrics
+│   ├── mod.rs                  Entry: run_deploy() in named stages, DeployConfig, add_metacall_edge()
+│   ├── pod.rs                  Union-Find partition_into_pods(), PodPartition, InterPodEdge
+│   ├── scanner.rs              tree-sitter call-site detection, CallSite, CallSiteVariant, confidence
+│   └── tags.rs                 LangId <-> MetaCall runtime tag mapping
 ├── extractor/
-│   └── mod.rs                Pipeline orchestration: parallel parse + extract per-file (symbols + imports + references)
-│
+│   └── mod.rs                  Pipeline orchestration: parallel parse + extract per file (symbols, imports, references, call sites, dataflow)
 ├── graph/
-│   ├── mod.rs                CodeGraph (DiGraph), add_edge_normalized_with_flow, re-exports
-│   ├── node.rs               NodeData enum (File / Symbol / External / Data)
-│   ├── edge.rs               EdgeKind enum (Ownership / Import / Reference / Flow) with confidence + flow_kind
-│   ├── builder.rs            GraphBuilder, from_extractions, add_data_node, add_flow_edge, import_adjacency
-│   ├── scc.rs                Tarjan SCC + DeployabilityHint
-│   └── resolver.rs           FlattenedScopeCache, ResolutionContext, resolve_all_references
-│
+│   ├── builder.rs              GraphBuilder: named stages for files, symbols, dataflow, imports, references and client calls
+│   ├── edge.rs                 EdgeKind enum (Ownership / Import / Reference / Flow) with confidence + flow_kind, one merge rule
+│   ├── mod.rs                  CodeGraph (DiGraph), add_edge_normalized_with_flow, re-exports
+│   ├── naming.rs               Node display name and kind name; one authority for the graph output
+│   ├── node.rs                 NodeData enum (File / Symbol / External / Data)
+│   ├── resolver.rs             FlattenedScopeCache, ResolutionContext, resolve_all_references
+│   └── scc.rs                  Tarjan SCC + DeployabilityHint in a single edge walk
+├── input/
+│   └── mod.rs                  File discovery, filtering, language routing, portable paths
+├── interface/
+│   ├── args.rs                 Clap derive structs (Inspect, Graph, Deploy and their flags)
+│   ├── banner.rs               Startup banner
+│   ├── commands.rs             Command implementations: inspect, graph, watch and deploy
+│   ├── mod.rs                  CLI module root
+│   └── report.rs               FailOn policy and diagnostic reporting
+├── language/
+│   ├── c.rs                    C queries + extraction
+│   ├── common.rs               extract_with_spec, extract_imports_and_references_with_spec, associate_docstrings
+│   ├── cpp.rs                  C++ queries + extraction
+│   ├── dataflow.rs             extract_dataflow() dispatcher (feature: dataflow; Rust impl in rust.rs)
+│   ├── go.rs                   Go queries + extraction
+│   ├── import_resolver.rs      ImportResolver trait, stateful resolvers (Python, Go, JS, TS)
+│   ├── javascript.rs           JavaScript queries + extraction
+│   ├── mod.rs                  LangId enum, LanguageSpec struct, DefaultVisibility, DocCommentConfig, the query registry
+│   ├── pack.rs                 define_language_pack! macro: query statics, fallible accessors, spec literal and snapshot scaffolding
+│   ├── python.rs               Python queries + extraction
+│   ├── ruby.rs                 Ruby queries + extraction
+│   ├── rust.rs                 Rust queries + extraction
+│   ├── tsx.rs                  TSX queries + extraction (separate grammar from TS)
+│   └── typescript.rs           TypeScript queries + extraction
+├── model/
+│   ├── ids.rs                  FileId, SymbolId, SnapshotId, DataNodeId (newtyped NonZeroU32; generator starts at 1)
+│   ├── mod.rs                  Symbol, SymbolKind, SourceRange, UnresolvedImport, UnresolvedReference, FileExtraction, DataNode, DataScope, FlowEdge, FlowKind (feature: dataflow)
+│   └── output.rs               InspectOutput, FuncEntry, ClassEntry, ObjectEntry
 ├── output/
-│   ├── mod.rs                OutputFormat enum (Json / Yaml) with serialize dispatch
-│   ├── emitter.rs            EmitConfig, emit_inspect(), emit_graph() - CLI output dispatch
-│   ├── inspect.rs            Inspect-compatible JSON/YAML emission
-│   ├── graph.rs              Unified GraphOutput (schema_version, metadata, nodes, edges, sccs, deployability)
-│   ├── shard/                `.metast` stable-name JSONL shard and index persistence
-│   │   ├── mod.rs            Module root, re-exports, unit tests
-│   │   ├── error.rs          ShardError enum
-│   │   ├── file.rs           ShardFile, ShardSymbol, write_shard(), read_shard()
-│   │   ├── edge.rs           ShardEdge, ShardEdgeKind, restore_shard_edges()
-│   │   ├── index.rs          load_index(), hardened index verification
-│   │   ├── manifest.rs       ShardManifestRecord, write_manifest(), read_manifest()
-│   │   ├── header.rs         ShardHeader, write_header(), read_header()
-│   │   └── name.rs           Stable naming, descriptors, and parent hierarchy resolution
-│   └── dashboard.rs          Interactive HTML dashboard (Cytoscape.js via CDN, --html)
-│
-└── sink/                     [feature: dataflow] GraphSink trait + JsonSink
-    └── mod.rs                GraphSink trait, JsonSink (file/stdout)
-│
-└── interface/                CLI layer
-    ├── mod.rs                CLI module root
-    └── args.rs               Clap derive structs (Inspect, Graph, Deploy + -l, --format, --html, --datagraph, --datagraph-output, --watch, --watch-debounce, -o, --check)
-│
-├── watch/                     [feature: watch]
-│   └── mod.rs                 IncrementalCache, WatchState, incremental_reanalyze, run_watch
-│
-└── deploy/                   [feature: metacall-deploy] See [DEPLOY.md](DEPLOY.md)
-    ├── mod.rs                Entry: run_deploy(), DeployConfig, add_metacall_edge()
-    ├── scanner.rs            tree-sitter call-site detection, CallSite, CallSiteVariant, confidence
-    ├── pod.rs                Union-Find partition_into_pods(), PodPartition, InterPodEdge
-    ├── cut.rs                find_cross_language_cuts(), find_oversized_pod_cut(), CutEdge
-    ├── dependency.rs         classify_external(), resolve_dependencies(), per-language resolvers
-    ├── metrics.rs            compute_file_metrics(), compute_pod_metrics(), FileMetrics
-    ├── manifest.rs           generate_pod_manifest(), PodManifest, ManifestEdge
-    ├── mesh.rs               generate_mesh_annotation(), DeploymentUnit, CrossLanguageEdge
-    ├── check.rs              check_cut_fairness() - bijection check between cuts and rpc_stub edges
-    └── tags.rs               LangId <-> MetaCall runtime tag mapping
+│   ├── dashboard.rs            Interactive HTML dashboard with the vendored Cytoscape bundle (--html, --open)
+│   ├── emitter.rs              EmitConfig, emit_inspect(), emit_graph() - CLI output dispatch
+│   ├── graph.rs                Unified GraphOutput (schema_version, metadata, nodes, edges, sccs, deployability)
+│   ├── inspect.rs              Inspect-compatible JSON/YAML emission
+│   ├── mod.rs                  OutputFormat and the single default output path
+│   └── shard/
+│       ├── edge.rs                 ShardEdge, ShardEdgeKind, restore_shard_edges()
+│       ├── error.rs                ShardError enum
+│       ├── file.rs                 ShardFile, ShardSymbol, write_shard(), read_shard()
+│       ├── header.rs               ShardHeader, write_header(), read_header()
+│       ├── index.rs                load_index(), hardened index verification
+│       ├── manifest.rs             ShardManifestRecord, write_manifest(), read_manifest()
+│       ├── mod.rs                  Module root, re-exports, unit tests
+│       └── name.rs                 Portable shard naming: the name plan, the collision key and parent hierarchy resolution
+├── parser/
+│   └── mod.rs                  Tree-sitter parser lifecycle, parse function
+├── sink/
+│   └── mod.rs                  GraphSink trait + JsonSink
+└── watch/
+    ├── config.rs               WatchConfig: debounce, emit configuration and the diagnostic policy
+    ├── mod.rs                  IncrementalCache, WatchState, re-analysis entry point, run_watch
+    └── watcher.rs              Debounced notify loop with a stop flag and a failure count
 ```
 
 ### Module dependency direction

--- a/docs/src/specs/graph-model.md
+++ b/docs/src/specs/graph-model.md
@@ -104,7 +104,10 @@ apply to the strum `Display`/`AsRefStr` and serde representations of `LangId`.
 
 Graph output schema version 2 adds `file_path` and `source_range` to serialized
 symbol nodes. `.metast` shards declare `SHARD_SCHEMA_VERSION` in `header.json`
-and in every record, and they spell symbol kinds and visibility in lowercase.
+and in every record, and they spell symbol kinds and visibility in lowercase. Version 5 stores
+the import specifier without its surrounding quotes and drops a specifier that is not valid UTF-8
+with a warning, so a version 4 reader refuses the payload instead of reading a value in the old
+shape.
 They do not persist numeric IDs: they store stable language-scoped endpoint
 names and regenerate symbol IDs when loaded. A reader refuses any other version,
 so an index written before a schema bump must be regenerated.

--- a/src/language/snapshots/meta_ast__language__javascript__tests__js_insta_snapshot.snap
+++ b/src/language/snapshots/meta_ast__language__javascript__tests__js_insta_snapshot.snap
@@ -7,14 +7,14 @@ expression: symbols
     "name": "hello",
     "kind": "function",
     "source_range": {
-      "byte_start": 93,
-      "byte_end": 133,
+      "byte_start": 0,
+      "byte_end": 40,
       "start": {
-        "line": 1,
+        "line": 0,
         "column": 0
       },
       "end": {
-        "line": 3,
+        "line": 2,
         "column": 1
       }
     },
@@ -27,14 +27,14 @@ expression: symbols
     "name": "fetchData",
     "kind": "function",
     "source_range": {
-      "byte_start": 135,
-      "byte_end": 235,
+      "byte_start": 42,
+      "byte_end": 142,
       "start": {
-        "line": 5,
+        "line": 4,
         "column": 0
       },
       "end": {
-        "line": 8,
+        "line": 7,
         "column": 1
       }
     },
@@ -47,14 +47,14 @@ expression: symbols
     "name": "compute",
     "kind": "function",
     "source_range": {
-      "byte_start": 243,
-      "byte_end": 268,
+      "byte_start": 150,
+      "byte_end": 175,
       "start": {
-        "line": 10,
+        "line": 9,
         "column": 6
       },
       "end": {
-        "line": 10,
+        "line": 9,
         "column": 31
       }
     },
@@ -67,14 +67,14 @@ expression: symbols
     "name": "greet",
     "kind": "function",
     "source_range": {
-      "byte_start": 277,
-      "byte_end": 311,
+      "byte_start": 184,
+      "byte_end": 218,
       "start": {
-        "line": 12,
+        "line": 11,
         "column": 6
       },
       "end": {
-        "line": 12,
+        "line": 11,
         "column": 40
       }
     },
@@ -82,5 +82,25 @@ expression: symbols
     "signature": "(name)",
     "docstring": null,
     "is_async": false
+  },
+  {
+    "name": "demo",
+    "kind": "function",
+    "source_range": {
+      "byte_start": 228,
+      "byte_end": 354,
+      "start": {
+        "line": 13,
+        "column": 7
+      },
+      "end": {
+        "line": 16,
+        "column": 1
+      }
+    },
+    "visibility": "public",
+    "signature": "(url)",
+    "docstring": null,
+    "is_async": true
   }
 ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+//! Polyglot static analysis: symbol extraction and cross-language dependency
+//! graphs from nine source languages, with optional MetaCall deployment
+//! manifests and dataflow extraction.
 pub mod cache;
 pub mod error;
 pub mod extractor;

--- a/src/output/emitter.rs
+++ b/src/output/emitter.rs
@@ -5,9 +5,13 @@ use std::path::PathBuf;
 
 #[derive(Debug, Clone)]
 pub struct EmitConfig {
+    /// Explicit output path. `None` writes the document to stdout.
     pub output: Option<PathBuf>,
+    /// Serialization format for the text document.
     pub format: OutputFormat,
+    /// Generate the HTML dashboard instead of the text document.
     pub html: bool,
+    /// Open the written dashboard in the default browser.
     pub open_browser: bool,
 }
 

--- a/src/output/shard/manifest.rs
+++ b/src/output/shard/manifest.rs
@@ -44,6 +44,7 @@ impl ShardManifestRecord {
     }
 
     /// Compute the BLAKE3 hex hash for source bytes.
+    #[must_use]
     pub fn compute_hash(bytes: &[u8]) -> String {
         blake3::hash(bytes).to_hex().to_string()
     }

--- a/tests/fixtures/javascript/functions.js
+++ b/tests/fixtures/javascript/functions.js
@@ -1,4 +1,3 @@
-/* biome-ignore-all lint/correctness/noUnusedVariables: every declaration is parser input */
 function hello() {
     return "hello";
 }
@@ -12,4 +11,7 @@ const compute = (x, y) => x + y;
 
 const greet = (name) => `Hello, ${name}`;
 
-module.exports = { hello, fetchData, compute, greet };
+export async function demo(url) {
+    const data = await fetchData(url);
+    return [hello(), data, compute(1, 2), greet("world")];
+}


### PR DESCRIPTION
Regenerates the module tree from the source tree, rewrites the deploy pipeline section to the stages the code runs, states that the dashboard bundle travels with the document and that the browser opens only on request, and moves the shard schema version to 5 wherever it is named. The `EmitConfig` fields and the shard readers are documented.\n\nStack top: 515 library tests, 192 integration tests with 2 ignored, the allocation budget test and the doc test, 0 failures; formatting and clippy clean on all targets and features; the feature matrix clean; the book builds.